### PR TITLE
feature: allow creating custom btrfs subvolumes from manual partitioning 

### DIFF
--- a/live-installer.pot
+++ b/live-installer.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,19 +22,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -43,10 +43,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -55,13 +57,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -70,12 +72,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -85,42 +87,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -137,7 +139,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -146,140 +148,146 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 msgid "Edit Partitions"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -307,6 +315,699 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+msgid "Keyboard Model"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:73
+msgid "Installation type?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -402,10 +1103,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -432,7 +1129,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr ""
@@ -452,671 +1149,60 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 msgid "Removing extra packages"
 msgstr ""
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr ""
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-msgid "Keyboard Model"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:73
-msgid "Installation type?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""

--- a/live-installer.pot
+++ b/live-installer.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -87,7 +87,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -185,9 +185,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -290,6 +290,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -319,8 +324,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -406,23 +411,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -440,9 +516,102 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -557,18 +726,6 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -600,25 +757,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -853,7 +991,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr ""
 
@@ -872,138 +1010,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1149,60 +1155,60 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 msgid "Removing extra packages"
 msgstr ""
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""

--- a/live-installer/frontend/gtk_interface.py
+++ b/live-installer/frontend/gtk_interface.py
@@ -1251,7 +1251,7 @@ class InstallerWindow:
                             print("subvolume",subvolume.mount_as, "name", subvolume.name)
                             if(subvolume.mount_as == "/"):
                                 found_root_partition = True
-                                if partition.format_as is None or partition.format_as == "":
+                                if subvolume.exists_on_disk and (not subvolume.format or subvolume.format is None):
                                     if not QuestionDialog(_("Installer"), _(
                                         "Root filesystem type not specified. Installation will continue without disk formatting. Do you want to continue?")):
                                         return

--- a/live-installer/frontend/gtk_interface.py
+++ b/live-installer/frontend/gtk_interface.py
@@ -1547,6 +1547,15 @@ class InstallerWindow:
                 if p.mount_as:
                     model.append(top, (bold(_("Mount %(path)s as %(mount)s") % {
                                  'path': p.path, 'mount': p.mount_as}),))
+            for p in self.setup.partitions:
+                if (p.type == "btrfs" or p.format_as == "btrfs") and p.subvolumes != []:
+                    for subvol in p.subvolumes:
+                        model.append(top, (bold(_("Create btrfs subvolume %(path)s under %(parentPath)s ") % {
+                                     'path': subvol.name, 'parentPath': p.path}),))
+                    for subvol in p.subvolumes:
+                        if subvol.mount_as:
+                            model.append(top, (bold(_("Mount %(path)s subvolume as %(mount)s") % {
+                                         'path': subvol.name, 'mount': subvol.mount_as}),))
         if config.get("lvm_enabled", True):
             _lvm = self.builder.get_object("check_lvm").get_active()
             _lux = self.builder.get_object("check_encrypt").get_active()

--- a/live-installer/frontend/gtk_interface.py
+++ b/live-installer/frontend/gtk_interface.py
@@ -1244,6 +1244,20 @@ class InstallerWindow:
                             if not QuestionDialog(_("Installer"), _(
                                 "The root partition is too small. It should be at least 16GB. Do you want to continue?")):
                                 return
+                if not found_root_partition:
+                    for partition in self.setup.partitions:
+                        for subvolume in partition.subvolumes:
+                            print("subvolume",subvolume.mount_as, "name", subvolume.name)
+                            if(subvolume.mount_as == "/"):
+                                found_root_partition = True
+                                if partition.format_as is None or partition.format_as == "":
+                                    if not QuestionDialog(_("Installer"), _(
+                                        "Root filesystem type not specified. Installation will continue without disk formatting. Do you want to continue?")):
+                                        return
+                                if int(float(partition.partition.getLength('GB'))) < 16:
+                                    if not QuestionDialog(_("Installer"), _(
+                                        "The root partition is too small. It should be at least 16GB. Do you want to continue?")):
+                                        return
 
                 if not found_root_partition:
                     ErrorDialog(_("Installer"), "<b>%s</b>" % _("Please select a root (/) partition."), _(

--- a/live-installer/frontend/gtk_interface.py
+++ b/live-installer/frontend/gtk_interface.py
@@ -1026,7 +1026,8 @@ class InstallerWindow:
             _("Partition {} will removed from {}.").format(path,mbr)):
             def update_partition_menu(pid, status):
                 partitioning.build_partitions(self)
-            command = "parted -s {} rm {}".format(mbr,partnum)
+            #  Use wipefs to ensure that filesystem signature is removed so that partition will not be restored after create new partition with same blocks
+            command = "wipefs -a {} && parted -s {} rm {}".format(path,mbr,partnum)
             pid, stdin, stdout, stderr = GLib.spawn_async(["/bin/bash", "-c", command],
             flags=GLib.SPAWN_DO_NOT_REAP_CHILD,
             standard_output=True,

--- a/live-installer/frontend/gtk_interface.py
+++ b/live-installer/frontend/gtk_interface.py
@@ -1011,7 +1011,7 @@ class InstallerWindow:
                     "treeview_disks").get_selection().get_selected()
                 subvolume.parent.subvolumes.remove(subvolume)
                 model.remove(itervar)
-                if not subvolume.exists_on_disk:
+                if subvolume.exists_on_disk:
                     mount_point = getoutput("mktemp -d").decode("utf-8").strip()
                     os.system("mount -t btrfs %s %s" %
                               (subvolume.parent.path, mount_point))

--- a/live-installer/frontend/gtk_interface.py
+++ b/live-installer/frontend/gtk_interface.py
@@ -1004,20 +1004,20 @@ class InstallerWindow:
 
     def part_remove_button_event(self,widget):
         if self.selected_partition.type == _("btrfs subvolume"):
-            subvolume_name = self.selected_partition.name
-            subvolume_parent = self.selected_partition.parent
+            subvolume = self.selected_partition
             if QuestionDialog(_("Are you sure?"),
-                              _("subvolume {} will removed from {}.").format(subvolume_name, subvolume_parent.path)):
+                              _("subvolume {} will removed from {}.").format(subvolume.name, subvolume.parent.path)):
                 model, itervar = self.builder.get_object(
                     "treeview_disks").get_selection().get_selected()
-                subvolume_parent.subvolumes.remove(self.selected_partition)
-                mount_point = getoutput("mktemp -d").decode("utf-8").strip()
-                os.system("mount -t btrfs %s %s" %
-                          (subvolume_parent.path, mount_point))
-                os.system("btrfs subvolume delete %s/%s" %
-                          (mount_point, subvolume_name))
-                os.system("umount --force %s" % mount_point)
+                subvolume.parent.subvolumes.remove(subvolume)
                 model.remove(itervar)
+                if not subvolume.exists_on_disk:
+                    mount_point = getoutput("mktemp -d").decode("utf-8").strip()
+                    os.system("mount -t btrfs %s %s" %
+                              (subvolume.parent.path, mount_point))
+                    os.system("btrfs subvolume delete %s/%s" %
+                              (mount_point, subvolume.name))
+                    os.system("umount --force %s" % mount_point)
             return
         path = self.selected_partition.path
         mbr = self.selected_partition.mbr

--- a/live-installer/frontend/partitioning.py
+++ b/live-installer/frontend/partitioning.py
@@ -292,7 +292,7 @@ def assign_mount_point(partition, mount_point, filesystem, read_only = False, su
             for subvol in part.iterchildren():
                 if partition == subvol[IDX_PART_OBJECT]:
                     subvol[IDX_PART_MOUNT_AS] = mount_point
-                    subvol[IDX_PART_PATH] = partition.name
+                    subvol[IDX_PART_PATH] = subvolume_name
                 elif mount_point == subvol[IDX_PART_MOUNT_AS] and mount_point != "":
                     subvol[IDX_PART_MOUNT_AS] = ""
 

--- a/live-installer/frontend/partitioning.py
+++ b/live-installer/frontend/partitioning.py
@@ -241,8 +241,7 @@ def create_subvolume_dialog(widget):
 
 def assign_mount_point(partition, mount_point, filesystem, read_only = False, subvolume_name = None):
     # Assign it in the treeview
-    model, itervar = installer.builder.get_object(
-        "treeview_disks").get_selection().get_selected()
+    model = installer.builder.get_object("treeview_disks").get_model()
     for disk in model:
         for part in disk.iterchildren():
             if partition == part[IDX_PART_OBJECT]:

--- a/live-installer/frontend/partitioning.py
+++ b/live-installer/frontend/partitioning.py
@@ -327,7 +327,7 @@ def partitions_popup_menu(widget, event):
     menu.append(menuItem)
 
     # if the selected "partition" is a subvolume then show a custom menu
-    if partition_type == "btrfs subvolume":
+    if partition_type == _("btrfs subvolume"):
         mount_points = ["/", "/home", "/var", "/tmp", "/srv", "/opt"]
         for mount_point in mount_points:
             menuItem = Gtk.MenuItem(_("Assign to %s") % mount_point)
@@ -802,7 +802,7 @@ class PartitionDialog(object):
     def show_chkbtn_btrfs_subvols(self,widget):
         w = self.builder.get_object("combobox_use_as")
         format_as = w.get_model()[w.get_active()][0]
-        if format_as == _("btrfs"):
+        if format_as == "btrfs":
             self.builder.get_object("checkbutton_default_btrfs_subvols").set_visible(True)
         else:
             self.builder.get_object("checkbutton_default_btrfs_subvols").set_visible(False)

--- a/live-installer/frontend/partitioning.py
+++ b/live-installer/frontend/partitioning.py
@@ -806,20 +806,25 @@ class PartitionDialog(object):
         combobox_use_as.connect(
             "changed", self.show_chkbtn_btrfs_subvols)
 
-        # Build list of pre-provided mountpoints
         combobox = self.builder.get_object("comboboxentry_mount_point")
-        model = Gtk.ListStore(str, str)
-        model.append(["", "/"])
-        model.append(["", "swap"])
-        for i in config.distro["additional_mountpoints"]:
-            model.append(["", i])
-        if is_efi_supported():
-            for i in config.distro["additional_efi_mountpoints"]:
+        typevar = typevar.replace("<span>", "").replace("</span>", "").strip()
+        if typevar == _("Unknown"):
+            # If the partition is unknown, we can't assign a mount point
+            combobox.set_sensitive(False)
+        else:
+            # Build list of pre-provided mountpoints
+            model = Gtk.ListStore(str, str)
+            model.append(["", "/"])
+            model.append(["", "swap"])
+            for i in config.distro["additional_mountpoints"]:
                 model.append(["", i])
-        combobox.set_model(model)
-        combobox.set_entry_text_column(1)
-        combobox.set_id_column(1)
-        combobox.get_child().set_text(mount_as)
+            if is_efi_supported():
+                for i in config.distro["additional_efi_mountpoints"]:
+                    model.append(["", i])
+            combobox.set_model(model)
+            combobox.set_entry_text_column(1)
+            combobox.set_id_column(1)
+            combobox.get_child().set_text(mount_as)
 
     # Show the default subvolumes checkbox only if btrfs is selected from combobox
     def show_chkbtn_btrfs_subvols(self,widget):

--- a/live-installer/frontend/partitioning.py
+++ b/live-installer/frontend/partitioning.py
@@ -244,10 +244,6 @@ def validate_subvolume_and_mountpoint(partition, subvolume_name, mount_as, subvo
         show_error(_(
             "The name of a subvolume must not be blank or contain a space"))
         return False
-    if " " in mount_as:
-        show_error(_(
-            "The mount point of a subvolume must not contain a space"))
-        return False
     for subvol in partition.subvolumes:
         if subvolume != None and subvol == subvolume:
             continue

--- a/live-installer/frontend/partitioning.py
+++ b/live-installer/frontend/partitioning.py
@@ -596,6 +596,16 @@ def get_partition_label(partition_path):
             return dev
     return None
 
+def does_objects_has_the_mount_points(mount_points):
+    model = installer.builder.get_object("treeview_disks").get_model()
+    for disk in model:
+        for part in disk.iterchildren():
+            if part[IDX_PART_MOUNT_AS] == mount_points[0] or part[IDX_PART_MOUNT_AS] == mount_points[1]:
+                return True
+            for subvol in part.iterchildren():
+                if subvol[IDX_PART_MOUNT_AS] == mount_points[0] or subvol[IDX_PART_MOUNT_AS] == mount_points[1]:
+                    return True
+    return False
 
 class PartitionBase(object):
     # Partition object but only struct
@@ -806,7 +816,7 @@ class PartitionDialog(object):
     def show_chkbtn_btrfs_subvols(self,widget):
         w = self.builder.get_object("combobox_use_as")
         format_as = w.get_model()[w.get_active()][0]
-        if format_as == "btrfs":
+        if format_as == "btrfs" and not does_objects_has_the_mount_points(("/","/home")):
             self.builder.get_object("checkbutton_default_btrfs_subvols").set_visible(True)
         else:
             self.builder.get_object("checkbutton_default_btrfs_subvols").set_visible(False)

--- a/live-installer/frontend/partitioning.py
+++ b/live-installer/frontend/partitioning.py
@@ -192,7 +192,8 @@ def edit_partition_dialog(widget, path, viewcol):
                               row[IDX_PART_TYPE],
                               _("Edit Subvolume"))
         response_is_ok, subvolume_name, mount_as = dlg.show()
-        assign_mount_point(partition, mount_as, _("btrfs subvolume"), False, subvolume_name)
+        if response_is_ok:
+            assign_mount_point(partition, mount_as, _("btrfs subvolume"), False, subvolume_name)
         return
     if (partition.partition.type != parted.PARTITION_EXTENDED and
             partition.partition.number != -1):

--- a/live-installer/frontend/partitioning.py
+++ b/live-installer/frontend/partitioning.py
@@ -219,9 +219,12 @@ def create_subvolume_dialog(widget):
                        "")
     response_is_ok, subvolume_name, mount_as = dlg.show()
     if response_is_ok:
-        if subvolume_name == "" or "/" in subvolume_name or " " in subvolume_name:
+        if subvolume_name.startswith("/") or subvolume_name.endswith("/"):
+            show_error(_("The name of a subvolume must not start or end with a forward slash"))
+            return
+        if subvolume_name == "" or  " " in subvolume_name:
             show_error(_(
-                "The name of a subvolume must not be blank or contain a space or a forward slash"))
+                "The name of a subvolume must not be blank or contain a space"))
             return
         if " " in mount_as:
             show_error(_(

--- a/live-installer/frontend/partitioning.py
+++ b/live-installer/frontend/partitioning.py
@@ -294,6 +294,8 @@ def assign_mount_point(partition, mount_point, filesystem, read_only = False, su
 
             for subvol in part.iterchildren():
                 if partition == subvol[IDX_PART_OBJECT]:
+                    if subvolume_name == None:
+                        subvolume_name = partition.name
                     subvol[IDX_PART_MOUNT_AS] = mount_point
                     subvol[IDX_PART_PATH] = subvolume_name
                 elif mount_point == subvol[IDX_PART_MOUNT_AS] and mount_point != "":

--- a/live-installer/frontend/partitioning.py
+++ b/live-installer/frontend/partitioning.py
@@ -190,6 +190,7 @@ def edit_partition_dialog(widget, path, viewcol):
     if partition.partition.type == _('btrfs subvolume'):
         dlg = SubvolDialog(partition.name,
                               row[IDX_PART_MOUNT_AS],
+                              partition.exists_on_disk,
                               _("Edit Subvolume"))
         response_is_ok, subvolume_name, mount_as = dlg.show()
         if response_is_ok:
@@ -217,7 +218,8 @@ def create_subvolume_dialog(widget):
     if not (partition or (partition.type == 'btrfs' and partition.format_as == '') or partition.format_as == 'btrfs'):
         return
     dlg = SubvolDialog("",
-                       "")
+                       "",
+                       False)
     response_is_ok, subvolume_name, mount_as = dlg.show()
     if response_is_ok:
         if subvolume_name.startswith("/") or subvolume_name.endswith("/"):
@@ -851,7 +853,7 @@ class PartitionDialog(object):
         return response_is_ok, mount_as, format_as, read_only, create_default_subvols
 
 class SubvolDialog(object):
-    def __init__(self, name, mount_as, title=_("Create Subvolume")):
+    def __init__(self, name, mount_as, exists_on_disk: bool, title=_("Create Subvolume")):
         glade_file = RESOURCE_DIR + 'interface.ui'
         self.builder = Gtk.Builder()
         self.builder.add_from_file(glade_file)
@@ -864,6 +866,8 @@ class SubvolDialog(object):
         self.builder.get_object("button_subvol_cancel").set_label(_("Cancel"))
         self.builder.get_object("button_subvol_ok").set_label(_("OK"))
         self.builder.get_object("entry_subvol_name").set_text(name)
+        if exists_on_disk:
+            self.builder.get_object("entry_subvol_name").set_sensitive(False)
         # Build list of pre-provided mountpoints
         combobox = self.builder.get_object("comboboxentry_subvol_mount_point")
         model = Gtk.ListStore(str, str)

--- a/live-installer/frontend/partitioning.py
+++ b/live-installer/frontend/partitioning.py
@@ -118,6 +118,7 @@ def get_btrfs_partition_subvolumes(partition):
             subvolume = BtrfsSubvolume()
             subvolume.name = subvol.split(" path ")[1]
             subvolume.parent = partition
+            subvolume.exists_on_disk = True
             subvolumes.append(subvolume)
             log("subvolume: %s" % subvolume.name)
         return subvolumes
@@ -763,6 +764,7 @@ class BtrfsSubvolume(object):
         self.parent = None
         self.partition = self
         self.mount_as = ''
+        self.exists_on_disk = False
 
 class PartitionDialog(object):
     def __init__(self, path, mount_as, format_as, typevar, read_only=False):

--- a/live-installer/frontend/partitioning.py
+++ b/live-installer/frontend/partitioning.py
@@ -285,7 +285,7 @@ def assign_mount_point(partition, mount_point, filesystem, read_only = False, su
                 part[IDX_PART_MOUNT_AS] = mount_point
                 part[IDX_PART_FORMAT_AS] = filesystem
                 part[IDX_PART_READ_ONLY] = read_only
-            elif mount_point == part[IDX_PART_MOUNT_AS]:
+            elif mount_point == part[IDX_PART_MOUNT_AS] and mount_point != "":
                 part[IDX_PART_MOUNT_AS] = ""
                 part[IDX_PART_FORMAT_AS] = ""
                 part[IDX_PART_READ_ONLY] = False

--- a/live-installer/frontend/partitioning.py
+++ b/live-installer/frontend/partitioning.py
@@ -213,18 +213,22 @@ def create_subvolume_dialog(widget):
     if not itervar:
         return
     partition = model.get_value(itervar, IDX_PART_OBJECT)
-    if not partition or partition.type != 'btrfs' or partition.format_as != 'btrfs':
+    if not (partition or (partition.type == 'btrfs' and partition.format_as == '') or partition.format_as == 'btrfs'):
         return
     dlg = SubvolDialog("",
                        partition.mount_as,
                        partition.partition.type)
     response_is_ok, subvolume_name, mount_as = dlg.show()
     if response_is_ok:
+        if subvolume_name == "" or "/" in subvolume_name or " " in subvolume_name:
+            dialogs.ErrorDialog(_("Installer"), _(
+                "The name of a subvolume must not be blank or contain a space or a forward slash"))
+            return
+        if " " in mount_as:
+            dialogs.ErrorDialog(_("Installer"), _(
+                "The mount point of a subvolume must not contain a space"))
+            return
         for subvol in partition.subvolumes:
-            if subvol.name == "":
-                dialogs.ErrorDialog(_("Installer"), _(
-                    "You cant create a subvolume with empty name or mount point"))
-                return
             if subvol.name == subvolume_name:
                 dialogs.ErrorDialog(_("Installer"), _(
                     "Subvolume with name '%s' already exists") % subvolume_name)

--- a/live-installer/frontend/partitioning.py
+++ b/live-installer/frontend/partitioning.py
@@ -313,8 +313,9 @@ def partitions_popup_menu(widget, event):
     partition = model.get_value(itervar, IDX_PART_OBJECT)
     if not partition:
         return
-    partition_type = model.get_value(itervar, IDX_PART_TYPE)
-    if (partition.partition.type == parted.PARTITION_EXTENDED or
+    partition_type = model.get_value(itervar, IDX_PART_TYPE).replace("<span>","").replace("</span>","").strip()
+
+    if (partition_type != _("btrfs subvolume")) and (partition.partition.type == parted.PARTITION_EXTENDED or
         partition.partition.number == -1 or
             "swap" in partition_type):
         return
@@ -324,6 +325,18 @@ def partitions_popup_menu(widget, event):
     menu.append(menuItem)
     menuItem = Gtk.SeparatorMenuItem()
     menu.append(menuItem)
+
+    # if the selected "partition" is a subvolume then show a custom menu
+    if partition_type == "btrfs subvolume":
+        mount_points = ["/", "/home", "/var", "/tmp", "/srv", "/opt"]
+        for mount_point in mount_points:
+            menuItem = Gtk.MenuItem(_("Assign to %s") % mount_point)
+            menuItem.connect("activate", lambda w: assign_mount_point(partition, mount_point, _("btrfs subvolume"), False, partition.name))
+            menu.append(menuItem)
+        menu.show_all()
+        menu.popup(None, None, None, None, 0, event.time)
+        return
+
     menuItem = Gtk.MenuItem(_("Assign to %s") % "/")
     menuItem.connect("activate", lambda w: assign_mount_point(
         partition, '/', 'ext4'))

--- a/live-installer/frontend/partitioning.py
+++ b/live-installer/frontend/partitioning.py
@@ -303,12 +303,12 @@ def assign_mount_point(partition, mount_point, filesystem, read_only = False, su
     for part in installer.setup.partitions:
         if part == partition:
             partition.mount_as, partition.format_as, partition.read_only = mount_point, filesystem, read_only
-        elif part.mount_as == mount_point:
+        elif part.mount_as == mount_point and mount_point != "":
             part.mount_as, part.format_as, partition.read_only = '', '', False
         for subvol in part.subvolumes:
             if subvol == partition:
                 partition.name, partition.mount_as = subvolume_name, mount_point
-            elif subvol.mount_as == mount_point:
+            elif subvol.mount_as == mount_point and mount_point != "":
                 subvol.mount_as = ''
 
 

--- a/live-installer/frontend/partitioning.py
+++ b/live-installer/frontend/partitioning.py
@@ -278,6 +278,16 @@ def assign_mount_point(partition, mount_point, filesystem, read_only = False, su
                         "label_new").set_label(_("Create a subvolume"))
                     if use_default_subvols:
                         assign_default_subvolumes(partition)
+                        # ignore the mount_point that is given to the partition if its same with the default subvolumes
+                        if mount_point in ["/", "/home"]:
+                            mount_point = ""
+                part[IDX_PART_MOUNT_AS] = mount_point
+                part[IDX_PART_FORMAT_AS] = filesystem
+                part[IDX_PART_READ_ONLY] = read_only
+            elif mount_point == part[IDX_PART_MOUNT_AS] and mount_point != "":
+                part[IDX_PART_MOUNT_AS] = ""
+                part[IDX_PART_FORMAT_AS] = ""
+                part[IDX_PART_READ_ONLY] = False
 
             for subvol in part.iterchildren():
                 if partition == subvol[IDX_PART_OBJECT]:
@@ -286,14 +296,6 @@ def assign_mount_point(partition, mount_point, filesystem, read_only = False, su
                 elif mount_point == subvol[IDX_PART_MOUNT_AS] and mount_point != "":
                     subvol[IDX_PART_MOUNT_AS] = ""
 
-            if partition == part[IDX_PART_OBJECT]:
-                part[IDX_PART_MOUNT_AS] = mount_point
-                part[IDX_PART_FORMAT_AS] = filesystem
-                part[IDX_PART_READ_ONLY] = read_only
-            elif mount_point == part[IDX_PART_MOUNT_AS] and mount_point != "":
-                part[IDX_PART_MOUNT_AS] = ""
-                part[IDX_PART_FORMAT_AS] = ""
-                part[IDX_PART_READ_ONLY] = False
     # Assign it in our setup
     for part in installer.setup.partitions:
         if part == partition:
@@ -819,10 +821,14 @@ class PartitionDialog(object):
     def show_chkbtn_btrfs_subvols(self,widget):
         w = self.builder.get_object("combobox_use_as")
         format_as = w.get_model()[w.get_active()][0]
+        w = self.builder.get_object("checkbutton_default_btrfs_subvols")
         if format_as == "btrfs" and not does_objects_has_the_mount_points(("/","/home")):
-            self.builder.get_object("checkbutton_default_btrfs_subvols").set_visible(True)
+            w.set_visible(True)
+            # Use the default btrfs subvols scheme by default
+            w.set_active(True)
         else:
-            self.builder.get_object("checkbutton_default_btrfs_subvols").set_visible(False)
+            w.set_visible(False)
+            w.set_active(False)
 
     def show(self):
         response = self.window.run()

--- a/live-installer/frontend/partitioning.py
+++ b/live-installer/frontend/partitioning.py
@@ -222,20 +222,20 @@ def create_subvolume_dialog(widget):
     response_is_ok, subvolume_name, mount_as = dlg.show()
     if response_is_ok:
         if subvolume_name == "" or "/" in subvolume_name or " " in subvolume_name:
-            dialogs.ErrorDialog(_("Installer"), _(
+            show_error(_(
                 "The name of a subvolume must not be blank or contain a space or a forward slash"))
             return
         if " " in mount_as:
-            dialogs.ErrorDialog(_("Installer"), _(
+            show_error(_(
                 "The mount point of a subvolume must not contain a space"))
             return
         for subvol in partition.subvolumes:
             if subvol.name == subvolume_name:
-                dialogs.ErrorDialog(_("Installer"), _(
+                show_error(_(
                     "Subvolume with name '%s' already exists") % subvolume_name)
                 return
             if subvol.mount_as == mount_as and subvol.mount_as != "":
-                dialogs.ErrorDialog(_("Installer"), _(
+                show_error(_(
                     "Subvolume with mount point '%s' already exists") % mount_as)
                 return
         subvolume = BtrfsSubvolume()

--- a/live-installer/installer.py
+++ b/live-installer/installer.py
@@ -571,7 +571,7 @@ class InstallerEngine:
                         fstab.write("%s %s %s %s %s %s\n" % (
                             partition_uuid, partition.mount_as, fs, fstab_mount_options, "0", fstab_fsck_option))
 
-                if partition.subvolumes != []:
+                if partition.subvolumes != [] and partition.type == "btrfs":
                     for subvolume in partition.subvolumes:
                         fstab.write("# %s\n" % (partition.path))
                         rw="rw"

--- a/live-installer/installer.py
+++ b/live-installer/installer.py
@@ -563,9 +563,8 @@ class InstallerEngine:
                         rw="ro"
                     if fs == "fat16" or fs == "fat32":
                         fs = "vfat"
-                    else:
-                        fstab_mount_options = "defaults,{}".format(rw)
 
+                    fstab_mount_options = "defaults,{}".format(rw)
                     partition_uuid = self.get_blkid(partition.path)
                     if(fs == "swap"):
                         fstab.write("%s swap swap sw 0 0\n" %

--- a/live-installer/installer.py
+++ b/live-installer/installer.py
@@ -428,10 +428,8 @@ class InstallerEngine:
                                 # Mount subvolumes
                                 partition.subvolumes.sort(key = lambda x : x.mount_as, reverse=False)
                                 for subvolume in partition.subvolumes:
-                                    log(" ------ Mounting btrfs subvolume {} on /target/{}".format(subvolume.name,subvolume.mount_as))
-                                    self.do_mount(partition.path, "/target/{}".format(subvolume.mount_as), fs, "subvol={}".format(subvolume.name),"--mkdir") 
-                            if partition.mount_as != "":
-                                self.do_mount(partition.path, "/target", fs, "subvol=@")
+                                    log(" ------ Mounting btrfs subvolume {} on /target{}".format(subvolume.name,subvolume.mount_as))
+                                    self.do_mount(partition.path, "/target{}".format(subvolume.mount_as), fs, "subvol={}".format(subvolume.name),"--mkdir") 
                     else:
                         self.error_message(
                             "Cannot mount rootfs (type: {}): {}".format(partition.type, partition.path))
@@ -455,7 +453,7 @@ class InstallerEngine:
                         notOld = True
                         break
                 if not notOld:
-                    self.run("mv /target/{0} {1}/{0}".format(old,target),vital=False)
+                    self.run("mv /target{0} {1}/{0}".format(old,target),vital=False)
 
 
         # Mount the other partitions

--- a/live-installer/installer.py
+++ b/live-installer/installer.py
@@ -413,6 +413,9 @@ class InstallerEngine:
                                 # Create subvolumes
                                 partition.subvolumes.sort(key = lambda x : x.name, reverse=False)
                                 for subvolume in partition.subvolumes:
+                                    if subvolume.format:
+                                        os.system("btrfs subvolume delete /target/{}".format(subvolume.name))
+                                        subvolume.exists_on_disk = False
                                     if subvolume.exists_on_disk:
                                         continue
                                     log(" ------ Creating btrfs subvolume {} on /target/{}".format(subvolume.name,subvolume.mount_as))

--- a/live-installer/installer.py
+++ b/live-installer/installer.py
@@ -396,16 +396,7 @@ class InstallerEngine:
 
     def mount_partitions(self):
         # Sort partitions for mount order
-        partitions_sorted = []
-        mountpoint_sorted = []
-        for partition in self.setup.partitions:
-            mountpoint_sorted.append(partition.mount_as)
-        mountpoint_sorted.sort()
-        for dir in mountpoint_sorted:
-            for partition in self.setup.partitions:
-                if partition.mount_as == dir:
-                    partitions_sorted.append(partition)
-        self.setup.partitions = partitions_sorted
+        self.setup.partitions.sort(key = lambda x : x.mount_as, reverse=False)
         # Mount the target partition
         for partition in self.setup.partitions:
             if(partition.mount_as not in [None, "swap"] and partition.subvolumes != [] and not self.is_subvolume_has_mountpoint(partition.subvolumes,"")) or (partition.mount_as not in ["", None, "swap"]):

--- a/live-installer/installer.py
+++ b/live-installer/installer.py
@@ -6,7 +6,7 @@ import parted
 import frontend.partitioning as partitioning
 import config
 import shutil
-from utils import run, set_governor, is_cmd
+from utils import run, set_governor, is_cmd, getoutput
 from logger import log, err, inf, set_logfile
 
 gettext.install("live-installer", "/usr/share/locale")
@@ -408,8 +408,8 @@ class InstallerEngine:
         self.setup.partitions = partitions_sorted
         # Mount the target partition
         for partition in self.setup.partitions:
-            if(partition.mount_as not in ["", None, "swap"]):
-                if partition.mount_as == "/":
+            if(partition.mount_as not in [None, "swap"] and partition.subvolumes != [] and not self.is_subvolume_has_mountpoint(partition.subvolumes,"")) or (partition.mount_as not in ["", None, "swap"]):
+                if partition.mount_as == "/" or self.is_subvolume_has_mountpoint(partition.subvolumes, "/"):
                     self.update_progress(_("Mounting %(partition)s on %(mountpoint)s") % {
                                          'partition': partition.path, 'mountpoint': "/target/"})
                     log(" ------ Mounting partition %s on %s" %
@@ -417,21 +417,23 @@ class InstallerEngine:
                     fs = partition.type
                     if 0 == self.do_mount(partition.path, "/target", partition.type, None):
                         if fs == "btrfs":
+                            log(" ------ Found btrfs filesystem")
                             # Create subvolumes for Btrfs
-                            os.system("btrfs subvolume create /target/@")
-                            os.system("btrfs subvolume list -p /target")
-                            log(" ------ Umount btrfs to remount subvolume @")
-                            os.system("umount --force /target")
-                            self.do_mount(partition.path, "/target", fs, "subvol=@")
-                            if not self.setup_has_dedicated_home():
-                                # If there is no dedicated home partition, add a @home subvolume to /
-                                os.system("mkdir -p /target/home")
-                                self.do_mount(partition.path, "/target/home", fs, None)
-                                os.system("btrfs subvolume create /target/home/@home")
-                                os.system("btrfs subvolume list -p /target/home")
-                                log(" ------- Umount btrfs to remount subvolume @home")
-                                os.system("umount --force /target/home")
-                                self.do_mount(partition.path, "/target/home", fs, "subvol=@home")
+                            if partition.subvolumes != []:
+                                partition.subvolumes.sort(key = lambda x : x.mount_as, reverse=False)
+                                for subvolume in partition.subvolumes:
+                                    print("mounting subvolume {}".format(subvolume.name))
+                                    log(" ------ Mounting btrfs subvolume {} on /target/{}".format(subvolume.name,subvolume.mount_as))
+                                    os.system("btrfs subvolume create /target/{}".format(subvolume.name))
+                                os.system("umount --force /target")
+                                for subvolume in partition.subvolumes:
+                                    log(" ------ Umount btrfs to remount subvolume {}".format(subvolume.name))
+                                    # self.do_mount(partition.path, "/target", fs, "subvol={}".format(subvolume))
+
+                                    print("mounting subvolume {}".format(subvolume.mount_as))
+                                    self.do_mount(partition.path, "/target/{}".format(subvolume.mount_as), fs, "subvol={}".format(subvolume.name),"--mkdir") 
+                            if partition.mount_as != "":
+                                self.do_mount(partition.path, "/target", fs, "subvol=@")
                     else:
                         self.error_message(
                             "Cannot mount rootfs (type: {}): {}".format(partition.type, partition.path))
@@ -450,23 +452,29 @@ class InstallerEngine:
 
         # Mount the other partitions
         for partition in self.setup.partitions:
-            if(partition.mount_as not in [ None, "/", "swap", ""]):
+            if(partition.mount_as not in [ None, "/", "swap"] and partition.subvolumes != [] and not self.is_subvolume_has_mountpoint(partition.subvolumes,"") and not self.is_subvolume_has_mountpoint(partition.subvolumes,"/")) or (partition.mount_as not in ["", None, "/", "swap"]):
                 log(" ------ Mounting %s on %s" %
                     (partition.path, "/target" + partition.mount_as))
                 self.run("mkdir -p /target" + partition.mount_as)
+                if partition.subvolumes != []:
+                    tempdir = getoutput("mktemp -d").decode("utf-8").strip()
+                    self.do_mount(partition.path, tempdir, partition.type, None)
+                    for subvolume in partition.subvolumes:
+                        os.system("btrfs subvolume create {}/{}".format(tempdir,subvolume.name))
+                    os.system("umount --force {}".format(tempdir))
+
                 if partition.type == "fat16" or partition.type == "fat32":
                     fs = "vfat"
                 else:
                     fs = partition.type
-                self.do_mount(partition.path, "/target" +
-                              partition.mount_as, fs, None)
-                if partition.mount_as == "/home" and fs == "btrfs":
-                    # Dedicated home partition with Btrfs, needs a @home subvolume
-                    os.system("btrfs subvolume create /target/home/@home")
-                    os.system("btrfs subvolume list -p /target/home")
-                    print(" ------- Umount btrfs to remount subvolume @home")
-                    os.system("umount --force /target/home")
-                    self.do_mount(partition.path, "/target/home", fs, "subvol=@home")
+
+                if partition.mount_as != "":
+                    self.do_mount(partition.path, "/target" +
+                                  partition.mount_as, fs, None)
+                elif partition.subvolumes != []:
+                    for subvolume in partition.subvolumes:
+                        self.do_mount(partition.path, "/target" +
+                                      subvolume.mount_as, fs, "subvol={}".format(subvolume.name),"--mkdir")
 
     def get_blkid(self, path):
         uuid = path  # If we can't find the UUID we use the path
@@ -482,14 +490,11 @@ class InstallerEngine:
                 break
         return uuid
 
-    def setup_has_dedicated_home(self):
-        # Find out if there is a dedicated home partition
-        has_dedicated_home = False
-        for partition in self.setup.partitions:
-            if partition.mount_as == "/home":
-                has_dedicated_home = True
-                break
-        return has_dedicated_home
+    def is_subvolume_has_mountpoint(self, subvolumes, mountpoint):
+        for subvolume in subvolumes:
+            if subvolume.mount_as == mountpoint:
+                return True
+        return False
 
     def write_fstab(self):
         # write the /etc/fstab
@@ -541,10 +546,6 @@ class InstallerEngine:
                         rw="ro"
                     if fs == "fat16" or fs == "fat32":
                         fs = "vfat"
-                    if fs == "btrfs" and partition.mount_as == "/":
-                        fstab_mount_options = "defaults,subvol=@"
-                    elif fs == "btrfs" and self.setup_has_dedicated_home():
-                        fstab_mount_options = "defaults,subvol=@home"
                     else:
                         fstab_mount_options = "defaults,{}".format(rw)
 
@@ -556,9 +557,17 @@ class InstallerEngine:
                         fstab.write("%s %s %s %s %s %s\n" % (
                             partition_uuid, partition.mount_as, fs, fstab_mount_options, "0", fstab_fsck_option))
 
-                    if fs == "btrfs" and partition.mount_as == "/" and not self.setup_has_dedicated_home():
-                        fstab.write("%s %s %s %s %s %s\n" % (
-                            partition_uuid, "/home", "btrfs", "defaults,subvol=@home", "0", "0"))
+                if partition.subvolumes != []:
+                    for subvolume in partition.subvolumes:
+                        fstab.write("# %s\n" % (partition.path))
+                        rw="rw"
+                        if partition.read_only:
+                            rw="ro"
+                        fstab_mount_options = "defaults,subvol={},{}".format(subvolume.name,rw)
+
+                        partition_uuid = self.get_blkid(partition.path)
+                        fstab.write("%s %s %s %s 0 0\n" % (
+                            partition_uuid, subvolume.mount_as, partition.type, fstab_mount_options))
 
         if self.setup.luks:
             self.run("echo '{}   {}   none   luks,tries=3' >> /target/etc/crypttab".format(
@@ -895,7 +904,7 @@ class InstallerEngine:
             err("!No /target/boot/grub/grub.cfg file found!")
             return False
 
-    def do_mount(self, device, dest, typevar="auto", options=None):
+    def do_mount(self, device, dest, typevar="auto", options=None, args=""):
         ''' Mount a filesystem '''
         if typevar == "none" or typevar == "":
             return 0
@@ -903,9 +912,9 @@ class InstallerEngine:
             os.sync()
             time.sleep(0.1)
         if(options is not None):
-            cmd = "mount -o %s -t %s %s %s" % (options, typevar, device, dest)
+            cmd = "mount -o %s -t %s %s %s %s" % (options, typevar, device, dest, args)
         else:
-            cmd = "mount -t %s %s %s" % (typevar, device, dest)
+            cmd = "mount -t %s %s %s %s" % (typevar, device, dest, args)
         return self.run(cmd)
 
     def do_unmount(self, mountpoint):

--- a/live-installer/installer.py
+++ b/live-installer/installer.py
@@ -418,10 +418,12 @@ class InstallerEngine:
                     if 0 == self.do_mount(partition.path, "/target", partition.type, None):
                         if fs == "btrfs":
                             log(" ------ Found btrfs filesystem")
-                            # Create subvolumes for Btrfs
                             if partition.subvolumes != []:
+                                # Create subvolumes
                                 partition.subvolumes.sort(key = lambda x : x.name, reverse=False)
                                 for subvolume in partition.subvolumes:
+                                    if subvolume.exists_on_disk:
+                                        continue
                                     log(" ------ Creating btrfs subvolume {} on /target/{}".format(subvolume.name,subvolume.mount_as))
                                     # btrfs-progs have a parameter to create subvolumes with parent directories but in a version newer(v6.5.3) than the debian 12 package(v6.2)
                                     # you can replace this with "btrfs subvolume create -p" when next debian release(trixie) based pardus is out 
@@ -432,6 +434,7 @@ class InstallerEngine:
                                     os.system("btrfs subvolume create /target/{}".format(subvolume.name))
 
                                 os.system("umount --force /target")
+                                # Mount subvolumes
                                 partition.subvolumes.sort(key = lambda x : x.mount_as, reverse=False)
                                 for subvolume in partition.subvolumes:
                                     log(" ------ Mounting btrfs subvolume {} on /target/{}".format(subvolume.name,subvolume.mount_as))

--- a/live-installer/resources/interface.ui
+++ b/live-installer/resources/interface.ui
@@ -2675,7 +2675,7 @@ install</property>
             </child>
             <child>
               <object class="GtkCheckButton" id="checkbutton_format_subvolume">
-                <property name="label" translatable="yes">checkbutton</property>
+                <property name="label" translatable="yes">Format subvolume</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>

--- a/live-installer/resources/interface.ui
+++ b/live-installer/resources/interface.ui
@@ -2404,7 +2404,7 @@ install</property>
           </packing>
         </child>
         <child>
-          <!-- n-columns=3 n-rows=4 -->
+          <!-- n-columns=3 n-rows=5 -->
           <object class="GtkGrid">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
@@ -2512,6 +2512,24 @@ install</property>
                 <property name="left-attach">1</property>
                 <property name="top-attach">3</property>
               </packing>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="checkbutton_default_btrfs_subvols">
+                <property name="label" translatable="yes">Use default Btrfs subvolumes</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="draw-indicator">True</property>
+              </object>
+              <packing>
+                <property name="left-attach">1</property>
+                <property name="top-attach">4</property>
+              </packing>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
             </child>
             <child>
               <placeholder/>

--- a/live-installer/resources/interface.ui
+++ b/live-installer/resources/interface.ui
@@ -2542,4 +2542,131 @@ install</property>
       <action-widget response="-5">button_ok</action-widget>
     </action-widgets>
   </object>
+  <object class="GtkDialog" id="subvol_dialog">
+    <property name="can-focus">False</property>
+    <property name="border-width">5</property>
+    <property name="icon">../branding/icon.svg</property>
+    <property name="type-hint">dialog</property>
+    <property name="transient-for">main_window</property>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
+            <child>
+              <object class="GtkButton" id="button_subvol_cancel">
+                <property name="label">Cancel</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button_subvol_ok">
+                <property name="label">OK</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <!-- n-columns=2 n-rows=2 -->
+          <object class="GtkGrid">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="row-spacing">6</property>
+            <property name="column-spacing">6</property>
+            <child>
+              <object class="GtkLabel" id="label_subvolume_name">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">label</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label_subvol_mount_point">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">label</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkComboBox" id="comboboxentry_subvol_mount_point">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="has-entry">True</property>
+                <child>
+                  <object class="GtkCellRendererText" id="renderer4"/>
+                  <attributes>
+                    <attribute name="text">0</attribute>
+                  </attributes>
+                </child>
+                <child internal-child="entry">
+                  <object class="GtkEntry">
+                    <property name="can-focus">True</property>
+                    <property name="primary-icon-activatable">False</property>
+                    <property name="secondary-icon-activatable">False</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="left-attach">1</property>
+                <property name="top-attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkEntry" id="entry_subvol_name">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+              </object>
+              <packing>
+                <property name="left-attach">1</property>
+                <property name="top-attach">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-6">button_subvol_cancel</action-widget>
+      <action-widget response="-5">button_subvol_ok</action-widget>
+    </action-widgets>
+  </object>
 </interface>

--- a/live-installer/resources/interface.ui
+++ b/live-installer/resources/interface.ui
@@ -2609,7 +2609,7 @@ install</property>
           </packing>
         </child>
         <child>
-          <!-- n-columns=2 n-rows=2 -->
+          <!-- n-columns=2 n-rows=3 -->
           <object class="GtkGrid">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
@@ -2672,6 +2672,22 @@ install</property>
                 <property name="left-attach">1</property>
                 <property name="top-attach">0</property>
               </packing>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="checkbutton_format_subvolume">
+                <property name="label" translatable="yes">checkbutton</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="draw-indicator">True</property>
+              </object>
+              <packing>
+                <property name="left-attach">1</property>
+                <property name="top-attach">2</property>
+              </packing>
+            </child>
+            <child>
+              <placeholder/>
             </child>
           </object>
           <packing>

--- a/po/live-installer-af.po
+++ b/po/live-installer-af.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2013-11-06 17:40+0000\n"
 "Last-Translator: Clement Lefebvre <root@linuxmint.com>\n"
 "Language-Team: Afrikaans <af@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,141 +149,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Stelselinstellings"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -310,6 +318,702 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Sleutelborduitleg "
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Installeringsfout"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Soort"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Uitleg"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Toestel"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Bedryfstelsel"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Hegpunt"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Grootte"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Oop spasie"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Lokalisasie"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Taal "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Tydsone "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Sleutelborduitleg "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Gebruikers-instellings"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Regte naam "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Gebruikernaam: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Stelselinstellings"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Lêerstelsel bedrywighede"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Selflaaiprogram installeer nie"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Monteer tans %(partition)s by %(mountpoint)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Installasie Voltooi"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Installeringsfout"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Stelselinstellings"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -405,10 +1109,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -435,7 +1135,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Monteer tans %(partition)s by %(mountpoint)s"
@@ -455,49 +1155,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Instelling van gasheer naam"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Verstel lokale inligting"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Instelling van gasheer naam"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Verstel sleutelbord opsies"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Verwyder lewendige konfigurasie (programmatuur)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Installeer selflaai program"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Stel tans selflaai program in"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -505,630 +1205,16 @@ msgstr ""
 "WAARSKUWING: Grub selflaai program was nie reg opgestel nie! Jy moet dit "
 "self regstel."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Installasie Voltooi"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Ondersoek tans die selflaai program"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Uitleg"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Variant"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Toestel"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Soort"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Bedryfstelsel"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Hegpunt"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Grootte"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Oop spasie"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Lokalisasie"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Taal "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Tydsone "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Sleutelborduitleg "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Gebruikers-instellings"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Regte naam "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Gebruikernaam: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Stelselinstellings"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Lêerstelsel bedrywighede"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Selflaaiprogram installeer nie"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Installeringsfout"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Sleutelborduitleg "
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Installeringsfout"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Stelselinstellings"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-af.po
+++ b/po/live-installer-af.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2013-11-06 17:40+0000\n"
 "Last-Translator: Clement Lefebvre <root@linuxmint.com>\n"
 "Language-Team: Afrikaans <af@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -292,6 +292,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -322,8 +327,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -411,23 +416,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Uitleg"
-
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Variant"
-
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -445,9 +521,103 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Oop spasie"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Stelselinstellings"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Uitleg"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -562,18 +732,6 @@ msgstr ""
 msgid "Size"
 msgstr "Grootte"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Oop spasie"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -605,25 +763,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -858,7 +997,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Installasie Voltooi"
 
@@ -877,139 +1016,6 @@ msgstr "Installeringsfout"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Stelselinstellings"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1155,49 +1161,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Instelling van gasheer naam"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Verstel lokale inligting"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Instelling van gasheer naam"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Verstel sleutelbord opsies"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Verwyder lewendige konfigurasie (programmatuur)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Installeer selflaai program"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Stel tans selflaai program in"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1205,15 +1211,15 @@ msgstr ""
 "WAARSKUWING: Grub selflaai program was nie reg opgestel nie! Jy moet dit "
 "self regstel."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Ondersoek tans die selflaai program"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-am.po
+++ b/po/live-installer-am.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2018-08-10 01:48+0000\n"
 "Last-Translator: samson <Unknown>\n"
 "Language-Team: Amharic <am@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "ጌባ"
 
@@ -189,9 +189,9 @@ msgid "Format"
 msgstr "አቀራረብ እንደ"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -295,6 +295,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "አቀራረብ እንደ"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -325,8 +331,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "እሺ"
 
@@ -415,23 +421,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "አገር"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "ባ"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "አቀማመጥ"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "ኪባ"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "የተለየ"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "ሜባ"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "የ ፋይል ማውጫዎች በማስላት ላይ ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "ቴባ"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "የሚወልቁ:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "ማረሚያ"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "መመደቢያ ወደ /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -449,10 +526,104 @@ msgstr "የ ፋይል ማውጫዎች በማስላት ላይ ..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "ነፃ ቦታ"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "ሎጂካል ክፍልፋይ"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "የ ተስፋፋ መከፋፈያ"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "ያልታወቀ"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "ክፍልፋዮችን ማረሚያ"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "ክፍልፋዮችን ማረሚያ"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "አካል:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "አቀራረብ እንደ:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "መጫኛ ነጥብ:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "መሰረዣ"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "አገር"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "አቀማመጥ"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "የተለየ"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "የ ፋይል ማውጫዎች በማስላት ላይ ..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -567,18 +738,6 @@ msgstr "አቀራረብ እንደ"
 msgid "Size"
 msgstr "መጠን"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "ነፃ ቦታ"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -611,25 +770,6 @@ msgstr "ላጥፋው?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "በ እርግጥ መግጠሚያውን ማጥፋት ይፈልጋሉ?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -869,7 +1009,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "መግጠሙ ተጠናቋል"
 
@@ -888,139 +1028,6 @@ msgstr "የመግጠም ስህተት ተፈጥሯል"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "ባ"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "ኪባ"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "ሜባ"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "ቴባ"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "የሚወልቁ:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "ማረሚያ"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "መመደቢያ ወደ /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "ሎጂካል ክፍልፋይ"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "የ ተስፋፋ መከፋፈያ"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "ያልታወቀ"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "ክፍልፋዮችን ማረሚያ"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "ክፍልፋዮችን ማረሚያ"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "አካል:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "አቀራረብ እንደ:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "መጫኛ ነጥብ:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "መሰረዣ"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1179,63 +1186,63 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "አቀራረብ %(partition)s እንደ %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "የጋባዥ ስም በማሰናዳት ላይ"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "አካባቢን በማሰናዳት ላይ"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "የጋባዥ ስም በማሰናዳት ላይ"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "የፊደል ገበታ አቀማመጥ ምርጫዎች"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "በማስወገድ ላይ ላይሽ ማዋቀሪያን (ለጥቅሎች)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "ቡትሎደር በመግጠም ላይ"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "ማስነሻ መጫኛውን በማዋቀር ላይ"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr "ማስጠንቀቂያ : የ grub ማስነሻ መጫኛው በሚገባ አልተዋቀረም! እርስዎ በእጅ ያዋቅሩት"
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "ማስነሻ መጫኛውን በመመርመር ላይ"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-am.po
+++ b/po/live-installer-am.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2018-08-10 01:48+0000\n"
 "Last-Translator: samson <Unknown>\n"
 "Language-Team: Amharic <am@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "የሰዓት ክልል"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "ክፍልፋዮችን ማረሚያ"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "ጌባ"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "በ ባለሞያ ዘዴ"
@@ -149,142 +151,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "ማነቃቂያ"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "አቀራረብ እንደ"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "ክፍልፋዮች ማረሚያ"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "ራሱ በራሱ መግቢያ"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -313,6 +321,710 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "እሺ"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "አይ"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "አዎ"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "የሰዓት ክልል"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "ቋንቋ"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "የፊደል ገበታ አቀማመጥ"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "መግጠሙ ተቋርጧል"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "አይነት"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "አገር"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "አቀማመጥ"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "የተለየ"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "የ ፋይል ማውጫዎች በማስላት ላይ ..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "የፊደል ገበታ አቀማመጥ"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "በ እርግጥ መግጠሚያውን ማጥፋት ይፈልጋሉ?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "በመከፋፈል ላይ"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "ማጠቃለያ"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "ወደ ኋላ"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "ክፍልፋዮች ማረሚያ"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "አካል"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "የስርአት መተግበሪያ"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "መጫኛ ጣቢያ"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "አቀራረብ እንደ"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "መጠን"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "ነፃ ቦታ"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "መግጠሚያ"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "የ እርስዎ የመግቢያ ቃሎች አይመሳሰሉም"
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "ላጥፋው?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "በ እርግጥ መግጠሚያውን ማጥፋት ይፈልጋሉ?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "እባክዎን ቋንቋ ይምረጡ"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "እባክዎን ለ እርስዎ የተጠቃሚ መግለጫ የመግቢያ ቃል ያስገቡ"
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "እባክዎን ሙሉ ስም ያስገቡ"
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "የ እርስዎ የመግቢያ ቃሎች አይመሳሰሉም"
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "የ EFI partition is not bootable. እባክዎን ያርሙ የ partition flags."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "እባክዎን ይምረጡ የ root (/) መከፋፈያ"
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "የ EFI partition is not bootable. እባክዎን ያርሙ የ partition flags."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "የ EFI ክፍልፋይ አቀራረብ መሆን አለበት እንደ vfat."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "የ EFI ክፍልፋይ አቀራረብ መሆን አለበት እንደ vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "እባክዎን የ EFI መከፋፈያ ይምረጡ"
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "እባክዎን የተጠቃሚ ስም ያስገቡ"
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "መተርጎም"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "ቋንቋ : "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "የሰአት ክልል : "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "የፊደል ገበታ አቅማመጥ : "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "ተጠቃሚ ማሰናጃዎች"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "ትክክለኛ ስም : "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "የተጠቃሚ ስም : "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "ራሱ በራሱ መግቢያ: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "ተችሏል"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "ተሰናክሏል"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "የስርአት ማሰናጃ"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "የፋይል ስርአት ተግባሮች"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "መግጠሚያ bootloader በ %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "ማስነሻ መጫኛውን አትግጠም"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "ይጠቀሙ በቅድሚያ-የ ተጫነውን /target."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "አቀራረብ %(path)s እንደ %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "መጫኛ %(path)s እንደ %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "መጫኛ %(path)s እንደ %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "መግጠሙ ተጠናቋል"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr "መግጠሚያ አሁን ጨርሷል: እርስዎ ኮምፒዩተሩን እንደገና ማስጀመር ይፈልጋሉ አዲሱን ስርአት ለ መጠቀም?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "የመግጠም ስህተት ተፈጥሯል"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "ባ"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "ኪባ"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "ሜባ"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "ቴባ"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "የሚወልቁ:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "ማረሚያ"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "መመደቢያ ወደ /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "ሎጂካል ክፍልፋይ"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "የ ተስፋፋ መከፋፈያ"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "ያልታወቀ"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "ክፍልፋዮችን ማረሚያ"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "ክፍልፋዮችን ማረሚያ"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "አካል:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "አቀራረብ እንደ:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "መጫኛ ነጥብ:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "መሰረዣ"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -421,10 +1133,6 @@ msgstr "የ እርስዎ የመግቢያ ቃሎች አይመሳሰሉም"
 msgid "Please provide a password for your user account."
 msgstr "እባክዎን ለ እርስዎ የተጠቃሚ መግለጫ የመግቢያ ቃል ያስገቡ"
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -451,7 +1159,7 @@ msgstr "አዲስ ተጠቃሚ ወደ ስርአቱ በመጨመር ላይ"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "የ ፋይል ስርአት መጫኛ መረጃ በ መጻፍ ላይ ወደ /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "በመጫን ላይ %(partition)s በ %(mountpoint)s"
@@ -471,687 +1179,65 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "አቀራረብ %(partition)s እንደ %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "የጋባዥ ስም በማሰናዳት ላይ"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "አካባቢን በማሰናዳት ላይ"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "የጋባዥ ስም በማሰናዳት ላይ"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "የፊደል ገበታ አቀማመጥ ምርጫዎች"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "በማስወገድ ላይ ላይሽ ማዋቀሪያን (ለጥቅሎች)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "ቡትሎደር በመግጠም ላይ"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "ማስነሻ መጫኛውን በማዋቀር ላይ"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr "ማስጠንቀቂያ : የ grub ማስነሻ መጫኛው በሚገባ አልተዋቀረም! እርስዎ በእጅ ያዋቅሩት"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "መግጠሙ ተጠናቋል"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "ማስነሻ መጫኛውን በመመርመር ላይ"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "አገር"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "ቋንቋ"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "አቀማመጥ"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "የተለየ"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "የ ፋይል ማውጫዎች በማስላት ላይ ..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "የፊደል ገበታ አቀማመጥ"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "በ እርግጥ መግጠሚያውን ማጥፋት ይፈልጋሉ?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "በመከፋፈል ላይ"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "ማጠቃለያ"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "ወደ ኋላ"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "ክፍልፋዮች ማረሚያ"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "አካል"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "አይነት"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "የስርአት መተግበሪያ"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "መጫኛ ጣቢያ"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "አቀራረብ እንደ"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "መጠን"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "ነፃ ቦታ"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "መግጠሚያ"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "የ እርስዎ የመግቢያ ቃሎች አይመሳሰሉም"
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "ላጥፋው?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "በ እርግጥ መግጠሚያውን ማጥፋት ይፈልጋሉ?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "እባክዎን ቋንቋ ይምረጡ"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "እባክዎን ለ እርስዎ የተጠቃሚ መግለጫ የመግቢያ ቃል ያስገቡ"
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "እባክዎን ሙሉ ስም ያስገቡ"
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "የ እርስዎ የመግቢያ ቃሎች አይመሳሰሉም"
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "የ EFI partition is not bootable. እባክዎን ያርሙ የ partition flags."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "እባክዎን ይምረጡ የ root (/) መከፋፈያ"
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "የ EFI partition is not bootable. እባክዎን ያርሙ የ partition flags."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "የ EFI ክፍልፋይ አቀራረብ መሆን አለበት እንደ vfat."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "የ EFI ክፍልፋይ አቀራረብ መሆን አለበት እንደ vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "እባክዎን የ EFI መከፋፈያ ይምረጡ"
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "እባክዎን የተጠቃሚ ስም ያስገቡ"
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "መተርጎም"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "ቋንቋ : "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "የሰአት ክልል : "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "የፊደል ገበታ አቅማመጥ : "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "ተጠቃሚ ማሰናጃዎች"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "ትክክለኛ ስም : "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "የተጠቃሚ ስም : "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "ራሱ በራሱ መግቢያ: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "ተችሏል"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "ተሰናክሏል"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "የስርአት ማሰናጃ"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "የፋይል ስርአት ተግባሮች"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "መግጠሚያ bootloader በ %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "ማስነሻ መጫኛውን አትግጠም"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "ይጠቀሙ በቅድሚያ-የ ተጫነውን /target."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "አቀራረብ %(path)s እንደ %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "መጫኛ %(path)s እንደ %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr "መግጠሚያ አሁን ጨርሷል: እርስዎ ኮምፒዩተሩን እንደገና ማስጀመር ይፈልጋሉ አዲሱን ስርአት ለ መጠቀም?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "የመግጠም ስህተት ተፈጥሯል"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "የፊደል ገበታ አቀማመጥ"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "መግጠሙ ተቋርጧል"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "የሰዓት ክልል"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "ባ"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "ኪባ"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "ሜባ"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "ቴባ"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "የሚወልቁ:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "ማረሚያ"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "መመደቢያ ወደ /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "ሎጂካል ክፍልፋይ"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "የ ተስፋፋ መከፋፈያ"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "ያልታወቀ"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "ክፍልፋዮችን ማረሚያ"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "ክፍልፋዮችን ማረሚያ"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "አካል:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "አቀራረብ እንደ:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "መጫኛ ነጥብ:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "መሰረዣ"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "እሺ"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "አይ"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "አዎ"
 
 #~ msgid "Quit"
 #~ msgstr "ማጥፊያ"

--- a/po/live-installer-ar.po
+++ b/po/live-installer-ar.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2019-02-27 21:16+0000\n"
 "Last-Translator: Ibrahim Saed <ibraheem5000@gmail.com>\n"
 "Language-Team: anwar AL_iskandrany <anwareleskndrany13@gmail.com>\n"
@@ -84,7 +84,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "جب"
 
@@ -184,9 +184,9 @@ msgid "Format"
 msgstr "تنسيق مثل"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -290,6 +290,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "تنسيق مثل"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -320,8 +326,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "حسنا"
 
@@ -410,23 +416,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "الدولة"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "بت"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "تخطيط"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "كب"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "مختلف"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "مب"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "حساب فهرسة الملفات..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "تب"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "قابل للإزالة:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "تحرير"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "تعيين إلى/"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -444,10 +521,104 @@ msgstr "حساب فهرسة الملفات..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "مساحة حرة"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "قسم منطقي"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "قسم موسع"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "غير معروف"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "تحرير القسم"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "تحرير القسم"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "الجهاز:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "تنسيق مثل:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "نقطة التحميل:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "إلغاء"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "الدولة"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "تخطيط"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "مختلف"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "حساب فهرسة الملفات..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -562,18 +733,6 @@ msgstr "تنسيق مثل"
 msgid "Size"
 msgstr "الحجم"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "مساحة حرة"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -606,25 +765,6 @@ msgstr "إنهاء؟"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "هل تريد بالتأكيد إنهاء برنامج التثبيت؟"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -864,7 +1004,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "الإنتهاء من التثبيت"
 
@@ -884,139 +1024,6 @@ msgstr "خطأ في التثبيت"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "بت"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "كب"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "مب"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "تب"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "قابل للإزالة:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "تحرير"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "تعيين إلى/"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "قسم منطقي"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "قسم موسع"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "غير معروف"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "تحرير القسم"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "تحرير القسم"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "الجهاز:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "تنسيق مثل:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "نقطة التحميل:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "إلغاء"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1175,64 +1182,64 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "تنسيق %(partition)s كـ%(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "إعداد اسم المضيف"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "الإعداد المحلي"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "إعداد اسم المضيف"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "إعداد خيارات لوحة المفاتيح"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "إزالة التكوين المباشر (الحزم)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "تثبيت مُحمل الإقلاع"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "تكوين مُحمل الإقلاع"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 "تحذير: لم يتم تكوين مُحمل الإقلاع grub بشكل صحيح! تحتاج إلى تكوينه يدويا."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "التحقق من مُحمل الإقلاع"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-ar.po
+++ b/po/live-installer-ar.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2019-02-27 21:16+0000\n"
 "Last-Translator: Ibrahim Saed <ibraheem5000@gmail.com>\n"
 "Language-Team: anwar AL_iskandrany <anwareleskndrany13@gmail.com>\n"
@@ -18,19 +18,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -39,10 +39,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -51,13 +53,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "المنطقة الزمنية"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -66,12 +68,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "تحرير القسم"
@@ -82,42 +84,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "جب"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -134,7 +136,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "وضع الخبراء"
@@ -144,142 +146,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "تحديث"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "تنسيق مثل"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "تحرير الأقسام"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "تسجيل الدخول تلقائيا"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -308,6 +316,711 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "حسنا"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "ﻻ"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "نعم"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "المنطقة الزمنية"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "اللغة"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "تخطيط لوحة المفاتيح"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "التثبيت متوقف مؤقتاً"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "النوع"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "الدولة"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "تخطيط"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "مختلف"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "حساب فهرسة الملفات..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "تخطيط لوحة المفاتيح"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "هل تريد بالتأكيد إنهاء برنامج التثبيت؟"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "التقسيم"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "الملخص"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "عودة"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "تحرير الأقسام"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "الجهاز"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "نظام التشغيل"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "نقطة التحميل"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "تنسيق مثل"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "الحجم"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "مساحة حرة"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "ثبّت"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "كلمات المرور الخاصة بك لا تتطابق."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "إنهاء؟"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "هل تريد بالتأكيد إنهاء برنامج التثبيت؟"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "يرجى اختيار لغة"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "يرجى تقديم كلمة مرور لحساب المستخدم الخاص بك."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "يرجى تقديم اسمك الكامل."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "كلمات المرور الخاصة بك لا تتطابق."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "قسم EFI غير قابل للتمهيد. الرجاء تحرير علامات القسم."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "يرجى تحديد قسم الجذر (/)."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "قسم EFI غير قابل للتمهيد. الرجاء تحرير علامات القسم."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "يجب تهيئة قسم EFI على أنه vfat."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "يجب تهيئة قسم EFI على أنه vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "يرجى اختيار قسم EFI."
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "يرجى تقديم اسم المستخدم."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "التوطين"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "اللغة: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "المنطقة الزمنية: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "تخطيط لوحة المفاتيح: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "إعدادات المستخدم"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "الاسم الحقيقي: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "اسم المستخدم: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "تسجيل دخول تلقائي: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "ممكن"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "معطل"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "إعدادات النظام"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "عمليات نظام الملفات"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "تثبيت مُحمل الإقلاع على %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "عدم تثبيت مُحمل الإقلاع"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "استخدم المحمل بالفعل /target."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "تنسيق %(path)s كـ%(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "تحميل %(path)s كـ%(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "تحميل %(path)s كـ%(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "الإنتهاء من التثبيت"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"التثبيت اكتمل الان. هل تريد إعادة تشغيل الكمبيوتر لاستخدام النظام الجديد؟"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "خطأ في التثبيت"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "بت"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "كب"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "مب"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "تب"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "قابل للإزالة:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "تحرير"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "تعيين إلى/"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "قسم منطقي"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "قسم موسع"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "غير معروف"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "تحرير القسم"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "تحرير القسم"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "الجهاز:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "تنسيق مثل:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "نقطة التحميل:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "إلغاء"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -416,10 +1129,6 @@ msgstr "كلمات المرور الخاصة بك لا تتطابق."
 msgid "Please provide a password for your user account."
 msgstr "يرجى تقديم كلمة مرور لحساب المستخدم الخاص بك."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -446,7 +1155,7 @@ msgstr "إضافة مستخدم جديد إلى النظام"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "كتابة معلومات نظام الملفات إلى /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "تحميل %(partition)s على %(mountpoint)s"
@@ -466,689 +1175,66 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "تنسيق %(partition)s كـ%(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "إعداد اسم المضيف"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "الإعداد المحلي"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "إعداد اسم المضيف"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "إعداد خيارات لوحة المفاتيح"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "إزالة التكوين المباشر (الحزم)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "تثبيت مُحمل الإقلاع"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "تكوين مُحمل الإقلاع"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 "تحذير: لم يتم تكوين مُحمل الإقلاع grub بشكل صحيح! تحتاج إلى تكوينه يدويا."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "الإنتهاء من التثبيت"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "التحقق من مُحمل الإقلاع"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "الدولة"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "اللغة"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "تخطيط"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "مختلف"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "حساب فهرسة الملفات..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "تخطيط لوحة المفاتيح"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "هل تريد بالتأكيد إنهاء برنامج التثبيت؟"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "التقسيم"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "الملخص"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "عودة"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "تحرير الأقسام"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "الجهاز"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "النوع"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "نظام التشغيل"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "نقطة التحميل"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "تنسيق مثل"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "الحجم"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "مساحة حرة"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "ثبّت"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "كلمات المرور الخاصة بك لا تتطابق."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "إنهاء؟"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "هل تريد بالتأكيد إنهاء برنامج التثبيت؟"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "يرجى اختيار لغة"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "يرجى تقديم كلمة مرور لحساب المستخدم الخاص بك."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "يرجى تقديم اسمك الكامل."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "كلمات المرور الخاصة بك لا تتطابق."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "قسم EFI غير قابل للتمهيد. الرجاء تحرير علامات القسم."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "يرجى تحديد قسم الجذر (/)."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "قسم EFI غير قابل للتمهيد. الرجاء تحرير علامات القسم."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "يجب تهيئة قسم EFI على أنه vfat."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "يجب تهيئة قسم EFI على أنه vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "يرجى اختيار قسم EFI."
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "يرجى تقديم اسم المستخدم."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "التوطين"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "اللغة: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "المنطقة الزمنية: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "تخطيط لوحة المفاتيح: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "إعدادات المستخدم"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "الاسم الحقيقي: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "اسم المستخدم: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "تسجيل دخول تلقائي: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "ممكن"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "معطل"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "إعدادات النظام"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "عمليات نظام الملفات"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "تثبيت مُحمل الإقلاع على %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "عدم تثبيت مُحمل الإقلاع"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "استخدم المحمل بالفعل /target."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "تنسيق %(path)s كـ%(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "تحميل %(path)s كـ%(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"التثبيت اكتمل الان. هل تريد إعادة تشغيل الكمبيوتر لاستخدام النظام الجديد؟"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "خطأ في التثبيت"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "تخطيط لوحة المفاتيح"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "التثبيت متوقف مؤقتاً"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "المنطقة الزمنية"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "بت"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "كب"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "مب"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "تب"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "قابل للإزالة:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "تحرير"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "تعيين إلى/"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "قسم منطقي"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "قسم موسع"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "غير معروف"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "تحرير القسم"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "تحرير القسم"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "الجهاز:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "تنسيق مثل:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "نقطة التحميل:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "إلغاء"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "حسنا"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "ﻻ"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "نعم"
 
 #~ msgid "Quit"
 #~ msgstr "خروج"

--- a/po/live-installer-ast.po
+++ b/po/live-installer-ast.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2014-12-25 23:56+0000\n"
 "Last-Translator: enolp <enolp@softastur.org>\n"
 "Language-Team: Asturian <ast@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Fusu horariu"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,141 +149,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Configuración del sistema"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -310,6 +318,703 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Fusu horariu"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Llingua"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Distribución del tecláu"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Error d'instalación"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Triba"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Distribución"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variante"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Distribución del tecláu"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Resume"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Preséu"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Sistema operativu"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Puntu de montaxe"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Tamañu"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Espaciu llibre"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Llocalización"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Llingua: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Estaya horaria: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Distribución del tecláu: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Configuración del usuariu"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Nome real: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Nome d'usuariu: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Configuración del sistema"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Operaciones del sistema de ficheros"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Nun instalar el cargador d'arranque"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Montando %(partition)s en %(mountpoint)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Instalacion finada"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Error d'instalación"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Configuración del sistema"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -405,10 +1110,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -435,7 +1136,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Montando %(partition)s en %(mountpoint)s"
@@ -455,49 +1156,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Afitando'l nome d'agospiu"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Afitando locale"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Afitando'l nome d'agospiu"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Afitando opciones del tecláu"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Desaniciando la configuración live (paquetes)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Instalando'l cargador d'arranque"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Configurando'l cargador d'arranque"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -505,631 +1206,16 @@ msgstr ""
 "AVISU: ¡El cargador d'arranque grub nun se configuró correutamente! "
 "Necesites configuralu de mou manual."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Instalacion finada"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Comprobando'l cargador d'arranque"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Llingua"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Distribución"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Variante"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Distribución del tecláu"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Resume"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Preséu"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Triba"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Sistema operativu"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Puntu de montaxe"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Tamañu"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Espaciu llibre"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Llocalización"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Llingua: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Estaya horaria: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Distribución del tecláu: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Configuración del usuariu"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Nome real: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Nome d'usuariu: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Configuración del sistema"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Operaciones del sistema de ficheros"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Nun instalar el cargador d'arranque"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Error d'instalación"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Distribución del tecláu"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Error d'instalación"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Fusu horariu"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Configuración del sistema"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-ast.po
+++ b/po/live-installer-ast.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2014-12-25 23:56+0000\n"
 "Last-Translator: enolp <enolp@softastur.org>\n"
 "Language-Team: Asturian <ast@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -292,6 +292,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -322,8 +327,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -412,23 +417,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Distribución"
-
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Variante"
-
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -446,9 +522,103 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Espaciu llibre"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Configuración del sistema"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Distribución"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variante"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -563,18 +733,6 @@ msgstr ""
 msgid "Size"
 msgstr "Tamañu"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Espaciu llibre"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -606,25 +764,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -859,7 +998,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Instalacion finada"
 
@@ -878,139 +1017,6 @@ msgstr "Error d'instalación"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Configuración del sistema"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1156,49 +1162,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Afitando'l nome d'agospiu"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Afitando locale"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Afitando'l nome d'agospiu"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Afitando opciones del tecláu"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Desaniciando la configuración live (paquetes)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Instalando'l cargador d'arranque"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Configurando'l cargador d'arranque"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1206,15 +1212,15 @@ msgstr ""
 "AVISU: ¡El cargador d'arranque grub nun se configuró correutamente! "
 "Necesites configuralu de mou manual."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Comprobando'l cargador d'arranque"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-az.po
+++ b/po/live-installer-az.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2018-08-03 01:05+0000\n"
 "Last-Translator: Arif <mdyos@inbox.ru>\n"
 "Language-Team: Azerbaijani <az@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "QB"
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -292,6 +292,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -321,8 +326,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -411,23 +416,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Ölkə"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Düzülüş"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Redaktə"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -445,9 +521,103 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Boş sahə"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Naməlum"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Sistem tənzimləmələri"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Avadanlıq:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Ölkə"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Düzülüş"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -563,18 +733,6 @@ msgstr ""
 msgid "Size"
 msgstr "Ölçü"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Boş sahə"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -607,25 +765,6 @@ msgstr "Çıxılsınmı?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Quraşdırılmadan çıxmaq istədiyinizdən əminsiniz?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -860,7 +999,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Quraşdırılma sonlandı"
 
@@ -879,139 +1018,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Redaktə"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Naməlum"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Sistem tənzimləmələri"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Avadanlıq:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1166,62 +1172,62 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "%(partition)s 'nu %(format)s kimi biçimlə ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Tinli qurulum (bağlamaları) silinir"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-az.po
+++ b/po/live-installer-az.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2018-08-03 01:05+0000\n"
 "Last-Translator: Arif <mdyos@inbox.ru>\n"
 "Language-Team: Azerbaijani <az@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Saat qurşağı"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "QB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,141 +149,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Yenilə"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Sistem tənzimləmələri"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Avtomatik olaraq daxil ol"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -309,6 +317,705 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Saat qurşağı"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Dil"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Klaviatura düzülüşü"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Quraşdırılma sonlandı"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Növ"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Ölkə"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Düzülüş"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Klaviatura düzülüşü"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Quraşdırılmadan çıxmaq istədiyinizdən əminsiniz?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Avadanlıq"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Əməliyyat sistemi"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Ölçü"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Boş sahə"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Şifrələr eyni deyil."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Çıxılsınmı?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Quraşdırılmadan çıxmaq istədiyinizdən əminsiniz?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Lütfən, bir dil seçin"
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Şifrələr eyni deyil."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Lokallaşma"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Dil: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Saat qurşağı: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Klaviatura düzülüşü: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "İstifadəçi tənzimləmələri"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Əsl adı: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "İstifadəçi adı: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Avtomatik giriş: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Sistem tənzimləmələri"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "%(partition)s 'nu %(mountpoint)s 'a bərkit"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Quraşdırılma sonlandı"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Redaktə"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Naməlum"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Sistem tənzimləmələri"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Avadanlıq:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -413,10 +1120,6 @@ msgstr "Şifrələr eyni deyil."
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -443,7 +1146,7 @@ msgstr "Qurmacaya yeni işlədən artır"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "%(partition)s 'nu %(mountpoint)s 'a bərkit"
@@ -463,680 +1166,63 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "%(partition)s 'nu %(format)s kimi biçimlə ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Tinli qurulum (bağlamaları) silinir"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Quraşdırılma sonlandı"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Ölkə"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Dil"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Düzülüş"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Klaviatura düzülüşü"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Quraşdırılmadan çıxmaq istədiyinizdən əminsiniz?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Avadanlıq"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Növ"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Əməliyyat sistemi"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Ölçü"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Boş sahə"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Şifrələr eyni deyil."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Çıxılsınmı?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Quraşdırılmadan çıxmaq istədiyinizdən əminsiniz?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Lütfən, bir dil seçin"
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Şifrələr eyni deyil."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Lokallaşma"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Dil: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Saat qurşağı: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Klaviatura düzülüşü: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "İstifadəçi tənzimləmələri"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Əsl adı: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "İstifadəçi adı: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Avtomatik giriş: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Sistem tənzimləmələri"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Klaviatura düzülüşü"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Quraşdırılma sonlandı"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Saat qurşağı"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Redaktə"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Naməlum"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Sistem tənzimləmələri"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Avadanlıq:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid ""

--- a/po/live-installer-be.po
+++ b/po/live-installer-be.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2019-12-18 14:38+0000\n"
 "Last-Translator: Alexis Borovik <Unknown>\n"
 "Language-Team: Belarusian <be@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Часавы пояс"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Змяніць партыцыю"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "ГБ"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Рэжым для экспертаў"
@@ -149,142 +151,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Абнавіць"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Фарматаваць як"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Змяніць партыцыі"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Уваходзіць у сістэму аўтаматычна"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -313,6 +321,712 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "Добра"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Не"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Так"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Часавы пояс"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Мова"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Раскладка клавіятуры"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Усталёўванне прыпынена"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Тып"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Краіна"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Раскладка"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Варыянт"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Вылічэнне файлавых індэксаў..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Раскладка клавіятуры"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Вы сапраўды хочаце закрыць усталёўнік?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Падзел на партыцыі"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Сцісла"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Вярнуцца"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Змяніць партыцыі"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Прылада"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Аперацыйная сістэма"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Пункт мантавання"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Фарматаваць як"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Памер"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Свабоднае месца"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Усталяваць"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Вашы паролі не супадаюць."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Выйсці?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Вы сапраўды хочаце закрыць усталёўнік?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Абярыце мову"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Увядзіце пароль на ваш конт."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Увядзіце ваша поўнае імя"
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Вашы паролі не супадаюць."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "EFI-партыцыя - незапускальная. Змяніце сцяжкі партыцыі."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Абярыце партыцыю root (/)."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "EFI-партыцыя - незапускальная. Змяніце сцяжкі партыцыі."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "EFI-партыцыя мае быць фарматаванай як vfat."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "EFI-партыцыя мае быць фарматаванай як vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Абярыце партыцыю EFI."
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Увядзіце імя карыстальніка"
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Лакалізацыя"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Мова: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Часавы пояс: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Раскладка клавіятуры: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Настáўленні карыстальніка"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Сапраўднае імя: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Імя карыстальніка: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Аўтаматычны ўваход "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "уключана"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "адключана"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Сістэмныя настáўленні"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Аперацыі файлавай сістэмы"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Усталяваць загрузчык на %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Не ўсталёўваць стартавальнік"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Фарматаваць %(path)s як %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Мантаваць %(path)s як %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Мантаваць %(path)s як %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Усталяванне скончана"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Усталяванне завершана. Жадаеце перазагрузіць камп'ютар і пачаць карыстацца "
+"новай сістэмай?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Памылка усталявання"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "Б"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "кБ"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "МБ"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "ТБ"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Змяніць"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Прызначыць на /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Лагічная партыцыя"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Пашыраная партыцыя"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Невядома"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Змяніць партыцыю"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Змяніць партыцыю"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Прылада:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Фарматаваць як:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Кропка мантавання:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -421,10 +1135,6 @@ msgstr "Вашы паролі не супадаюць."
 msgid "Please provide a password for your user account."
 msgstr "Увядзіце пароль на ваш конт."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -451,7 +1161,7 @@ msgstr "Даданне новага карыстальніка ў сістэму
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Запісванне схемы мантавання файлавых сістэм у /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Мантаванне %(partition)s да %(mountpoint)s"
@@ -471,49 +1181,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Фарматаванне %(partition)s як %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Настáўленне назвы хоста"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Настáўленне лакалі"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Настáўленне назвы хоста"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Настáўленне клавіятуры"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Выдаленне live-канфігурацыі (пакункі)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Усталёўванне стартавальніка (bootloader)"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Настáўленне стартавальніка"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -521,641 +1231,17 @@ msgstr ""
 "УВАГА: стартавальнік GRUB не быў настаўлены належным чынам! Трэба наставіць "
 "яго ўласнаручна."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Усталяванне скончана"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Праверка стартавальніка"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Краіна"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Мова"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Раскладка"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Варыянт"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Вылічэнне файлавых індэксаў..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Раскладка клавіятуры"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Вы сапраўды хочаце закрыць усталёўнік?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Падзел на партыцыі"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Сцісла"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Вярнуцца"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Змяніць партыцыі"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Прылада"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Тып"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Аперацыйная сістэма"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Пункт мантавання"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Фарматаваць як"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Памер"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Свабоднае месца"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Усталяваць"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Вашы паролі не супадаюць."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Выйсці?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Вы сапраўды хочаце закрыць усталёўнік?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Абярыце мову"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Увядзіце пароль на ваш конт."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Увядзіце ваша поўнае імя"
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Вашы паролі не супадаюць."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "EFI-партыцыя - незапускальная. Змяніце сцяжкі партыцыі."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Абярыце партыцыю root (/)."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "EFI-партыцыя - незапускальная. Змяніце сцяжкі партыцыі."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "EFI-партыцыя мае быць фарматаванай як vfat."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "EFI-партыцыя мае быць фарматаванай як vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Абярыце партыцыю EFI."
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Увядзіце імя карыстальніка"
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Лакалізацыя"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Мова: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Часавы пояс: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Раскладка клавіятуры: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Настáўленні карыстальніка"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Сапраўднае імя: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Імя карыстальніка: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Аўтаматычны ўваход "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "уключана"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "адключана"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Сістэмныя настáўленні"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Аперацыі файлавай сістэмы"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Усталяваць загрузчык на %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Не ўсталёўваць стартавальнік"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Фарматаваць %(path)s як %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Мантаваць %(path)s як %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Усталяванне завершана. Жадаеце перазагрузіць камп'ютар і пачаць карыстацца "
-"новай сістэмай?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Памылка усталявання"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Раскладка клавіятуры"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Усталёўванне прыпынена"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Часавы пояс"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "Б"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "кБ"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "МБ"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "ТБ"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Змяніць"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Прызначыць на /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Лагічная партыцыя"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Пашыраная партыцыя"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Невядома"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Змяніць партыцыю"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Змяніць партыцыю"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Прылада:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Фарматаваць як:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Кропка мантавання:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "Добра"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Не"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Так"
 
 #~ msgid "Quit"
 #~ msgstr "Выйсці"

--- a/po/live-installer-be.po
+++ b/po/live-installer-be.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2019-12-18 14:38+0000\n"
 "Last-Translator: Alexis Borovik <Unknown>\n"
 "Language-Team: Belarusian <be@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "ГБ"
 
@@ -189,9 +189,9 @@ msgid "Format"
 msgstr "Фарматаваць як"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -295,6 +295,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Фарматаваць як"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -325,8 +331,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "Добра"
 
@@ -415,23 +421,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Краіна"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "Б"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Раскладка"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "кБ"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Варыянт"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "МБ"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Вылічэнне файлавых індэксаў..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "ТБ"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Змяніць"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Прызначыць на /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -449,10 +526,104 @@ msgstr "Вылічэнне файлавых індэксаў..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Свабоднае месца"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Лагічная партыцыя"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Пашыраная партыцыя"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Невядома"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Змяніць партыцыю"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Змяніць партыцыю"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Прылада:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Фарматаваць як:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Кропка мантавання:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Краіна"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Раскладка"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Варыянт"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Вылічэнне файлавых індэксаў..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -567,18 +738,6 @@ msgstr "Фарматаваць як"
 msgid "Size"
 msgstr "Памер"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Свабоднае месца"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -611,25 +770,6 @@ msgstr "Выйсці?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Вы сапраўды хочаце закрыць усталёўнік?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -869,7 +1009,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Усталяванне скончана"
 
@@ -890,139 +1030,6 @@ msgstr "Памылка усталявання"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "Б"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "кБ"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "МБ"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "ТБ"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Змяніць"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Прызначыць на /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Лагічная партыцыя"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Пашыраная партыцыя"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Невядома"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Змяніць партыцыю"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Змяніць партыцыю"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Прылада:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Фарматаваць як:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Кропка мантавання:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1181,49 +1188,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Фарматаванне %(partition)s як %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Настáўленне назвы хоста"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Настáўленне лакалі"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Настáўленне назвы хоста"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Настáўленне клавіятуры"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Выдаленне live-канфігурацыі (пакункі)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Усталёўванне стартавальніка (bootloader)"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Настáўленне стартавальніка"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1231,15 +1238,15 @@ msgstr ""
 "УВАГА: стартавальнік GRUB не быў настаўлены належным чынам! Трэба наставіць "
 "яго ўласнаручна."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Праверка стартавальніка"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-bg.po
+++ b/po/live-installer-bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2020-03-11 17:37+0000\n"
 "Last-Translator: spacy01 <Unknown>\n"
 "Language-Team: Bulgarian <bg@li.org>\n"
@@ -24,8 +24,8 @@ msgid "Welcome to the 17g Installer."
 msgstr "Добре дошли в инсталатора на 17G."
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 #, fuzzy
 msgid ""
 "This program will ask you some questions and set up system on your computer."
@@ -33,12 +33,12 @@ msgstr ""
 "Програмата ще ви зададе няколко въпроса и ще инсталира 17G на вашия компютър."
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr "Модел на клавиатурата:"
 
@@ -48,10 +48,12 @@ msgid "Type here to test your keyboard"
 msgstr "Пишете тук, за да тествате клавиатурата"
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -60,13 +62,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Часова зона"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr "Автоматизирана инсталация"
 
@@ -76,12 +78,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr "Изтрий диска и инсталирай 17G на него."
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr "Диск:"
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Редакция на дял"
@@ -92,42 +94,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "ГБ"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr "Използване на LVM (Logical Volume Management)"
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr "Криптиране на операционната система"
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr "Парола"
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr "Потвърдете паролата"
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr "Това добавя допълнителна сигурност, но може да отнеме часове."
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr "Запълване на диска с произволни данни"
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr "Ръчно разделяне"
 
@@ -145,7 +147,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Експертен режим"
@@ -155,144 +157,150 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 #, fuzzy
 msgid "Minimal installation"
 msgstr "Автоматизирана инсталация"
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Опресняване"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Форматиране като"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr "Инсталиране на стартиращото меню GRUB във:"
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Редактиране на дялове"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr "Вашето име:"
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr "Името на вашия компютър:"
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr "Изберете потребителско име:"
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr "Името, което ще се използва при комуникация с други компютри."
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr "Изберете парола:"
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Автоматично влизане в системата"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr "Изискване на парола при влизане"
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr "Криптиране на домашната папка"
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr "Потвърдете парола си:"
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 #, fuzzy
 msgid "Automated installation enabled!"
 msgstr "Автоматизирана инсталация на %s"
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr "Добре дошли"
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -323,6 +331,744 @@ msgstr ""
 #, fuzzy
 msgid "Welcome to 17g"
 msgstr "Добре дошли"
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "ОК"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Не"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Да"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Часова зона"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, fuzzy, python-format
+msgid "Welcome to the %s Installer."
+msgstr "Добре дошли в инсталатора на 17G."
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr "Какъв език искате да използвате?"
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Език"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr "Къде се намирате?"
+
+#: live-installer/frontend/tui_interface.py:57
+#, fuzzy
+msgid "What keyboard would you like to use?"
+msgstr "Какъв език искате да използвате?"
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Модел на клавиатурата:"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Тип инсталация"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Тип"
+
+#: live-installer/frontend/tui_interface.py:80
+#, fuzzy
+msgid "Select a disk?"
+msgstr "Моля изберете диск."
+
+#: live-installer/frontend/tui_interface.py:84
+#, fuzzy
+msgid "Disk"
+msgstr "Диск:"
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, fuzzy, python-format
+msgid "Welcome to %s"
+msgstr "Добре дошли"
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Държава"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Подредба"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Вариант"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Изчисляване на файлови индекси..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr "Инсталатор"
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Клавиатурна подредба"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr "Каква е клавиатурната ви подредба?"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr "Потребителски акаунт"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr "Кой сте Вие?"
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr "Тип инсталация"
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Къде искате да инсталирате 17G?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Определяне ня дялове"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Обобщение"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr "Инсталиране"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+#, fuzzy
+msgid "Automated Install"
+msgstr "Автоматизирана инсталация"
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Назад"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr "Следващ"
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr "Пишете тук, за да тествате клавиатурата"
+
+#: live-installer/frontend/gtk_interface.py:546
+#, fuzzy
+msgid "Erase a disk and install system on it."
+msgstr "Изтрий диска и инсталирай 17G на него."
+
+#: live-installer/frontend/gtk_interface.py:559
+#, fuzzy
+msgid "Manually create, resize or choose partitions for system."
+msgstr "Ръчно създайте, оразмерете и изберете дялове за 17G."
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Редактиране на дялове"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Устройство"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Операционна система"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Точка на монтиране"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Форматиране като"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Размер"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Свободно пространство"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr "Внимание"
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr "Всички данни от %s ще бъдат изтрити. Сигурни ли сте?"
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Инсталирай"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr "Моля напишете криптираща парола"
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Паролата Ви не съвпада."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Изход?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Сигурни ли сте че искате да излезете от инсталатора?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Моля изберете език"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Моля, дайте име на компютъра си."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Моля напишете цялото си име."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Паролата Ви не съвпада."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "EFI дела е твърде малък. Трябва да е поне 35 МБ."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Моля изберете коренов (/) дял."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, fuzzy, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+"Нужен е коренов дял за инсталиране на Линукс Минт.\n"
+"\n"
+" - Точка на монтиране: /\n"
+" - Препоръчителен размер: 30 ГБ\n"
+" - Препоръчителен формат на файловата система: ext4\n"
+"\n"
+"Бележка: За употребата на brtfs снапшот с timeshift се изисква употребата "
+"на:\n"
+" - подустройство с точка на монтиране /@\n"
+" - файлова система с btrfs форматиране\n"
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "EFI дела не е стартиращ. Моля редактирайте флаговете за този дял."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "EFI дела е твърде малък. Трябва да е поне 35 МБ."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "EFI дела трябва да е формат vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Моля изберете EFI дял."
+
+#: live-installer/frontend/gtk_interface.py:1301
+#, fuzzy
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+"Нужен е системен дял EFI, със следните изисквания:\n"
+"\n"
+" - Точка на монтиране: /boot/efi\n"
+" - Флаг на дяла: Bootable\n"
+" - Размер: Поне 35 МБ (Препоръчва се 100 МБ и повече)\n"
+" - Формат: vfat или fat32\n"
+"\n"
+"За да се осигури съвместимост с Windows, препоръчваме употребата на първия "
+"дял на диска като системен дял EFI.\n"
+" "
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr "Моля изберете диск."
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Моля напишете потребителско име."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Локализация"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Език: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Часови пояс: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Клавиатурна подредба: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Потребителски настройки:"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Истинско име: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Потребителско име: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Автоматично влизане: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "включено"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "изключено"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Системни настройки:"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr "Име на компютъра: "
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+#, fuzzy
+msgid "Install updates after installation"
+msgstr "Автоматизирана инсталация"
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Операции с файлови системи"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Инсталиране на инсрумента за стартиране (bootloader) в: %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Да не се инсталира програма за начално инсталиране"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Използвайте вече монтирана /цел."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr "Автоматизирана инсталация на %s"
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Форматиране на %(path)s в %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Монтиране на %(path)s като %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Монтиране на %(path)s като %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr "LVM: "
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr "Криптиране на диска: "
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Инсталирането завърши"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Инсталацията вече е завършена. Искате ли да рестартирате компютъра и да "
+"ползвате новата система?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Грешка при инсталация"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "Б"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "кБ"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "МБ"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "ТБ"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Преносим:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Редакция"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Определяне на /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"Таблицата с дяловете не можа да бъде записана за %s. Рестартирайте компютъра "
+"и опитайте отново."
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"Дял %s не можа да се създаде. Инсталацията ще спре. Рестартирайте компютъра "
+"и опитайте отново."
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Логически дял"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Разширен дял"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Неизвестно"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Редакция на дял"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Редакция на дял"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Устройство:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Форматиране като:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Точка на монтиране:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Отказ"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
+msgstr ""
 
 #: live-installer/validate.py:12
 msgid "Please provide a username."
@@ -432,10 +1178,6 @@ msgstr "Паролата Ви не съвпада."
 msgid "Please provide a password for your user account."
 msgstr "Моля напишете парола за вашия потребителски акаунт."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -462,7 +1204,7 @@ msgstr "Добавяне на нов потребител към система�
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Записване на информацията за монтиране в /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Монтиране на %(partition)s в %(mountpoint)s"
@@ -484,49 +1226,49 @@ msgstr "Създаване на дялове на %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Форматиране на %(partition)s в %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Настройване на системното име"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Настройване на локал"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Настройване на системното име"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Настройване на клавиатурата"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Премахване на Live конфигурацията (пакети)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Инсталиране на програмата за начално стартиране"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Конфигуриране на програмата за начално зареждане"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -534,673 +1276,17 @@ msgstr ""
 "ВНИМАНИЕ: Grub не е конфигуриран правилно! Вие трябва да го конфигурирате "
 "ръчно."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Инсталирането завърши"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Проверка на програмата за начално зареждане"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Държава"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Език"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Подредба"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Вариант"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Изчисляване на файлови индекси..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr "Инсталатор"
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr "Какъв език искате да използвате?"
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr "Къде се намирате?"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Клавиатурна подредба"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr "Каква е клавиатурната ви подредба?"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr "Потребителски акаунт"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr "Кой сте Вие?"
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr "Тип инсталация"
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Къде искате да инсталирате 17G?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Определяне ня дялове"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Обобщение"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr "Инсталиране"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-#, fuzzy
-msgid "Automated install"
-msgstr "Автоматизирана инсталация"
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Назад"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr "Следващ"
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, fuzzy, python-format
-msgid "Welcome to the %s Installer."
-msgstr "Добре дошли в инсталатора на 17G."
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr "Пишете тук, за да тествате клавиатурата"
-
-#: live-installer/frontend/gtk_interface.py:542
-#, fuzzy
-msgid "Erase a disk and install system on it."
-msgstr "Изтрий диска и инсталирай 17G на него."
-
-#: live-installer/frontend/gtk_interface.py:555
-#, fuzzy
-msgid "Manually create, resize or choose partitions for system."
-msgstr "Ръчно създайте, оразмерете и изберете дялове за 17G."
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Редактиране на дялове"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Устройство"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Тип"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Операционна система"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Точка на монтиране"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Форматиране като"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Размер"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Свободно пространство"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Инсталирай"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr "Моля напишете криптираща парола"
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Паролата Ви не съвпада."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Изход?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Сигурни ли сте че искате да излезете от инсталатора?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Моля изберете език"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Моля, дайте име на компютъра си."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Моля напишете цялото си име."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Паролата Ви не съвпада."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "EFI дела е твърде малък. Трябва да е поне 35 МБ."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Моля изберете коренов (/) дял."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, fuzzy, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-"Нужен е коренов дял за инсталиране на Линукс Минт.\n"
-"\n"
-" - Точка на монтиране: /\n"
-" - Препоръчителен размер: 30 ГБ\n"
-" - Препоръчителен формат на файловата система: ext4\n"
-"\n"
-"Бележка: За употребата на brtfs снапшот с timeshift се изисква употребата "
-"на:\n"
-" - подустройство с точка на монтиране /@\n"
-" - файлова система с btrfs форматиране\n"
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "EFI дела не е стартиращ. Моля редактирайте флаговете за този дял."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "EFI дела е твърде малък. Трябва да е поне 35 МБ."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "EFI дела трябва да е формат vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Моля изберете EFI дял."
-
-#: live-installer/frontend/gtk_interface.py:1226
-#, fuzzy
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-"Нужен е системен дял EFI, със следните изисквания:\n"
-"\n"
-" - Точка на монтиране: /boot/efi\n"
-" - Флаг на дяла: Bootable\n"
-" - Размер: Поне 35 МБ (Препоръчва се 100 МБ и повече)\n"
-" - Формат: vfat или fat32\n"
-"\n"
-"За да се осигури съвместимост с Windows, препоръчваме употребата на първия "
-"дял на диска като системен дял EFI.\n"
-" "
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr "Моля изберете диск."
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr "Внимание"
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr "Всички данни от %s ще бъдат изтрити. Сигурни ли сте?"
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Моля напишете потребителско име."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Локализация"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Език: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Часови пояс: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Клавиатурна подредба: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Потребителски настройки:"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Истинско име: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Потребителско име: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Автоматично влизане: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "включено"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "изключено"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Системни настройки:"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr "Име на компютъра: "
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-#, fuzzy
-msgid "Install updates after installation"
-msgstr "Автоматизирана инсталация"
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Операции с файлови системи"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Инсталиране на инсрумента за стартиране (bootloader) в: %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Да не се инсталира програма за начално инсталиране"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Използвайте вече монтирана /цел."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr "Автоматизирана инсталация на %s"
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Форматиране на %(path)s в %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Монтиране на %(path)s като %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr "LVM: "
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr "Криптиране на диска: "
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Инсталацията вече е завършена. Искате ли да рестартирате компютъра и да "
-"ползвате новата система?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Грешка при инсталация"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, fuzzy, python-format
-msgid "Welcome to %s"
-msgstr "Добре дошли"
-
-#: live-installer/frontend/tui_interface.py:57
-#, fuzzy
-msgid "What keyboard would you like to use?"
-msgstr "Какъв език искате да използвате?"
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Модел на клавиатурата:"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Тип инсталация"
-
-#: live-installer/frontend/tui_interface.py:80
-#, fuzzy
-msgid "Select a disk?"
-msgstr "Моля изберете диск."
-
-#: live-installer/frontend/tui_interface.py:84
-#, fuzzy
-msgid "Disk"
-msgstr "Диск:"
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Часова зона"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "Б"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "кБ"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "МБ"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "ТБ"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Преносим:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Редакция"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Определяне на /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"Таблицата с дяловете не можа да бъде записана за %s. Рестартирайте компютъра "
-"и опитайте отново."
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"Дял %s не можа да се създаде. Инсталацията ще спре. Рестартирайте компютъра "
-"и опитайте отново."
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Логически дял"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Разширен дял"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Неизвестно"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Редакция на дял"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Редакция на дял"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Устройство:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Форматиране като:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Точка на монтиране:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Отказ"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "ОК"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Не"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Да"
 
 #~ msgid "Quit"
 #~ msgstr "Изход"

--- a/po/live-installer-bg.po
+++ b/po/live-installer-bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2020-03-11 17:37+0000\n"
 "Last-Translator: spacy01 <Unknown>\n"
 "Language-Team: Bulgarian <bg@li.org>\n"
@@ -94,7 +94,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "ГБ"
 
@@ -196,9 +196,9 @@ msgid "Format"
 msgstr "Форматиране като"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -303,6 +303,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Форматиране като"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -334,8 +340,8 @@ msgstr "Добре дошли"
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "ОК"
 
@@ -427,23 +433,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr "Добре дошли"
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Държава"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "Б"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Подредба"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "кБ"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Вариант"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "МБ"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Изчисляване на файлови индекси..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "ТБ"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Преносим:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Редакция"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Определяне на /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -461,10 +538,108 @@ msgstr "Изчисляване на файлови индекси..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr "Инсталатор"
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Свободно пространство"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"Таблицата с дяловете не можа да бъде записана за %s. Рестартирайте компютъра "
+"и опитайте отново."
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"Дял %s не можа да се създаде. Инсталацията ще спре. Рестартирайте компютъра "
+"и опитайте отново."
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Логически дял"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Разширен дял"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Неизвестно"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Редакция на дял"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Редакция на дял"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Устройство:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Форматиране като:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Точка на монтиране:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Отказ"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Държава"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Подредба"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Вариант"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Изчисляване на файлови индекси..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -582,18 +757,6 @@ msgstr "Форматиране като"
 msgid "Size"
 msgstr "Размер"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Свободно пространство"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -626,25 +789,6 @@ msgstr "Изход?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Сигурни ли сте че искате да излезете от инсталатора?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -906,7 +1050,7 @@ msgid "Disk Encryption: "
 msgstr "Криптиране на диска: "
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Инсталирането завърши"
 
@@ -927,143 +1071,6 @@ msgstr "Грешка при инсталация"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "Б"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "кБ"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "МБ"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "ТБ"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Преносим:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Редакция"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Определяне на /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"Таблицата с дяловете не можа да бъде записана за %s. Рестартирайте компютъра "
-"и опитайте отново."
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"Дял %s не можа да се създаде. Инсталацията ще спре. Рестартирайте компютъра "
-"и опитайте отново."
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Логически дял"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Разширен дял"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Неизвестно"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Редакция на дял"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Редакция на дял"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Устройство:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Форматиране като:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Точка на монтиране:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Отказ"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1226,49 +1233,49 @@ msgstr "Създаване на дялове на %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Форматиране на %(partition)s в %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Настройване на системното име"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Настройване на локал"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Настройване на системното име"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Настройване на клавиатурата"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Премахване на Live конфигурацията (пакети)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Инсталиране на програмата за начално стартиране"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Конфигуриране на програмата за начално зареждане"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1276,15 +1283,15 @@ msgstr ""
 "ВНИМАНИЕ: Grub не е конфигуриран правилно! Вие трябва да го конфигурирате "
 "ръчно."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Проверка на програмата за начално зареждане"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-bn.po
+++ b/po/live-installer-bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2019-05-12 19:42+0000\n"
 "Last-Translator: Arnab <Unknown>\n"
 "Language-Team: Bengali <bn@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -293,6 +293,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -323,8 +328,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -413,23 +418,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "দেশ"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "বিন্যাস"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "ভিন্ন"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "ফাইল ইনডেক্স গণনা করা হচ্ছে"
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -447,10 +523,104 @@ msgstr "ফাইল ইনডেক্স গণনা করা হচ্ছ�
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "ফাঁকা জায়গা"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "পার্টিশন পুনর্বিন্যাস করুন"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "মাউন্ট পয়েন্ট:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "দেশ"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "বিন্যাস"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "ভিন্ন"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "ফাইল ইনডেক্স গণনা করা হচ্ছে"
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -565,18 +735,6 @@ msgstr ""
 msgid "Size"
 msgstr "আকার"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "ফাঁকা জায়গা"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -609,25 +767,6 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "আপনি ইন্সটলার থেকে প্রস্থান করতে চান ?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -864,7 +1003,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "ইন্সটল প্রক্রিয়া সম্পন্ন হয়েছে"
 
@@ -885,139 +1024,6 @@ msgstr "ইন্সটলে সমস্যা হয়েছে"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "পার্টিশন পুনর্বিন্যাস করুন"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "মাউন্ট পয়েন্ট:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1176,49 +1182,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "হোস্টনেম নির্ধারণ করা হচ্ছে"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "অবস্থান নির্ধারিত হচ্ছে"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "হোস্টনেম নির্ধারণ করা হচ্ছে"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "কী-বোর্ড বাছাই করা হচ্ছে"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "লাইভ কনফিগারেশন (প্যাকেজসমূহ) সরিয়ে নেয়া হচ্ছে"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "বুটলোডার ইন্সটল করা হচ্ছে"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "বুটলোডআর কনফিগার করা হচ্ছে"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1226,15 +1232,15 @@ msgstr ""
 "সতর্কবার্তাঃ গ্রুব বুটলোডআরটি সঠিকভাবে কনফিগার করা হয় নি! আপনাকে এটি নিজের থেকে "
 "কনফিগার করতে হবে।"
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "বুটলোডআর পরীক্ষা করা হচ্ছে"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-bn.po
+++ b/po/live-installer-bn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2019-05-12 19:42+0000\n"
 "Last-Translator: Arnab <Unknown>\n"
 "Language-Team: Bengali <bn@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "টাইমজোন"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "পার্টিশন পুনর্বিন্যাস করুন"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -148,141 +150,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "পার্টিশন পুনর্বিন্যাস করুন"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "স্বয়ংক্রিয় লগইন (Log in automatically)"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -311,6 +319,709 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "টাইমজোন"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "ভাষা"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "কীবোর্ড বিন্যাস (Layout)"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "ইন্সটল থেমে আছে"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "প্রকার"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "দেশ"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "বিন্যাস"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "ভিন্ন"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "ফাইল ইনডেক্স গণনা করা হচ্ছে"
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "কীবোর্ড বিন্যাস (Layout)"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "আপনি ইন্সটলার থেকে প্রস্থান করতে চান ?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "পার্টিশন করা"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "পার্টিশন পুনর্বিন্যাস করুন"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "ডিভাইস"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "অপারেটিং সিস্টেম"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "মাউন্ট পয়েন্ট"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "আকার"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "ফাঁকা জায়গা"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "আপনার পাসওয়ার্ড মিলছে না ।"
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "আপনি ইন্সটলার থেকে প্রস্থান করতে চান ?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "ভাষা বাছুন"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "দয়া করে আপনার সম্পূর্ণ নাম দিন ।"
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "দয়া করে আপনার সম্পূর্ণ নাম দিন ।"
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "আপনার পাসওয়ার্ড মিলছে না ।"
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "দয়া করে একটি ব্যাবহারিক নাম দিন ।"
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "স্থানীয়করণ"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "ভাষাঃ "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "টাইমজ়োনঃ "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "কিবোর্ড লেআউটঃ "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "ইউজার সেটিংস"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "আসল নামঃ "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "ইউজারনেমঃ "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "সক্রিয়"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "নিষ্ক্রিয়"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "সিস্টেম সেটিংস"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "ফাইলসিস্টেমের কার্যসমূহ"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "বুটলোডার ইন্সটল না করা"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "%(partition)s পার্টিশনটিকে %(mountpoint)s হিসেবে মাউন্ট করা হচ্ছে..."
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "ইন্সটল প্রক্রিয়া সম্পন্ন হয়েছে"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"ইন্সটল সম্পূর্ণ হয়েছে । আপনি কি নতুন সিস্টেম ব্যাবহার করার জন্য পুনরায় আপনার কম্পিউটার "
+"চালু করতে চান ?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "ইন্সটলে সমস্যা হয়েছে"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "পার্টিশন পুনর্বিন্যাস করুন"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "মাউন্ট পয়েন্ট:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -419,10 +1130,6 @@ msgstr "আপনার পাসওয়ার্ড মিলছে না ।"
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -449,7 +1156,7 @@ msgstr "নতুন ব্যাবহারকারীকে সিস্ট�
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "%(partition)s পার্টিশনটিকে %(mountpoint)s হিসেবে মাউন্ট করা হচ্ছে..."
@@ -469,49 +1176,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "হোস্টনেম নির্ধারণ করা হচ্ছে"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "অবস্থান নির্ধারিত হচ্ছে"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "হোস্টনেম নির্ধারণ করা হচ্ছে"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "কী-বোর্ড বাছাই করা হচ্ছে"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "লাইভ কনফিগারেশন (প্যাকেজসমূহ) সরিয়ে নেয়া হচ্ছে"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "বুটলোডার ইন্সটল করা হচ্ছে"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "বুটলোডআর কনফিগার করা হচ্ছে"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -519,637 +1226,16 @@ msgstr ""
 "সতর্কবার্তাঃ গ্রুব বুটলোডআরটি সঠিকভাবে কনফিগার করা হয় নি! আপনাকে এটি নিজের থেকে "
 "কনফিগার করতে হবে।"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "ইন্সটল প্রক্রিয়া সম্পন্ন হয়েছে"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "বুটলোডআর পরীক্ষা করা হচ্ছে"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "দেশ"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "ভাষা"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "বিন্যাস"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "ভিন্ন"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "ফাইল ইনডেক্স গণনা করা হচ্ছে"
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "কীবোর্ড বিন্যাস (Layout)"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "আপনি ইন্সটলার থেকে প্রস্থান করতে চান ?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "পার্টিশন করা"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "পার্টিশন পুনর্বিন্যাস করুন"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "ডিভাইস"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "প্রকার"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "অপারেটিং সিস্টেম"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "মাউন্ট পয়েন্ট"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "আকার"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "ফাঁকা জায়গা"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "আপনার পাসওয়ার্ড মিলছে না ।"
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "আপনি ইন্সটলার থেকে প্রস্থান করতে চান ?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "ভাষা বাছুন"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "দয়া করে আপনার সম্পূর্ণ নাম দিন ।"
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "দয়া করে আপনার সম্পূর্ণ নাম দিন ।"
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "আপনার পাসওয়ার্ড মিলছে না ।"
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "দয়া করে একটি ব্যাবহারিক নাম দিন ।"
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "স্থানীয়করণ"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "ভাষাঃ "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "টাইমজ়োনঃ "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "কিবোর্ড লেআউটঃ "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "ইউজার সেটিংস"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "আসল নামঃ "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "ইউজারনেমঃ "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "সক্রিয়"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "নিষ্ক্রিয়"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "সিস্টেম সেটিংস"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "ফাইলসিস্টেমের কার্যসমূহ"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "বুটলোডার ইন্সটল না করা"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"ইন্সটল সম্পূর্ণ হয়েছে । আপনি কি নতুন সিস্টেম ব্যাবহার করার জন্য পুনরায় আপনার কম্পিউটার "
-"চালু করতে চান ?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "ইন্সটলে সমস্যা হয়েছে"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "কীবোর্ড বিন্যাস (Layout)"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "ইন্সটল থেমে আছে"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "টাইমজোন"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "পার্টিশন পুনর্বিন্যাস করুন"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "মাউন্ট পয়েন্ট:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-bs.po
+++ b/po/live-installer-bs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2014-07-11 13:59+0000\n"
 "Last-Translator: Almir Zulic <zalmir@yahoo.com>\n"
 "Language-Team: Bosnian <bs@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Vremenska zona"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,141 +149,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Postavke sistema"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -310,6 +318,706 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Vremenska zona"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Jezik"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Raspored tastature"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Greška pri instalaciji"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Vrsta"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Raspored"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Varijanta"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Raspored tastature"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Podjela diska"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Sažetak"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Uređaj"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Operativni sistem"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Tačka učitavanja"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Veličina"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Slobodan prostor"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "EFI particija nije butabilna. Molimo uredite oznake particije."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "EFI particija nije butabilna. Molimo uredite oznake particije."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "EFI particija mora biti formatirana kao vfat."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "EFI particija mora biti formatirana kao vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Lokalizacija"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Jezik: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Vremenska zona: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Raspored tastature: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Korisnička podešavanja"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Pravo ime: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Korisničko ime: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Postavke sistema"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Operacija nad sistemom podataka"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Nemoj instalirati program za podizanje sistema"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Učitavam %(partition)s na %(mountpoint)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Instalacija je završena"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Greška pri instalaciji"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Postavke sistema"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -405,10 +1113,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -435,7 +1139,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Učitavam %(partition)s na %(mountpoint)s"
@@ -455,49 +1159,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Podešavanje imena hosta"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Podešavanje lokalizacije"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Podešavanje imena hosta"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Podešavanje opcija tastature"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Uklanjam live konfiguraciju (pakete)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Instaliram program za podizanje sistema"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Konfigurišem pokretač sistema"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -505,634 +1209,16 @@ msgstr ""
 "UPOZORENJE: GRUB bootloader nije ispravno konfigurisan! Potrebno je da ga "
 "ručno konfigurišete."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Instalacija je završena"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Provjeravam pokretač sistema"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Jezik"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Raspored"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Varijanta"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Raspored tastature"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Podjela diska"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Sažetak"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Uređaj"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Vrsta"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Operativni sistem"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Tačka učitavanja"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Veličina"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Slobodan prostor"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "EFI particija nije butabilna. Molimo uredite oznake particije."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "EFI particija nije butabilna. Molimo uredite oznake particije."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "EFI particija mora biti formatirana kao vfat."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "EFI particija mora biti formatirana kao vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Lokalizacija"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Jezik: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Vremenska zona: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Raspored tastature: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Korisnička podešavanja"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Pravo ime: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Korisničko ime: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Postavke sistema"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Operacija nad sistemom podataka"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Nemoj instalirati program za podizanje sistema"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Greška pri instalaciji"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Raspored tastature"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Greška pri instalaciji"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Vremenska zona"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Postavke sistema"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-bs.po
+++ b/po/live-installer-bs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2014-07-11 13:59+0000\n"
 "Last-Translator: Almir Zulic <zalmir@yahoo.com>\n"
 "Language-Team: Bosnian <bs@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -292,6 +292,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -322,8 +327,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -412,23 +417,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Raspored"
-
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Varijanta"
-
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -446,9 +522,103 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Slobodan prostor"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Postavke sistema"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Raspored"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Varijanta"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -563,18 +733,6 @@ msgstr ""
 msgid "Size"
 msgstr "Veličina"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Slobodan prostor"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -606,25 +764,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -862,7 +1001,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Instalacija je završena"
 
@@ -881,139 +1020,6 @@ msgstr "Greška pri instalaciji"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Postavke sistema"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1159,49 +1165,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Podešavanje imena hosta"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Podešavanje lokalizacije"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Podešavanje imena hosta"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Podešavanje opcija tastature"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Uklanjam live konfiguraciju (pakete)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Instaliram program za podizanje sistema"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Konfigurišem pokretač sistema"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1209,15 +1215,15 @@ msgstr ""
 "UPOZORENJE: GRUB bootloader nije ispravno konfigurisan! Potrebno je da ga "
 "ručno konfigurišete."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Provjeravam pokretač sistema"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-ca.po
+++ b/po/live-installer-ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2020-03-09 21:50+0000\n"
 "Last-Translator: Isidro Pisa <isidro@utils.info>\n"
 "Language-Team: Catalan <ca@li.org>\n"
@@ -24,8 +24,8 @@ msgid "Welcome to the 17g Installer."
 msgstr "Benvingut/da a l'instal·lador de 17G."
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 #, fuzzy
 msgid ""
 "This program will ask you some questions and set up system on your computer."
@@ -34,12 +34,12 @@ msgstr ""
 "equip."
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr "Model de teclat:"
 
@@ -49,10 +49,12 @@ msgid "Type here to test your keyboard"
 msgstr "Escriviu aquí per provar la distribució de el teclat"
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -61,13 +63,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Zona horària"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr "Instal·lació automatitzada"
 
@@ -77,12 +79,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr "Esborrar un disc i instal·lar-hi 17G."
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr "Disc:"
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Edita la partició"
@@ -93,42 +95,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr "Utilitzar LVM (gestió de volum lògic)"
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr "Cifrar el sistema operatiu"
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr "Frase de pas"
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr "Confirmeu la frase de pas"
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr "Proporciona seguretat extra, però pot trigar hores."
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr "Omple el disc amb dades aleatòries"
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr "Particionat manual"
 
@@ -146,7 +148,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Mode expert"
@@ -156,144 +158,150 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 #, fuzzy
 msgid "Minimal installation"
 msgstr "Instal·lació automatitzada"
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Refresca"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Formata com a"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr "Instal·la el menú d'arrencada GRUB a:"
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Edita les particions"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr "El vostre nom:"
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr "El nom del vostre equip:"
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr "Trieu un nom d'usuari:"
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr "El nom de l'equip per comunicar-se amb altres equips."
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr "Trieu una contrasenya:"
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Inicia automàticament la sessió"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr "Demana contrasenya per iniciar sessió"
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr "Encripta la meva carpeta personal"
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr "Confirmeu la contrasenya:"
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 #, fuzzy
 msgid "Automated installation enabled!"
 msgstr "Instalació automatitzada a %s"
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr "Benvingut/da"
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -324,6 +332,741 @@ msgstr ""
 #, fuzzy
 msgid "Welcome to 17g"
 msgstr "Benvingut/da"
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "Accepta"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "No"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Sí"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Zona horària"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, fuzzy, python-format
+msgid "Welcome to the %s Installer."
+msgstr "Benvingut/da a l'instal·lador de 17G."
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr "Quina llengua voleu utilitzar?"
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Llengua"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr "On sou?"
+
+#: live-installer/frontend/tui_interface.py:57
+#, fuzzy
+msgid "What keyboard would you like to use?"
+msgstr "Quina llengua voleu utilitzar?"
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Model de teclat:"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Tipus d'instal·lació"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Tipus"
+
+#: live-installer/frontend/tui_interface.py:80
+#, fuzzy
+msgid "Select a disk?"
+msgstr "Trieu un disc"
+
+#: live-installer/frontend/tui_interface.py:84
+#, fuzzy
+msgid "Disk"
+msgstr "Disc:"
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, fuzzy, python-format
+msgid "Welcome to %s"
+msgstr "Benvingut/da"
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "País"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Disposició"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Càlcul dels índexs dels fitxers..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr "Instal·lador"
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Disposició del teclat"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr "Quina és la distribució del vostre teclat?"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr "Compte d'usuari"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr "Qui sou?"
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr "Tipus d'instal·lació"
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "On voleu instal·lar 17G?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Particionat"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Resum"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr "Instal·lant"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+#, fuzzy
+msgid "Automated Install"
+msgstr "Instal·lació automatitzada"
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Enrere"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr "Següent"
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr "Escriviu aquí per provar la distribució de el teclat"
+
+#: live-installer/frontend/gtk_interface.py:546
+#, fuzzy
+msgid "Erase a disk and install system on it."
+msgstr "Esborrar un disc i instal·lar-hi 17G."
+
+#: live-installer/frontend/gtk_interface.py:559
+#, fuzzy
+msgid "Manually create, resize or choose partitions for system."
+msgstr "Crear, redimensionar o triar particions de 17G manualment."
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Edita les particions"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Dispositiu"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Sistema operatiu"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Punt de muntatge"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Formata com a"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Mida"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Espai lliure"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr "Atenció"
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr "Això eliminarà totes les dades a %s. Esteu segur?"
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Instal·la"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr "Indiqueu una frase de pas per al xifrat."
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Les vostres contrasenyes no coincideixen."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Voleu sortir?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Esteu segur que voleu sortir de l'instal·lador?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Trieu un idioma"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Introduïu un nom per al vostre equip."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Proporcioneu el vostre nom complet."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Les vostres contrasenyes no coincideixen."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "La partició EFI és massa petita. Ha de tenir almenys 35 MB."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Seleccioneu una partició arrel (/)."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, fuzzy, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+"Cal una partició arrel on instal·lar Linux Mint.\n"
+"\n"
+"- Punt de muntatge: /\n"
+"- Mida recomanada: 30 GB\n"
+"- Sistema de fitxers recomanat: ext4\n"
+"\n"
+"Nota: La funció d'instantànies btrfs timeshift requereix l'ús de:\n"
+"- Punt de muntatge de subvolum /@\n"
+"- Sistema de fitxers btrfs\n"
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+"La partició EFI no és d'arrencada. Editeu els indicadors de la partició."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "La partició EFI és massa petita. Ha de tenir almenys 35 MB."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "La partició EFI ha de tenir format vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Seleccioneu una partició EFI."
+
+#: live-installer/frontend/gtk_interface.py:1301
+#, fuzzy
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+"Cal una partició de sistema EFI amb els següents requisits:\n"
+"\n"
+"- Punt de muntatge: /boot/efi\n"
+"- Flags de partició: arrencable\n"
+"- Mida: mínim 35 MB (es recomanen 100 MB o més)\n"
+"- Format: vfat o fat32\n"
+" "
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr "Trieu un disc"
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Proporcioneu un nom d'usuari."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Localització"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Idioma: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Zona horària: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Disposició del teclat: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Ajusts de l'usuari"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Nom real: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Nom d'usuari: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Inici de sessió automàtic: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "activat"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "desactivat"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Ajusts del sistema"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr "Nom de l'equip: "
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+#, fuzzy
+msgid "Install updates after installation"
+msgstr "Instal·lació automatitzada"
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Operacions del sistema de fitxers"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Instal·la el gestor d'arrencada a %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "No instal·lis el gestor d'arrencada"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Utilitza /target ja muntat."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr "Instalació automatitzada a %s"
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Formata %(path)s com a %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Munta %(path)s com a %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Munta %(path)s com a %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr "LVM: "
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr "Xifrat de disc: "
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "S'ha finalitzat la instal·lació"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Ara s'ha completat la instal·lació. Voleu reiniciar el vostre ordinador per "
+"utilitzar el sistema nou?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Error en la instal·lació"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Extraïble:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Edita"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Assigna a /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"No s'ha pogut escriure la taula de partició de %s. Reinicieu l'equip i "
+"torneu-ho a provar."
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"No s'ha pogut crear la partició %s. La instal·lació s'aturarà. Reinicieu "
+"l'equip i torneu-ho a provar."
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Partició lògica"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Partició estesa"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Desconegut"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Edita la partició"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Edita la partició"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Dispositiu:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Formata com:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Punt de muntatge:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Cancel·la"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
+msgstr ""
 
 #: live-installer/validate.py:12
 msgid "Please provide a username."
@@ -433,10 +1176,6 @@ msgstr "Les vostres contrasenyes no coincideixen."
 msgid "Please provide a password for your user account."
 msgstr "Proporcioneu una contrasenya per al vostre compte d'usuari."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -464,7 +1203,7 @@ msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 "Escriptura de la informació del muntatge del sistema de fitxers a /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "S’està muntant «%(partition)s» a %(mountpoint)s…"
@@ -484,49 +1223,49 @@ msgstr "Creant particions a %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "S’està formatant «%(partition)s» com a %(format)s…"
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "S'està establint el nom de l'amfitrió"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "S'està establint la configuració regional"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "S'està establint el nom de l'amfitrió"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "S'estan establint les opcions del teclat"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "S'està suprimint la configuració autònoma (paquets)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "S'està instal·lant el gestor d'arrencada"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "S'està configurant el gestor d'arrencada"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -534,670 +1273,17 @@ msgstr ""
 "Atenció: el gestor d'arrencada GRUB no està configurat correctament! Cal "
 "configurar-lo manualment."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "S'ha finalitzat la instal·lació"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "S'està comprovant el gestor d'arrencada"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "País"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Llengua"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Disposició"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Variant"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Càlcul dels índexs dels fitxers..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr "Instal·lador"
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr "Quina llengua voleu utilitzar?"
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr "On sou?"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Disposició del teclat"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr "Quina és la distribució del vostre teclat?"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr "Compte d'usuari"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr "Qui sou?"
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr "Tipus d'instal·lació"
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "On voleu instal·lar 17G?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Particionat"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Resum"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr "Instal·lant"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-#, fuzzy
-msgid "Automated install"
-msgstr "Instal·lació automatitzada"
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Enrere"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr "Següent"
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, fuzzy, python-format
-msgid "Welcome to the %s Installer."
-msgstr "Benvingut/da a l'instal·lador de 17G."
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr "Escriviu aquí per provar la distribució de el teclat"
-
-#: live-installer/frontend/gtk_interface.py:542
-#, fuzzy
-msgid "Erase a disk and install system on it."
-msgstr "Esborrar un disc i instal·lar-hi 17G."
-
-#: live-installer/frontend/gtk_interface.py:555
-#, fuzzy
-msgid "Manually create, resize or choose partitions for system."
-msgstr "Crear, redimensionar o triar particions de 17G manualment."
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Edita les particions"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Dispositiu"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Tipus"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Sistema operatiu"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Punt de muntatge"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Formata com a"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Mida"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Espai lliure"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Instal·la"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr "Indiqueu una frase de pas per al xifrat."
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Les vostres contrasenyes no coincideixen."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Voleu sortir?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Esteu segur que voleu sortir de l'instal·lador?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Trieu un idioma"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Introduïu un nom per al vostre equip."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Proporcioneu el vostre nom complet."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Les vostres contrasenyes no coincideixen."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "La partició EFI és massa petita. Ha de tenir almenys 35 MB."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Seleccioneu una partició arrel (/)."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, fuzzy, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-"Cal una partició arrel on instal·lar Linux Mint.\n"
-"\n"
-"- Punt de muntatge: /\n"
-"- Mida recomanada: 30 GB\n"
-"- Sistema de fitxers recomanat: ext4\n"
-"\n"
-"Nota: La funció d'instantànies btrfs timeshift requereix l'ús de:\n"
-"- Punt de muntatge de subvolum /@\n"
-"- Sistema de fitxers btrfs\n"
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-"La partició EFI no és d'arrencada. Editeu els indicadors de la partició."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "La partició EFI és massa petita. Ha de tenir almenys 35 MB."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "La partició EFI ha de tenir format vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Seleccioneu una partició EFI."
-
-#: live-installer/frontend/gtk_interface.py:1226
-#, fuzzy
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-"Cal una partició de sistema EFI amb els següents requisits:\n"
-"\n"
-"- Punt de muntatge: /boot/efi\n"
-"- Flags de partició: arrencable\n"
-"- Mida: mínim 35 MB (es recomanen 100 MB o més)\n"
-"- Format: vfat o fat32\n"
-" "
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr "Trieu un disc"
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr "Atenció"
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr "Això eliminarà totes les dades a %s. Esteu segur?"
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Proporcioneu un nom d'usuari."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Localització"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Idioma: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Zona horària: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Disposició del teclat: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Ajusts de l'usuari"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Nom real: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Nom d'usuari: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Inici de sessió automàtic: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "activat"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "desactivat"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Ajusts del sistema"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr "Nom de l'equip: "
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-#, fuzzy
-msgid "Install updates after installation"
-msgstr "Instal·lació automatitzada"
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Operacions del sistema de fitxers"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Instal·la el gestor d'arrencada a %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "No instal·lis el gestor d'arrencada"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Utilitza /target ja muntat."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr "Instalació automatitzada a %s"
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Formata %(path)s com a %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Munta %(path)s com a %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr "LVM: "
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr "Xifrat de disc: "
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Ara s'ha completat la instal·lació. Voleu reiniciar el vostre ordinador per "
-"utilitzar el sistema nou?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Error en la instal·lació"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, fuzzy, python-format
-msgid "Welcome to %s"
-msgstr "Benvingut/da"
-
-#: live-installer/frontend/tui_interface.py:57
-#, fuzzy
-msgid "What keyboard would you like to use?"
-msgstr "Quina llengua voleu utilitzar?"
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Model de teclat:"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Tipus d'instal·lació"
-
-#: live-installer/frontend/tui_interface.py:80
-#, fuzzy
-msgid "Select a disk?"
-msgstr "Trieu un disc"
-
-#: live-installer/frontend/tui_interface.py:84
-#, fuzzy
-msgid "Disk"
-msgstr "Disc:"
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Zona horària"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Extraïble:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Edita"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Assigna a /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"No s'ha pogut escriure la taula de partició de %s. Reinicieu l'equip i "
-"torneu-ho a provar."
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"No s'ha pogut crear la partició %s. La instal·lació s'aturarà. Reinicieu "
-"l'equip i torneu-ho a provar."
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Partició lògica"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Partició estesa"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Desconegut"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Edita la partició"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Edita la partició"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Dispositiu:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Formata com:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Punt de muntatge:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Cancel·la"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "Accepta"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "No"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Sí"
 
 #~ msgid "Quit"
 #~ msgstr "Surt"

--- a/po/live-installer-ca.po
+++ b/po/live-installer-ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2020-03-09 21:50+0000\n"
 "Last-Translator: Isidro Pisa <isidro@utils.info>\n"
 "Language-Team: Catalan <ca@li.org>\n"
@@ -95,7 +95,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -197,9 +197,9 @@ msgid "Format"
 msgstr "Formata com a"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -304,6 +304,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Formata com a"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -335,8 +341,8 @@ msgstr "Benvingut/da"
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "Accepta"
 
@@ -428,23 +434,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr "Benvingut/da"
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "País"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Disposició"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Variant"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Càlcul dels índexs dels fitxers..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Extraïble:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Edita"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Assigna a /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -462,10 +539,108 @@ msgstr "Càlcul dels índexs dels fitxers..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr "Instal·lador"
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Espai lliure"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"No s'ha pogut escriure la taula de partició de %s. Reinicieu l'equip i "
+"torneu-ho a provar."
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"No s'ha pogut crear la partició %s. La instal·lació s'aturarà. Reinicieu "
+"l'equip i torneu-ho a provar."
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Partició lògica"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Partició estesa"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Desconegut"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Edita la partició"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Edita la partició"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Dispositiu:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Formata com:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Punt de muntatge:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Cancel·la"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "País"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Disposició"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Càlcul dels índexs dels fitxers..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -583,18 +758,6 @@ msgstr "Formata com a"
 msgid "Size"
 msgstr "Mida"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Espai lliure"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -627,25 +790,6 @@ msgstr "Voleu sortir?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Esteu segur que voleu sortir de l'instal·lador?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -904,7 +1048,7 @@ msgid "Disk Encryption: "
 msgstr "Xifrat de disc: "
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "S'ha finalitzat la instal·lació"
 
@@ -925,143 +1069,6 @@ msgstr "Error en la instal·lació"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Extraïble:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Edita"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Assigna a /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"No s'ha pogut escriure la taula de partició de %s. Reinicieu l'equip i "
-"torneu-ho a provar."
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"No s'ha pogut crear la partició %s. La instal·lació s'aturarà. Reinicieu "
-"l'equip i torneu-ho a provar."
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Partició lògica"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Partició estesa"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Desconegut"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Edita la partició"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Edita la partició"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Dispositiu:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Formata com:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Punt de muntatge:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Cancel·la"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1223,49 +1230,49 @@ msgstr "Creant particions a %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "S’està formatant «%(partition)s» com a %(format)s…"
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "S'està establint el nom de l'amfitrió"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "S'està establint la configuració regional"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "S'està establint el nom de l'amfitrió"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "S'estan establint les opcions del teclat"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "S'està suprimint la configuració autònoma (paquets)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "S'està instal·lant el gestor d'arrencada"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "S'està configurant el gestor d'arrencada"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1273,15 +1280,15 @@ msgstr ""
 "Atenció: el gestor d'arrencada GRUB no està configurat correctament! Cal "
 "configurar-lo manualment."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "S'està comprovant el gestor d'arrencada"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-ca@valencia.po
+++ b/po/live-installer-ca@valencia.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2019-02-15 19:42+0000\n"
 "Last-Translator: Juan Hidalgo-Saavedra <Unknown>\n"
 "Language-Team: Catalan (Valencian) <ca@valencia@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -292,6 +292,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -322,8 +327,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -412,23 +417,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "País"
-
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Disposició"
-
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -446,9 +522,102 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "País"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Disposició"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -563,18 +732,6 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -606,25 +763,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -859,7 +997,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "S'ha finalitzat la instal·lació"
 
@@ -878,138 +1016,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1156,49 +1162,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "S’està formatant «%(partition)s» com a %(format)s…"
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "S'està establint el hostname"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "S'està establint la configuració regional"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "S'està establint el hostname"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "S'estan establint les opcions del teclat"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "S'està suprimint la configuració autònoma (paquets)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "S'està instal·lant el gestor d'arrencada"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "S'està configurant el gestor d'arrencada"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1206,15 +1212,15 @@ msgstr ""
 "Atenció: el gestor d'arrencada GRUB no està configurat correctament! Cal "
 "configurar-lo manualment."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "S'està comprovant el gestor d'arrencada"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-ca@valencia.po
+++ b/po/live-installer-ca@valencia.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2019-02-15 19:42+0000\n"
 "Last-Translator: Juan Hidalgo-Saavedra <Unknown>\n"
 "Language-Team: Catalan (Valencian) <ca@valencia@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Zona horària"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,141 +149,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Particionat"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -310,6 +318,702 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Zona horària"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Llenguatge"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Disposició del teclat"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "S'ha finalitzat la instal·lació"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "País"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Disposició"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Disposició del teclat"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Particionat"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Resum"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Arrere"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "S’està muntant «%(partition)s» a %(mountpoint)s…"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "S'ha finalitzat la instal·lació"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -405,10 +1109,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -436,7 +1136,7 @@ msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 "Escriptura de la informació del muntatge del sistema de fitxers a /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "S’està muntant «%(partition)s» a %(mountpoint)s…"
@@ -456,49 +1156,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "S’està formatant «%(partition)s» com a %(format)s…"
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "S'està establint el hostname"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "S'està establint la configuració regional"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "S'està establint el hostname"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "S'estan establint les opcions del teclat"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "S'està suprimint la configuració autònoma (paquets)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "S'està instal·lant el gestor d'arrencada"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "S'està configurant el gestor d'arrencada"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -506,630 +1206,16 @@ msgstr ""
 "Atenció: el gestor d'arrencada GRUB no està configurat correctament! Cal "
 "configurar-lo manualment."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "S'ha finalitzat la instal·lació"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "S'està comprovant el gestor d'arrencada"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "País"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Llenguatge"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Disposició"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Disposició del teclat"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Particionat"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Resum"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Arrere"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Disposició del teclat"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "S'ha finalitzat la instal·lació"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Zona horària"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #, fuzzy

--- a/po/live-installer-ckb.po
+++ b/po/live-installer-ckb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2014-04-27 14:47+0000\n"
 "Last-Translator: Aras Zagros <Unknown>\n"
 "Language-Team: Kurdish (Sorani) <ckb@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,140 +149,146 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 msgid "Edit Partitions"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -308,6 +316,699 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+msgid "Keyboard Model"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:73
+msgid "Installation type?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "دابەزاندن و سوار کردنی %(partition)s لەسەر %(mountpoint)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -403,10 +1104,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -433,7 +1130,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "دابەزاندن و سوار کردنی %(partition)s لەسەر %(mountpoint)s"
@@ -453,671 +1150,60 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 msgid "Removing extra packages"
 msgstr ""
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr ""
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-msgid "Keyboard Model"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:73
-msgid "Installation type?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""

--- a/po/live-installer-ckb.po
+++ b/po/live-installer-ckb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2014-04-27 14:47+0000\n"
 "Last-Translator: Aras Zagros <Unknown>\n"
 "Language-Team: Kurdish (Sorani) <ckb@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -291,6 +291,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -320,8 +325,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -407,23 +412,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -441,9 +517,102 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -558,18 +727,6 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -601,25 +758,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -854,7 +992,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr ""
 
@@ -873,138 +1011,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1150,60 +1156,60 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 msgid "Removing extra packages"
 msgstr ""
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""

--- a/po/live-installer-cs.po
+++ b/po/live-installer-cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2020-03-10 20:08+0000\n"
 "Last-Translator: Pavel Borecki <Unknown>\n"
 "Language-Team: Czech <cs@li.org>\n"
@@ -24,8 +24,8 @@ msgid "Welcome to the 17g Installer."
 msgstr "Vítejte v instalátoru 17G."
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 #, fuzzy
 msgid ""
 "This program will ask you some questions and set up system on your computer."
@@ -34,12 +34,12 @@ msgstr ""
 "nainstaluje 17G na váš počítač."
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr "Model klávesnice:"
 
@@ -49,10 +49,12 @@ msgid "Type here to test your keyboard"
 msgstr "Vyzkoušejte volbu rozložení klávesnice psaním sem."
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -61,13 +63,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Časové pásmo"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr "Automatizovaná instalace"
 
@@ -77,12 +79,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr "Vymazat disk a nainstalovat na něj 17G."
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr "Disk:"
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Upravit oddíl"
@@ -93,42 +95,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr "Použít LVM (Logical Volume Management)"
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr "Šifrovat operační systém"
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr "Heslová fráze"
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr "Potvrzení zadání heslové fráze"
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr "Toto poskytuje další zabezpečení, ale může trvat hodiny."
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr "Přepsat disk náhodnými daty"
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr "Ruční rozdělení"
 
@@ -146,7 +148,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Režim pro pokročilé uživatele"
@@ -156,144 +158,150 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 #, fuzzy
 msgid "Minimal installation"
 msgstr "Automatizovaná instalace"
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Načíst znovu"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Formátovat jako"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr "Nainstalovat nabídku zavaděče GRUB na:"
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Upravit oddíly"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr "Vaše jméno:"
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr "Název počítače:"
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr "Vyberte uživatelské jméno:"
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr "Název se používá při komunikaci s ostatními počítači."
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr "Zvolte heslo:"
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Přihlašovat se automaticky"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr "Požadovat mé heslo pro přihlášení"
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr "Šifrovat mou domovskou složku"
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr "Potvrďte zadání hesla:"
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 #, fuzzy
 msgid "Automated installation enabled!"
 msgstr "Automatizovaná instalace na %s"
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr "Vítejte"
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -324,6 +332,743 @@ msgstr ""
 #, fuzzy
 msgid "Welcome to 17g"
 msgstr "Vítejte"
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "OK"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Ne"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Ano"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Časové pásmo"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, fuzzy, python-format
+msgid "Welcome to the %s Installer."
+msgstr "Vítejte v instalátoru 17G."
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr "Který jazyk chcete používat?"
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Jazyk"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr "Kde se nacházíte?"
+
+#: live-installer/frontend/tui_interface.py:57
+#, fuzzy
+msgid "What keyboard would you like to use?"
+msgstr "Který jazyk chcete používat?"
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Model klávesnice:"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Typ instalace"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Typ"
+
+#: live-installer/frontend/tui_interface.py:80
+#, fuzzy
+msgid "Select a disk?"
+msgstr "Vyberte disk."
+
+#: live-installer/frontend/tui_interface.py:84
+#, fuzzy
+msgid "Disk"
+msgstr "Disk:"
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, fuzzy, python-format
+msgid "Welcome to %s"
+msgstr "Vítejte"
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Stát"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Rozvržení"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Varianta"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Počítání indexů souborů…"
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr "Instalátor"
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Rozvržení klávesnice"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr "Jaké je rozvržení vámi používané klávesnice"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr "Uživatelský účet"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr "Jak se jmenujete?"
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr "Typ instalace"
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Kam chcete 17G nainstalovat?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Dělení úložiště"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Souhrn"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr "Instaluje se"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+#, fuzzy
+msgid "Automated Install"
+msgstr "Automatizovaná instalace"
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Zpět"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr "Další"
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr "Vyzkoušejte volbu rozložení klávesnice psaním sem."
+
+#: live-installer/frontend/gtk_interface.py:546
+#, fuzzy
+msgid "Erase a disk and install system on it."
+msgstr "Vymazat disk a nainstalovat na něj 17G."
+
+#: live-installer/frontend/gtk_interface.py:559
+#, fuzzy
+msgid "Manually create, resize or choose partitions for system."
+msgstr "Ručně vytvořit, změnit velikost nebo zvolit oddíly pro 17G."
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Upravit oddíly"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Zařízení"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Operační systém"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Přípojný bod"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Formátovat jako"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Velikost"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Volné místo"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr "Varování"
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr "Toto smaže veškerá data na %s. Opravdu to chcete?"
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Nainstalovat"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr "Zadejte heslovou frázi, kterou použít pro šifrování."
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Zadání hesla se neshodují."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Ukončit?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Opravdu chcete instalátor ukončit?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Vyberte jazyk"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Zadejte název pro váš počítač."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Zadejte své celé jméno."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Zadání hesla se neshodují."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "EFI oddíl je příliš malý. Je třeba, aby byl nejméně 35 MB velký."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Zvolte oddíl pro kořen adresářové struktury (/)."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, fuzzy, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+"Je zapotřebí kořenového oddílu, na který Linux MInt nainstalovat.\n"
+"\n"
+" - Přípojný bod: /\n"
+" - Doporučená velikost: 30GB\n"
+" - Doporučený souborový systém: ext4\n"
+"\n"
+"Pozn.: Funkce timeshift btrfs zachyceného stavu vyžaduje použití:\n"
+" - přípojného bodu podsvazku /@\n"
+" - souborového systému btrfs\n"
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "EFI oddíl není zaveditelný. Upravte příznaky tohoto oddílu."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "EFI oddíl je příliš malý. Je třeba, aby byl nejméně 35 MB velký."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "Je třeba, aby EFI oddíl měl souborový systém vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Zvolte EFI oddíl."
+
+#: live-installer/frontend/gtk_interface.py:1301
+#, fuzzy
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+"Je zapotřebí EFI systémového oddílu s následujícími parametry:\n"
+"\n"
+" - Přípojný bod: /boot/efi\n"
+" - Příznaky oddílu: zaveditelný (bootable)\n"
+" - Velikost: přinejmenším 35 MB (100 MB a více doporučeno)\n"
+" - Souborový systém: vfat nebo fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr "Vyberte disk."
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Zadejte své uživatelské jméno."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Lokalizace"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Jazyk: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Časové pásmo: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Rozvržení klávesnice: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Nastavení uživatele"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Jméno a příjmení: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Uživatelské jméno: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Automatické přihlašování: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "zapnuto"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "vypnuto"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Nastavení systému"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr "Název počítače: "
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+#, fuzzy
+msgid "Install updates after installation"
+msgstr "Automatizovaná instalace"
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Vytváření souborového systému"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Nainstalovat zavaděč na %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Neinstalovat zavaděč systému"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Použít už připojený /target"
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr "Automatizovaná instalace na %s"
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Formátování %(path)s jako %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Připojit %(path)s do %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Připojit %(path)s do %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr "LVM: "
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr "Šífrování disku: "
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Instalace dokončena"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Instalace je nyní dokončená. Chcete restartovat počítač a začít používat Váš "
+"nový systém?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Chyba instalace"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Vyjímatelné:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Upravit"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Přiřadit k /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"Na %s se nedaří zapsat tabulku rozdělení oddílů. Restartujte počítač a "
+"zkuste to znovu."
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"Oddíl %s se nedaří vytvořit. Instalace se zastaví. Restartujte počítač a "
+"zkuste to znovu."
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Logický oddíl"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Rozšířený oddíl"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Neznámý"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Upravit oddíl"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Upravit oddíl"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Zařízení:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Formátovat jako:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Přípojný bod:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Storno"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
+msgstr ""
 
 #: live-installer/validate.py:12
 msgid "Please provide a username."
@@ -439,10 +1184,6 @@ msgstr "Zadání hesla se neshodují."
 msgid "Please provide a password for your user account."
 msgstr "Zadejte heslo pro svůj uživatelský účet."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -469,7 +1210,7 @@ msgstr "Přidávání nového uživatele do systému"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Zapisování údajů o připojení souborových systémů do /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Připojuje se %(partition)s do %(mountpoint)s"
@@ -490,721 +1231,66 @@ msgstr "Vytváření oddílů na %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formátování %(partition)s jako %(format)s…"
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Nastavuje se název počítače"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Nastavují se místní a jazyková nastavení"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Nastavuje se název počítače"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Natavují se parametry klávesnice"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Odstraňování nastavení (balíčků) od provozu z instalačního média"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Instalace zavaděče"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Nastavování zavaděče systému"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 "VAROVÁNÍ: Zavaděč Grub nebyl správně nastaven! Je třeba ho nastavit ručně."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Instalace dokončena"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Kontrolování zavaděče systému"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Stát"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Jazyk"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Rozvržení"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Varianta"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Počítání indexů souborů…"
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr "Instalátor"
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr "Který jazyk chcete používat?"
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr "Kde se nacházíte?"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Rozvržení klávesnice"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr "Jaké je rozvržení vámi používané klávesnice"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr "Uživatelský účet"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr "Jak se jmenujete?"
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr "Typ instalace"
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Kam chcete 17G nainstalovat?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Dělení úložiště"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Souhrn"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr "Instaluje se"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-#, fuzzy
-msgid "Automated install"
-msgstr "Automatizovaná instalace"
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Zpět"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr "Další"
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, fuzzy, python-format
-msgid "Welcome to the %s Installer."
-msgstr "Vítejte v instalátoru 17G."
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr "Vyzkoušejte volbu rozložení klávesnice psaním sem."
-
-#: live-installer/frontend/gtk_interface.py:542
-#, fuzzy
-msgid "Erase a disk and install system on it."
-msgstr "Vymazat disk a nainstalovat na něj 17G."
-
-#: live-installer/frontend/gtk_interface.py:555
-#, fuzzy
-msgid "Manually create, resize or choose partitions for system."
-msgstr "Ručně vytvořit, změnit velikost nebo zvolit oddíly pro 17G."
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Upravit oddíly"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Zařízení"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Typ"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Operační systém"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Přípojný bod"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Formátovat jako"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Velikost"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Volné místo"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Nainstalovat"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr "Zadejte heslovou frázi, kterou použít pro šifrování."
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Zadání hesla se neshodují."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Ukončit?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Opravdu chcete instalátor ukončit?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Vyberte jazyk"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Zadejte název pro váš počítač."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Zadejte své celé jméno."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Zadání hesla se neshodují."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "EFI oddíl je příliš malý. Je třeba, aby byl nejméně 35 MB velký."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Zvolte oddíl pro kořen adresářové struktury (/)."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, fuzzy, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-"Je zapotřebí kořenového oddílu, na který Linux MInt nainstalovat.\n"
-"\n"
-" - Přípojný bod: /\n"
-" - Doporučená velikost: 30GB\n"
-" - Doporučený souborový systém: ext4\n"
-"\n"
-"Pozn.: Funkce timeshift btrfs zachyceného stavu vyžaduje použití:\n"
-" - přípojného bodu podsvazku /@\n"
-" - souborového systému btrfs\n"
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "EFI oddíl není zaveditelný. Upravte příznaky tohoto oddílu."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "EFI oddíl je příliš malý. Je třeba, aby byl nejméně 35 MB velký."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "Je třeba, aby EFI oddíl měl souborový systém vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Zvolte EFI oddíl."
-
-#: live-installer/frontend/gtk_interface.py:1226
-#, fuzzy
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-"Je zapotřebí EFI systémového oddílu s následujícími parametry:\n"
-"\n"
-" - Přípojný bod: /boot/efi\n"
-" - Příznaky oddílu: zaveditelný (bootable)\n"
-" - Velikost: přinejmenším 35 MB (100 MB a více doporučeno)\n"
-" - Souborový systém: vfat nebo fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr "Vyberte disk."
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr "Varování"
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr "Toto smaže veškerá data na %s. Opravdu to chcete?"
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Zadejte své uživatelské jméno."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Lokalizace"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Jazyk: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Časové pásmo: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Rozvržení klávesnice: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Nastavení uživatele"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Jméno a příjmení: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Uživatelské jméno: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Automatické přihlašování: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "zapnuto"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "vypnuto"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Nastavení systému"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr "Název počítače: "
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-#, fuzzy
-msgid "Install updates after installation"
-msgstr "Automatizovaná instalace"
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Vytváření souborového systému"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Nainstalovat zavaděč na %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Neinstalovat zavaděč systému"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Použít už připojený /target"
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr "Automatizovaná instalace na %s"
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Formátování %(path)s jako %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Připojit %(path)s do %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr "LVM: "
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr "Šífrování disku: "
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Instalace je nyní dokončená. Chcete restartovat počítač a začít používat Váš "
-"nový systém?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Chyba instalace"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, fuzzy, python-format
-msgid "Welcome to %s"
-msgstr "Vítejte"
-
-#: live-installer/frontend/tui_interface.py:57
-#, fuzzy
-msgid "What keyboard would you like to use?"
-msgstr "Který jazyk chcete používat?"
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Model klávesnice:"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Typ instalace"
-
-#: live-installer/frontend/tui_interface.py:80
-#, fuzzy
-msgid "Select a disk?"
-msgstr "Vyberte disk."
-
-#: live-installer/frontend/tui_interface.py:84
-#, fuzzy
-msgid "Disk"
-msgstr "Disk:"
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Časové pásmo"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Vyjímatelné:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Upravit"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Přiřadit k /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"Na %s se nedaří zapsat tabulku rozdělení oddílů. Restartujte počítač a "
-"zkuste to znovu."
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"Oddíl %s se nedaří vytvořit. Instalace se zastaví. Restartujte počítač a "
-"zkuste to znovu."
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Logický oddíl"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Rozšířený oddíl"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Neznámý"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Upravit oddíl"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Upravit oddíl"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Zařízení:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Formátovat jako:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Přípojný bod:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Storno"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "OK"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Ne"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Ano"
 
 #~ msgid "Quit"
 #~ msgstr "Ukončit"

--- a/po/live-installer-cs.po
+++ b/po/live-installer-cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2020-03-10 20:08+0000\n"
 "Last-Translator: Pavel Borecki <Unknown>\n"
 "Language-Team: Czech <cs@li.org>\n"
@@ -95,7 +95,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -197,9 +197,9 @@ msgid "Format"
 msgstr "Formátovat jako"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -304,6 +304,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Formátovat jako"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -335,8 +341,8 @@ msgstr "Vítejte"
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "OK"
 
@@ -428,23 +434,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr "Vítejte"
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Stát"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Rozvržení"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Varianta"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Počítání indexů souborů…"
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Vyjímatelné:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Upravit"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Přiřadit k /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -462,10 +539,108 @@ msgstr "Počítání indexů souborů…"
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr "Instalátor"
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Volné místo"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"Na %s se nedaří zapsat tabulku rozdělení oddílů. Restartujte počítač a "
+"zkuste to znovu."
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"Oddíl %s se nedaří vytvořit. Instalace se zastaví. Restartujte počítač a "
+"zkuste to znovu."
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Logický oddíl"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Rozšířený oddíl"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Neznámý"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Upravit oddíl"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Upravit oddíl"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Zařízení:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Formátovat jako:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Přípojný bod:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Storno"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Stát"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Rozvržení"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Varianta"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Počítání indexů souborů…"
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -583,18 +758,6 @@ msgstr "Formátovat jako"
 msgid "Size"
 msgstr "Velikost"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Volné místo"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -627,25 +790,6 @@ msgstr "Ukončit?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Opravdu chcete instalátor ukončit?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -906,7 +1050,7 @@ msgid "Disk Encryption: "
 msgstr "Šífrování disku: "
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Instalace dokončena"
 
@@ -927,143 +1071,6 @@ msgstr "Chyba instalace"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Vyjímatelné:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Upravit"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Přiřadit k /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"Na %s se nedaří zapsat tabulku rozdělení oddílů. Restartujte počítač a "
-"zkuste to znovu."
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"Oddíl %s se nedaří vytvořit. Instalace se zastaví. Restartujte počítač a "
-"zkuste to znovu."
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Logický oddíl"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Rozšířený oddíl"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Neznámý"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Upravit oddíl"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Upravit oddíl"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Zařízení:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Formátovat jako:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Přípojný bod:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Storno"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1231,64 +1238,64 @@ msgstr "Vytváření oddílů na %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formátování %(partition)s jako %(format)s…"
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Nastavuje se název počítače"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Nastavují se místní a jazyková nastavení"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Nastavuje se název počítače"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Natavují se parametry klávesnice"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Odstraňování nastavení (balíčků) od provozu z instalačního média"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Instalace zavaděče"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Nastavování zavaděče systému"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 "VAROVÁNÍ: Zavaděč Grub nebyl správně nastaven! Je třeba ho nastavit ručně."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Kontrolování zavaděče systému"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-csb.po
+++ b/po/live-installer-csb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2013-01-17 20:58+0000\n"
 "Last-Translator: Mark Kwidzińsczi <Unknown>\n"
 "Language-Team: Kashubian <csb@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -292,6 +292,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -322,8 +327,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -411,23 +416,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Wëzdrzatk"
-
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Wariant"
-
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -445,9 +521,103 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Wòlny plac"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Systemòwé nastôwë"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Wëzdrzatk"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Wariant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -562,18 +732,6 @@ msgstr ""
 msgid "Size"
 msgstr "Miara"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Wòlny plac"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -605,25 +763,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -858,7 +997,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Instalacëjô zakùńczonô"
 
@@ -877,139 +1016,6 @@ msgstr "Instalacjowô fëla"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Systemòwé nastôwë"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1155,49 +1161,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Nastôw miona kòmpùtra"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Nastôw lokalnych òptacëji"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Nastôw miona kòmpùtra"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Nastôw òptacëji klawiaturë"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Nastôw kònfigùracëji live (paczétë)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Instalacëjô zrëszëniowi programë"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Kònfigùracëjô zrëszeniowi programë"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1205,15 +1211,15 @@ msgstr ""
 "BÔCZËNK: Zrëszeniowô programa GRUB nie je dobrze skòfigùrowónô! Je nót jã "
 "rãczno skòfigùrowac."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Sprôwdzanié zrëszeniowi programë"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-csb.po
+++ b/po/live-installer-csb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2013-01-17 20:58+0000\n"
 "Last-Translator: Mark Kwidzińsczi <Unknown>\n"
 "Language-Team: Kashubian <csb@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,141 +149,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Systemòwé nastôwë"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -310,6 +318,702 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Nastôw klawiaturë: "
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Instalacjowô fëla"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Ôrt"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Wëzdrzatk"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Wariant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Ùrządzenié"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Òperacjowô systema"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Pùnkt mòntowaniô"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Miara"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Wòlny plac"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Lokalizacëjô"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Jãzëk: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Czasowô cona: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Nastôw klawiaturë: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Nastôwë brëkòwnika"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Miono ë nôzwëskò: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Miono brëkòwnika: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Systemòwé nastôwë"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Òperacëje systemë lopków"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Nie instalëje zrëszeniowi programë"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Mòntowanié %(partition)s na %(mountpoint)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Instalacëjô zakùńczonô"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Instalacjowô fëla"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Systemòwé nastôwë"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -405,10 +1109,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -435,7 +1135,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Mòntowanié %(partition)s na %(mountpoint)s"
@@ -455,49 +1155,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Nastôw miona kòmpùtra"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Nastôw lokalnych òptacëji"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Nastôw miona kòmpùtra"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Nastôw òptacëji klawiaturë"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Nastôw kònfigùracëji live (paczétë)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Instalacëjô zrëszëniowi programë"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Kònfigùracëjô zrëszeniowi programë"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -505,630 +1205,16 @@ msgstr ""
 "BÔCZËNK: Zrëszeniowô programa GRUB nie je dobrze skòfigùrowónô! Je nót jã "
 "rãczno skòfigùrowac."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Instalacëjô zakùńczonô"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Sprôwdzanié zrëszeniowi programë"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Wëzdrzatk"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Wariant"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Ùrządzenié"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Ôrt"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Òperacjowô systema"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Pùnkt mòntowaniô"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Miara"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Wòlny plac"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Lokalizacëjô"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Jãzëk: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Czasowô cona: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Nastôw klawiaturë: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Nastôwë brëkòwnika"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Miono ë nôzwëskò: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Miono brëkòwnika: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Systemòwé nastôwë"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Òperacëje systemë lopków"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Nie instalëje zrëszeniowi programë"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Instalacjowô fëla"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Nastôw klawiaturë: "
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Instalacjowô fëla"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Systemòwé nastôwë"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-cv.po
+++ b/po/live-installer-cv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2010-08-09 08:14+0000\n"
 "Last-Translator: Metri <Unknown>\n"
 "Language-Team: Chuvash <cv@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -291,6 +291,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -320,8 +325,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -407,23 +412,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -441,9 +517,102 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -558,18 +727,6 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -601,25 +758,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -854,7 +992,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr ""
 
@@ -873,138 +1011,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1150,60 +1156,60 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 msgid "Removing extra packages"
 msgstr ""
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""

--- a/po/live-installer-cv.po
+++ b/po/live-installer-cv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2010-08-09 08:14+0000\n"
 "Last-Translator: Metri <Unknown>\n"
 "Language-Team: Chuvash <cv@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,140 +149,146 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 msgid "Edit Partitions"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -308,6 +316,699 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+msgid "Keyboard Model"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:73
+msgid "Installation type?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -403,10 +1104,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -433,7 +1130,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr ""
@@ -453,671 +1150,60 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 msgid "Removing extra packages"
 msgstr ""
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr ""
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-msgid "Keyboard Model"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:73
-msgid "Installation type?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""

--- a/po/live-installer-cy.po
+++ b/po/live-installer-cy.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2020-02-05 11:33+0000\n"
 "Last-Translator: Rhoslyn Prys <Unknown>\n"
 "Language-Team: Welsh <cy@li.org>\n"
@@ -94,7 +94,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -194,9 +194,9 @@ msgid "Format"
 msgstr "Fformatio fel"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -300,6 +300,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Fformatio fel"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -331,8 +337,8 @@ msgstr "Croeso"
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "Iawn"
 
@@ -422,23 +428,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr "Croeso"
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Gwlad"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Cynllun"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Amrywiolyn"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Cyfrifo maint y mynegeion ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ":Tynadwy"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Golygu"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Neulltuo i /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -456,10 +533,104 @@ msgstr "Cyfrifo maint y mynegeion ..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr "Gosodwr"
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Lle rhydd"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Rhaniad rhesymegol"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Rhaniad estynedig"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Anhysbys"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Golygu rhaniad"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Golygu rhaniad"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Dyfais:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Fformatio fel:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Pwynt arosod:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Diddymu"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Gwlad"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Cynllun"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Amrywiolyn"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Cyfrifo maint y mynegeion ..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -574,18 +745,6 @@ msgstr "Fformatio fel"
 msgid "Size"
 msgstr "Maint"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Lle rhydd"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -618,25 +777,6 @@ msgstr "Gadael?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Ydych chi'n siŵr eich bod am adael y gosodwr?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -896,7 +1036,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Wedi gorffen gosod"
 
@@ -917,139 +1057,6 @@ msgstr "Gawll gosod"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ":Tynadwy"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Golygu"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Neulltuo i /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Rhaniad rhesymegol"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Rhaniad estynedig"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Anhysbys"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Golygu rhaniad"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Golygu rhaniad"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Dyfais:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Fformatio fel:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Pwynt arosod:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Diddymu"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1208,49 +1215,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Fformatio %(partition)s fel %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Gosod enw gwesteiwr"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Gosod locale"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Gosod enw gwesteiwr"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Gosod dewisiadau bysellfwrdd"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Tynnu'r ffurfweddiad byw (pecynnau)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Gosod llwythwr cychwyn"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Ffurfweddu'r llwythwr cychwyn"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1258,15 +1265,15 @@ msgstr ""
 "RHYBUDD: Nid oedd y llwythwr cychwyn grub wedi ei ffurfweddu'n gywir. Rhaid "
 "ei ffurfweddu â llaw."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Gwirio'r llwythwr cychwyn"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-cy.po
+++ b/po/live-installer-cy.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2020-02-05 11:33+0000\n"
 "Last-Translator: Rhoslyn Prys <Unknown>\n"
 "Language-Team: Welsh <cy@li.org>\n"
@@ -24,8 +24,8 @@ msgid "Welcome to the 17g Installer."
 msgstr "Croeso i'r Gosodwr 17G."
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 #, fuzzy
 msgid ""
 "This program will ask you some questions and set up system on your computer."
@@ -34,12 +34,12 @@ msgstr ""
 "cyfrifiadur."
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr "Model Bysellfwrdd:"
 
@@ -49,10 +49,12 @@ msgid "Type here to test your keyboard"
 msgstr "Teipiwch yma i brofi cynllun eich bysellfwrdd"
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -61,13 +63,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Cylchfa amser"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -76,12 +78,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Golygu rhaniad"
@@ -92,42 +94,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -144,7 +146,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Modd arbenigwr"
@@ -154,142 +156,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Adnewyddu"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Fformatio fel"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr "Gosodwch ddewislen cychwyn GRUB ar:"
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Golygu rhaniadau"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr "Eich enw:"
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr "Enw eich cyfrifiadur:"
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr "Dewiswch enw defnyddiwr:"
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr "Yr enw y mae'n ei ddefnyddio pan mae'n siarad â chyfrifiaduron eraill."
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr "Dewiswch gyfrinair"
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Mewngofnodi'n awtomatig"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr "Gofyn am fy nghyfrinair i fewngofnodi"
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr "Amgryptio fy ffolder cartref"
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr "Cadarnhewch eich cyfrinair:"
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr "Croeso"
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -320,6 +328,733 @@ msgstr ""
 #, fuzzy
 msgid "Welcome to 17g"
 msgstr "Croeso"
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "Iawn"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Na"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Iawn"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Cylchfa amser"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, fuzzy, python-format
+msgid "Welcome to the %s Installer."
+msgstr "Croeso i'r Gosodwr 17G."
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr "Pa iaith hoffech chi ei defnyddio?"
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Iaith"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr "Ble ydych chi?"
+
+#: live-installer/frontend/tui_interface.py:57
+#, fuzzy
+msgid "What keyboard would you like to use?"
+msgstr "Pa iaith hoffech chi ei defnyddio?"
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Model Bysellfwrdd:"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Oedwyd y gosod"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Math"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, fuzzy, python-format
+msgid "Welcome to %s"
+msgstr "Croeso"
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Gwlad"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Cynllun"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Amrywiolyn"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Cyfrifo maint y mynegeion ..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr "Gosodwr"
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Cynllun bysellfwrdd"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr "Beth yw cynllun eich bysellfwrdd?"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr "Cyfrif defnyddiwr"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr "Pwy ydych chi?"
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Ble ydych chi am osod 17G?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Rhannu"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Crynodeb"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr "Wrthi'n gosod"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Nôl"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr "Nesaf"
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr "Teipiwch yma i brofi cynllun eich bysellfwrdd"
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Golygu rhaniadau"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Dyfais"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "System weithredu"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Pwynt arosod"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Fformatio fel"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Maint"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Lle rhydd"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Gosod"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Nid yw eich cyfrineiriau'n cydweddu."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Gadael?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Ydych chi'n siŵr eich bod am adael y gosodwr?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Dewiswch iaith"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Rhowch gyfrinair ar gyfer eich cyfrif defnyddiwr."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Rhowch eich enw'n llawn."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Nid yw eich cyfrineiriau'n cydweddu."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "Mae'r rhaniad EFI yn rhy fach. Rhaid iddo fod o leiaf 35MB."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Dewiswch raniad root (/)"
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, fuzzy, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+"Mae angen rhaniad gwraidd i osod Linux Mint ar.\n"
+"\n"
+" - Pwynt Arosod: /\n"
+" - Maint argymelledig: 30GB\n"
+" - Fformat system ffeiliau a argymhellir: ext4\n"
+"\n"
+"Nodyn: Mae'r nodwedd cipluniau btrfs newid-amser yn gofyn am ddefnyddio:\n"
+" - isgyfrol pwynt Arosod / @\n"
+" - btrfs fel fformat system ffeiliau\n"
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "Nid yw'r rhaniad EFI yn gychwynadwy. Golygwch y baneri rhaniad."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "Mae'r rhaniad EFI yn rhy fach. Rhaid iddo fod o leiaf 35MB."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "Rhaid i'r rhaniad EFI fod wedi ei fformatio fel vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Dewiswch raniad EFI."
+
+#: live-installer/frontend/gtk_interface.py:1301
+#, fuzzy
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+"Mae angen rhaniad system EFI gyda'r gofynion canlynol:\n"
+"\n"
+" - Pwynt arosod: / boot / efi\n"
+" - Baneri rhaniad: Bootable\n"
+" - Maint: o leiaf 35MB (argymhellir 100MB neu fwy)\n"
+" - Fformat: vfat neu fraster32\n"
+"\n"
+"Er mwyn sicrhau cydnawsedd â Windows rydym yn argymell eich bod yn defnyddio "
+"rhaniad cyntaf y ddisg fel rhaniad system EFI.\n"
+" "
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Rhowch eich enw defnyddiwr."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Lleoliadaeth"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Iaith: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Cylchfa amser: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Cynllun bysellfwrdd: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Gosodiadau defnyddiwr"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Enw: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Enw defnyddiwr: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Mewngofnodi awtomatig: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "galluogwyd"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "analluogwyd"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Gosodiadau'r System"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Gweithredoedd system ffeiliau"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Gosod y llwythwr cychwyn ar %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Peidiwch gosod llwythwr cychwyn"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Defnyddio'r /target sydd wedi ei arosod yn barod."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Fformatio %(path)s fel %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Arosod %(path)s fel %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Arosod %(path)s fel %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Wedi gorffen gosod"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Mae'r gosod wedi ei gwblhau. Hoffech chi ailgychwyn eich cyfrifiadur er mwyn "
+"defnyddio'r system newydd?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Gawll gosod"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ":Tynadwy"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Golygu"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Neulltuo i /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Rhaniad rhesymegol"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Rhaniad estynedig"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Anhysbys"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Golygu rhaniad"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Golygu rhaniad"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Dyfais:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Fformatio fel:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Pwynt arosod:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Diddymu"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
+msgstr ""
 
 #: live-installer/validate.py:12
 msgid "Please provide a username."
@@ -427,10 +1162,6 @@ msgstr "Nid yw eich cyfrineiriau'n cydweddu."
 msgid "Please provide a password for your user account."
 msgstr "Rhowch gyfrinair ar gyfer eich cyfrif defnyddiwr."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -457,7 +1188,7 @@ msgstr "Ychwanegu defnyddiwr newydd i'r system"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Wrthi'n ysgrifennu manylion arosod y system ffeil i /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Arosod %(partition)s ar %(mountpoint)s"
@@ -477,49 +1208,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Fformatio %(partition)s fel %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Gosod enw gwesteiwr"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Gosod locale"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Gosod enw gwesteiwr"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Gosod dewisiadau bysellfwrdd"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Tynnu'r ffurfweddiad byw (pecynnau)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Gosod llwythwr cychwyn"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Ffurfweddu'r llwythwr cychwyn"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -527,662 +1258,17 @@ msgstr ""
 "RHYBUDD: Nid oedd y llwythwr cychwyn grub wedi ei ffurfweddu'n gywir. Rhaid "
 "ei ffurfweddu â llaw."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Wedi gorffen gosod"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Gwirio'r llwythwr cychwyn"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Gwlad"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Iaith"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Cynllun"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Amrywiolyn"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Cyfrifo maint y mynegeion ..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr "Gosodwr"
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr "Pa iaith hoffech chi ei defnyddio?"
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr "Ble ydych chi?"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Cynllun bysellfwrdd"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr "Beth yw cynllun eich bysellfwrdd?"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr "Cyfrif defnyddiwr"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr "Pwy ydych chi?"
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Ble ydych chi am osod 17G?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Rhannu"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Crynodeb"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr "Wrthi'n gosod"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Nôl"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr "Nesaf"
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, fuzzy, python-format
-msgid "Welcome to the %s Installer."
-msgstr "Croeso i'r Gosodwr 17G."
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr "Teipiwch yma i brofi cynllun eich bysellfwrdd"
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Golygu rhaniadau"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Dyfais"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Math"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "System weithredu"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Pwynt arosod"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Fformatio fel"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Maint"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Lle rhydd"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Gosod"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Nid yw eich cyfrineiriau'n cydweddu."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Gadael?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Ydych chi'n siŵr eich bod am adael y gosodwr?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Dewiswch iaith"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Rhowch gyfrinair ar gyfer eich cyfrif defnyddiwr."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Rhowch eich enw'n llawn."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Nid yw eich cyfrineiriau'n cydweddu."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "Mae'r rhaniad EFI yn rhy fach. Rhaid iddo fod o leiaf 35MB."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Dewiswch raniad root (/)"
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, fuzzy, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-"Mae angen rhaniad gwraidd i osod Linux Mint ar.\n"
-"\n"
-" - Pwynt Arosod: /\n"
-" - Maint argymelledig: 30GB\n"
-" - Fformat system ffeiliau a argymhellir: ext4\n"
-"\n"
-"Nodyn: Mae'r nodwedd cipluniau btrfs newid-amser yn gofyn am ddefnyddio:\n"
-" - isgyfrol pwynt Arosod / @\n"
-" - btrfs fel fformat system ffeiliau\n"
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "Nid yw'r rhaniad EFI yn gychwynadwy. Golygwch y baneri rhaniad."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "Mae'r rhaniad EFI yn rhy fach. Rhaid iddo fod o leiaf 35MB."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "Rhaid i'r rhaniad EFI fod wedi ei fformatio fel vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Dewiswch raniad EFI."
-
-#: live-installer/frontend/gtk_interface.py:1226
-#, fuzzy
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-"Mae angen rhaniad system EFI gyda'r gofynion canlynol:\n"
-"\n"
-" - Pwynt arosod: / boot / efi\n"
-" - Baneri rhaniad: Bootable\n"
-" - Maint: o leiaf 35MB (argymhellir 100MB neu fwy)\n"
-" - Fformat: vfat neu fraster32\n"
-"\n"
-"Er mwyn sicrhau cydnawsedd â Windows rydym yn argymell eich bod yn defnyddio "
-"rhaniad cyntaf y ddisg fel rhaniad system EFI.\n"
-" "
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Rhowch eich enw defnyddiwr."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Lleoliadaeth"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Iaith: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Cylchfa amser: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Cynllun bysellfwrdd: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Gosodiadau defnyddiwr"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Enw: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Enw defnyddiwr: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Mewngofnodi awtomatig: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "galluogwyd"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "analluogwyd"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Gosodiadau'r System"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Gweithredoedd system ffeiliau"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Gosod y llwythwr cychwyn ar %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Peidiwch gosod llwythwr cychwyn"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Defnyddio'r /target sydd wedi ei arosod yn barod."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Fformatio %(path)s fel %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Arosod %(path)s fel %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Mae'r gosod wedi ei gwblhau. Hoffech chi ailgychwyn eich cyfrifiadur er mwyn "
-"defnyddio'r system newydd?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Gawll gosod"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, fuzzy, python-format
-msgid "Welcome to %s"
-msgstr "Croeso"
-
-#: live-installer/frontend/tui_interface.py:57
-#, fuzzy
-msgid "What keyboard would you like to use?"
-msgstr "Pa iaith hoffech chi ei defnyddio?"
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Model Bysellfwrdd:"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Oedwyd y gosod"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Cylchfa amser"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ":Tynadwy"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Golygu"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Neulltuo i /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Rhaniad rhesymegol"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Rhaniad estynedig"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Anhysbys"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Golygu rhaniad"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Golygu rhaniad"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Dyfais:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Fformatio fel:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Pwynt arosod:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Diddymu"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "Iawn"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Na"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Iawn"
 
 #~ msgid "Quit"
 #~ msgstr "Gadael"

--- a/po/live-installer-da.po
+++ b/po/live-installer-da.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2020-03-10 18:08+0000\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: Danish <da@li.org>\n"
@@ -95,7 +95,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -198,9 +198,9 @@ msgid "Format"
 msgstr "Formatér som"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -305,6 +305,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Formatér som"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -336,8 +342,8 @@ msgstr "Velkommen"
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "OK"
 
@@ -429,23 +435,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr "Velkommen"
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Land"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Udseende"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Variant"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Beregner filindekser …"
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Flytbar:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Redigér"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Tildel til /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -463,10 +540,108 @@ msgstr "Beregner filindekser …"
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr "Installationsprogram"
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Ledig plads"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"Partitionstabellen for %s kunne ikke skrives. Genstart computeren og prøv "
+"igen."
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"Partitionen %s kunne ikke oprettes. Installationen vil stoppe. Genstart "
+"computeren og prøv igen."
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Logisk partition"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Udvidet partition"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Ukendt"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Redigér partition"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Redigér partition"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Enhed:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Formatér som:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Monteringspunkt:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Annullér"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Land"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Udseende"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Beregner filindekser …"
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -585,18 +760,6 @@ msgstr "Formatér som"
 msgid "Size"
 msgstr "Størrelse"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Ledig plads"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -629,25 +792,6 @@ msgstr "Afslut?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Er du sikker på, du vil afslutte installationsprogrammet?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -909,7 +1053,7 @@ msgid "Disk Encryption: "
 msgstr "Diskkryptering: "
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Installationen er fuldført"
 
@@ -930,143 +1074,6 @@ msgstr "Installationsfejl"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Flytbar:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Redigér"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Tildel til /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"Partitionstabellen for %s kunne ikke skrives. Genstart computeren og prøv "
-"igen."
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"Partitionen %s kunne ikke oprettes. Installationen vil stoppe. Genstart "
-"computeren og prøv igen."
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Logisk partition"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Udvidet partition"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Ukendt"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Redigér partition"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Redigér partition"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Enhed:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Formatér som:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Monteringspunkt:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Annullér"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1229,49 +1236,49 @@ msgstr "Opretter partitioner på %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formaterer %(partition)s som %(format)s …"
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Sætter værtsnavn op"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Sætter regionsinformation op"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Sætter værtsnavn op"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Sætter tastaturindstillinger op"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Fjerner live-opsætningen (pakker)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Installerer opstartsindlæser"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Konfigurerer opstartsindlæseren"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1279,15 +1286,15 @@ msgstr ""
 "ADVARSEL: Grub-opstartsindlæseren blev ikke konfigureret ordentligt! Du er "
 "nødt til at foretage konfigurationen manuelt."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Tjekker opstartsindlæseren"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-da.po
+++ b/po/live-installer-da.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2020-03-10 18:08+0000\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: Danish <da@li.org>\n"
@@ -24,8 +24,8 @@ msgid "Welcome to the 17g Installer."
 msgstr "Velkommen til installationsprogrammet til 17G."
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 #, fuzzy
 msgid ""
 "This program will ask you some questions and set up system on your computer."
@@ -34,12 +34,12 @@ msgstr ""
 "computer."
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr "Tastaturmodel:"
 
@@ -49,10 +49,12 @@ msgid "Type here to test your keyboard"
 msgstr "Skriv her for at teste dit tastaturlayout"
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -61,13 +63,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Tidszone"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr "Automatiseret installation"
 
@@ -77,12 +79,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr "Slet en disk og installér 17G derpå."
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr "Disk:"
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Redigér partition"
@@ -93,42 +95,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr "Anvend LVM (Logical Volume Management)"
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr "Kryptér styresystemet"
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr "Adgangskode"
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr "Bekræft adgangskode"
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr "Det giver ekstra sikkerhed, men kan tage flere timer."
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr "Fyld disken med tilfældige data"
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr "Manuel partitionering"
 
@@ -147,7 +149,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Eksperttilstand"
@@ -157,144 +159,150 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 #, fuzzy
 msgid "Minimal installation"
 msgstr "Automatiseret installation"
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Opdatér"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Formatér som"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr "Installér GRUB-bootmenuen på:"
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Redigér partitioner"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr "Dit navn:"
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr "Navnet på din computer:"
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr "Vælg et brugernavn:"
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr "Navnet som bruges ved kommunikation med andre computere."
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr "Vælg en adgangskode:"
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Log på automatisk"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr "Kræv min adgangskode for at logge ind"
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr "Kryptér min Hjem-mappe"
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr "Bekræft din adgangskode:"
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 #, fuzzy
 msgid "Automated installation enabled!"
 msgstr "Automatiseret installation på %s"
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr "Velkommen"
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -325,6 +333,745 @@ msgstr ""
 #, fuzzy
 msgid "Welcome to 17g"
 msgstr "Velkommen"
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "OK"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Nej"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Ja"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Tidszone"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, fuzzy, python-format
+msgid "Welcome to the %s Installer."
+msgstr "Velkommen til installationsprogrammet til 17G."
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr "Hvilket sprog ønsker du at bruge?"
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Sprog"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr "Hvor befinder du dig?"
+
+#: live-installer/frontend/tui_interface.py:57
+#, fuzzy
+msgid "What keyboard would you like to use?"
+msgstr "Hvilket sprog ønsker du at bruge?"
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Tastaturmodel:"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Installationstype"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Type"
+
+#: live-installer/frontend/tui_interface.py:80
+#, fuzzy
+msgid "Select a disk?"
+msgstr "Vælg en disk."
+
+#: live-installer/frontend/tui_interface.py:84
+#, fuzzy
+msgid "Disk"
+msgstr "Disk:"
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, fuzzy, python-format
+msgid "Welcome to %s"
+msgstr "Velkommen"
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Land"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Udseende"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Beregner filindekser …"
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr "Installationsprogram"
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Tastaturlayout"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr "Hvad er dit tastaturlayout?"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr "Brugerkonto"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr "Hvem er du?"
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr "Installationstype"
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Hvor vil du installere 17G?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Partitionering"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Oversigt"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr "Installerer"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+#, fuzzy
+msgid "Automated Install"
+msgstr "Automatiseret installation"
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Tilbage"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr "Næste"
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr "Skriv her for at teste dit tastaturlayout"
+
+#: live-installer/frontend/gtk_interface.py:546
+#, fuzzy
+msgid "Erase a disk and install system on it."
+msgstr "Slet en disk og installér 17G derpå."
+
+#: live-installer/frontend/gtk_interface.py:559
+#, fuzzy
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+"Manuel oprettelse, størrelsesændring eller valg af partitioner til 17G."
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Redigér partitioner"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Enhed"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Styresystem"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Monteringspunkt"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Formatér som"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Størrelse"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Ledig plads"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr "Advarsel"
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr "Al data på %s vil blive slettet. Er du sikker?"
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Installér"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr "Angiv en adgangskode til kryptering."
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Dine adgangskoder er ikke ens."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Afslut?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Er du sikker på, du vil afslutte installationsprogrammet?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Vælg venligst et sprog"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Angiv et navn for din computer."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Indtast venligst dit fulde navn."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Dine adgangskoder er ikke ens."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "EFI-partitionen er for lille. Den skal mindst være 35 MB."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Vælg venligst en rodpartition (/)."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, fuzzy, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+"En rodpartition er nødvendig til installationen af Linux Mint.\n"
+"\n"
+" - Monteringspunkt: /\n"
+" - Anbefalet størrelse: 30 GB\n"
+" - Anbefalet format til filsystemet: ext4\n"
+"\n"
+"Bemærk: timeshifts funktion til øjebliksbilleder af btrfs kræver følgende:\n"
+" - underdiskenheds monteringspunkt /@\n"
+" - btrfs  som filsystemformat\n"
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+"Der kan ikke bootes fra EFI-partitionen. Redigér venligst partitionsflagene."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "EFI-partitionen er for lille. Den skal mindst være 35 MB."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "EFI-partitionen skal formateres som vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Vælg venligst en EFI-partition."
+
+#: live-installer/frontend/gtk_interface.py:1301
+#, fuzzy
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+"En EFI-systempartition med de følgende krav er nødvendig:\n"
+"\n"
+" - Monteringspunkt: /boot/efi\n"
+" - Partitionsflag: Bootable\n"
+" - Størrelse: mindst 35 MB (100 MB eller mere anbefales)\n"
+" - Format: vfat eller fat32\n"
+"\n"
+"For at sikre kompatibilitet med Windows anbefaler vi, at du bruger diskens "
+"første partition som EFI-systempartition.\n"
+" "
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr "Vælg en disk."
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Angiv venligst et brugernavn."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Lokalisering"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Sprog: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Tidszone: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Tastaturlayout: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Brugerindstillinger"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Rigtige navn: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Brugernavn: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Automatisk login: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "aktiveret"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "deaktiveret"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Systemindstillinger"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr "Computerens navn: "
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+#, fuzzy
+msgid "Install updates after installation"
+msgstr "Automatiseret installation"
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Filsystemhandlinger"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Installér opstartsindlæser på %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Installér ikke opstartsindlæser"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Anvend det allerede monterede /mål."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr "Automatiseret installation på %s"
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Formatér %(path)s som %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Montér %(path)s som %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Montér %(path)s som %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr "LVM: "
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr "Diskkryptering: "
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Installationen er fuldført"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Installationen er nu færdig. Vil du genstarte din computer og tage det nye "
+"system i brug?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Installationsfejl"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Flytbar:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Redigér"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Tildel til /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"Partitionstabellen for %s kunne ikke skrives. Genstart computeren og prøv "
+"igen."
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"Partitionen %s kunne ikke oprettes. Installationen vil stoppe. Genstart "
+"computeren og prøv igen."
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Logisk partition"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Udvidet partition"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Ukendt"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Redigér partition"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Redigér partition"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Enhed:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Formatér som:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Monteringspunkt:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Annullér"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
+msgstr ""
 
 #: live-installer/validate.py:12
 msgid "Please provide a username."
@@ -434,10 +1181,6 @@ msgstr "Dine adgangskoder er ikke ens."
 msgid "Please provide a password for your user account."
 msgstr "Angiv venligst en adgangskode for din brugerkonto."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -464,7 +1207,7 @@ msgstr "Tilføjer ny bruger til systemet"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Skriver information om filsystemets montering i /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Monterer %(partition)s på %(mountpoint)s"
@@ -486,49 +1229,49 @@ msgstr "Opretter partitioner på %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formaterer %(partition)s som %(format)s …"
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Sætter værtsnavn op"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Sætter regionsinformation op"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Sætter værtsnavn op"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Sætter tastaturindstillinger op"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Fjerner live-opsætningen (pakker)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Installerer opstartsindlæser"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Konfigurerer opstartsindlæseren"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -536,674 +1279,17 @@ msgstr ""
 "ADVARSEL: Grub-opstartsindlæseren blev ikke konfigureret ordentligt! Du er "
 "nødt til at foretage konfigurationen manuelt."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Installationen er fuldført"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Tjekker opstartsindlæseren"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Land"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Sprog"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Udseende"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Variant"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Beregner filindekser …"
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr "Installationsprogram"
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr "Hvilket sprog ønsker du at bruge?"
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr "Hvor befinder du dig?"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Tastaturlayout"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr "Hvad er dit tastaturlayout?"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr "Brugerkonto"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr "Hvem er du?"
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr "Installationstype"
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Hvor vil du installere 17G?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Partitionering"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Oversigt"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr "Installerer"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-#, fuzzy
-msgid "Automated install"
-msgstr "Automatiseret installation"
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Tilbage"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr "Næste"
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, fuzzy, python-format
-msgid "Welcome to the %s Installer."
-msgstr "Velkommen til installationsprogrammet til 17G."
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr "Skriv her for at teste dit tastaturlayout"
-
-#: live-installer/frontend/gtk_interface.py:542
-#, fuzzy
-msgid "Erase a disk and install system on it."
-msgstr "Slet en disk og installér 17G derpå."
-
-#: live-installer/frontend/gtk_interface.py:555
-#, fuzzy
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-"Manuel oprettelse, størrelsesændring eller valg af partitioner til 17G."
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Redigér partitioner"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Enhed"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Type"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Styresystem"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Monteringspunkt"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Formatér som"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Størrelse"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Ledig plads"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Installér"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr "Angiv en adgangskode til kryptering."
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Dine adgangskoder er ikke ens."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Afslut?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Er du sikker på, du vil afslutte installationsprogrammet?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Vælg venligst et sprog"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Angiv et navn for din computer."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Indtast venligst dit fulde navn."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Dine adgangskoder er ikke ens."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "EFI-partitionen er for lille. Den skal mindst være 35 MB."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Vælg venligst en rodpartition (/)."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, fuzzy, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-"En rodpartition er nødvendig til installationen af Linux Mint.\n"
-"\n"
-" - Monteringspunkt: /\n"
-" - Anbefalet størrelse: 30 GB\n"
-" - Anbefalet format til filsystemet: ext4\n"
-"\n"
-"Bemærk: timeshifts funktion til øjebliksbilleder af btrfs kræver følgende:\n"
-" - underdiskenheds monteringspunkt /@\n"
-" - btrfs  som filsystemformat\n"
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-"Der kan ikke bootes fra EFI-partitionen. Redigér venligst partitionsflagene."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "EFI-partitionen er for lille. Den skal mindst være 35 MB."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "EFI-partitionen skal formateres som vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Vælg venligst en EFI-partition."
-
-#: live-installer/frontend/gtk_interface.py:1226
-#, fuzzy
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-"En EFI-systempartition med de følgende krav er nødvendig:\n"
-"\n"
-" - Monteringspunkt: /boot/efi\n"
-" - Partitionsflag: Bootable\n"
-" - Størrelse: mindst 35 MB (100 MB eller mere anbefales)\n"
-" - Format: vfat eller fat32\n"
-"\n"
-"For at sikre kompatibilitet med Windows anbefaler vi, at du bruger diskens "
-"første partition som EFI-systempartition.\n"
-" "
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr "Vælg en disk."
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr "Advarsel"
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr "Al data på %s vil blive slettet. Er du sikker?"
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Angiv venligst et brugernavn."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Lokalisering"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Sprog: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Tidszone: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Tastaturlayout: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Brugerindstillinger"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Rigtige navn: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Brugernavn: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Automatisk login: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "aktiveret"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "deaktiveret"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Systemindstillinger"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr "Computerens navn: "
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-#, fuzzy
-msgid "Install updates after installation"
-msgstr "Automatiseret installation"
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Filsystemhandlinger"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Installér opstartsindlæser på %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Installér ikke opstartsindlæser"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Anvend det allerede monterede /mål."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr "Automatiseret installation på %s"
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Formatér %(path)s som %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Montér %(path)s som %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr "LVM: "
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr "Diskkryptering: "
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Installationen er nu færdig. Vil du genstarte din computer og tage det nye "
-"system i brug?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Installationsfejl"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, fuzzy, python-format
-msgid "Welcome to %s"
-msgstr "Velkommen"
-
-#: live-installer/frontend/tui_interface.py:57
-#, fuzzy
-msgid "What keyboard would you like to use?"
-msgstr "Hvilket sprog ønsker du at bruge?"
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Tastaturmodel:"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Installationstype"
-
-#: live-installer/frontend/tui_interface.py:80
-#, fuzzy
-msgid "Select a disk?"
-msgstr "Vælg en disk."
-
-#: live-installer/frontend/tui_interface.py:84
-#, fuzzy
-msgid "Disk"
-msgstr "Disk:"
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Tidszone"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Flytbar:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Redigér"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Tildel til /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"Partitionstabellen for %s kunne ikke skrives. Genstart computeren og prøv "
-"igen."
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"Partitionen %s kunne ikke oprettes. Installationen vil stoppe. Genstart "
-"computeren og prøv igen."
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Logisk partition"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Udvidet partition"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Ukendt"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Redigér partition"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Redigér partition"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Enhed:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Formatér som:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Monteringspunkt:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Annullér"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "OK"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Nej"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Ja"
 
 #~ msgid "Quit"
 #~ msgstr "Afslut"

--- a/po/live-installer-de.po
+++ b/po/live-installer-de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2020-03-12 19:14+0000\n"
 "Last-Translator: Niko Krause <nikokrause@gmx.de>\n"
 "Language-Team: German <de@li.org>\n"
@@ -95,7 +95,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -198,9 +198,9 @@ msgid "Format"
 msgstr "Formatieren als"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -306,6 +306,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Formatieren als"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -337,8 +343,8 @@ msgstr "Herzlich Willkommen"
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "Bestätigen"
 
@@ -430,23 +436,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr "Herzlich Willkommen"
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Land"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Belegung"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Variante"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Dateiindizes werden berechnet …"
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Entfernbar:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Bearbeiten"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Zuweisen zu /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -464,10 +541,108 @@ msgstr "Dateiindizes werden berechnet …"
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr "Installationsprogramm"
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Freier Speicherplatz"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"Die Partitionstabelle konnte nicht für %s geschrieben werden. Starten Sie "
+"den Rechner neu und versuchen Sie es erneut."
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"Die Partition %s konnte nicht erstellt werden. Die Installation wird "
+"abgebrochen. Starten Sie den Rechner neu und versuchen Sie es erneut."
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Logische Partition"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Erweiterte Partition"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Unbekannt"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Partition bearbeiten"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Partition bearbeiten"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Gerät:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Formatieren als:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Einhängepunkt:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Land"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Belegung"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variante"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Dateiindizes werden berechnet …"
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -586,18 +761,6 @@ msgstr "Formatieren als"
 msgid "Size"
 msgstr "Größe"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Freier Speicherplatz"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -630,25 +793,6 @@ msgstr "Beenden?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Sind Sie sicher, dass Sie das Installationsprogramm beenden wollen?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -912,7 +1056,7 @@ msgid "Disk Encryption: "
 msgstr "Festplattenverschlüsselung: "
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Installation abgeschlossen"
 
@@ -933,143 +1077,6 @@ msgstr "Fehler bei der Installation"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Entfernbar:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Bearbeiten"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Zuweisen zu /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"Die Partitionstabelle konnte nicht für %s geschrieben werden. Starten Sie "
-"den Rechner neu und versuchen Sie es erneut."
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"Die Partition %s konnte nicht erstellt werden. Die Installation wird "
-"abgebrochen. Starten Sie den Rechner neu und versuchen Sie es erneut."
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Logische Partition"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Erweiterte Partition"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Unbekannt"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Partition bearbeiten"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Partition bearbeiten"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Gerät:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Formatieren als:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Einhängepunkt:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Abbrechen"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1233,49 +1240,49 @@ msgstr "Partitionen werden auf %s erstellt"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "%(partition)s wird formatiert als %(format)s …"
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Rechnername wird eingestellt"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Lokale Einstellungen werden eingestellt"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Rechnername wird eingestellt"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Tastaturoptionen werden eingestellt"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Live-Konfiguration wird entfernt (Pakete)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Startprogramm wird installiert"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Startprogramm wird konfiguriert"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1283,15 +1290,15 @@ msgstr ""
 "ACHTUNG: Das GRUB-Startprogramm wurde nicht richtig konfiguriert! Sie müssen "
 "es manuell konfigurieren."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Startprogramm wird geprüft"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-de.po
+++ b/po/live-installer-de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2020-03-12 19:14+0000\n"
 "Last-Translator: Niko Krause <nikokrause@gmx.de>\n"
 "Language-Team: German <de@li.org>\n"
@@ -24,8 +24,8 @@ msgid "Welcome to the 17g Installer."
 msgstr "Willkommen beim 17G-Installationsprogramm."
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 #, fuzzy
 msgid ""
 "This program will ask you some questions and set up system on your computer."
@@ -34,12 +34,12 @@ msgstr ""
 "einrichten."
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr "Tastaturmodell:"
 
@@ -49,10 +49,12 @@ msgid "Type here to test your keyboard"
 msgstr "Hier tippen, um Ihre Tastaturbelegung zu testen"
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -61,13 +63,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Zeitzone"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr "Automatische Installation"
 
@@ -77,12 +79,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr "Medium löschen und 17G darauf installieren."
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr "Medium:"
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Partition bearbeiten"
@@ -93,42 +95,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr "LVM benutzen (Logical Volume Management)"
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr "Das Betriebssystem verschlüsseln"
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr "Passphrase"
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr "Passphrase bestätigen"
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr "Dies bietet zusätzliche Sicherheit, kann jedoch Stunden dauern."
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr "Die Festplatte mit zufälligen Daten befüllen"
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr "Manuelles Partitionieren"
 
@@ -147,7 +149,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Expertenmodus"
@@ -157,145 +159,151 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 #, fuzzy
 msgid "Minimal installation"
 msgstr "Automatische Installation"
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Auffrischen"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Formatieren als"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr "Das GRUB-Startmenü installieren unter:"
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Partitionen bearbeiten"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr "Ihr Name:"
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr "Name Ihres Rechners:"
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr "Bitte Benutzernamen auswählen:"
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 "Der Name, der bei der Kommunikation mit anderen Rechnern verwendet wird."
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr "Bitte Passwort auswählen:"
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Automatisch anmelden"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr "Passwort zum Anmelden abfragen"
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr "Meinen persönlichen Ordner verschlüsseln"
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr "Passwort bestätigen:"
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 #, fuzzy
 msgid "Automated installation enabled!"
 msgstr "Automatisierte Installation auf %s"
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr "Herzlich Willkommen"
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -326,6 +334,747 @@ msgstr ""
 #, fuzzy
 msgid "Welcome to 17g"
 msgstr "Herzlich Willkommen"
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "Bestätigen"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Nein"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Ja"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Zeitzone"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, fuzzy, python-format
+msgid "Welcome to the %s Installer."
+msgstr "Willkommen beim 17G-Installationsprogramm."
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr "Welche Sprache wollen Sie verwenden?"
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Sprache"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr "Wo befinden Sie sich?"
+
+#: live-installer/frontend/tui_interface.py:57
+#, fuzzy
+msgid "What keyboard would you like to use?"
+msgstr "Welche Sprache wollen Sie verwenden?"
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Tastaturmodell:"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Installationsart"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Typ"
+
+#: live-installer/frontend/tui_interface.py:80
+#, fuzzy
+msgid "Select a disk?"
+msgstr "Bitte ein Medium auswählen."
+
+#: live-installer/frontend/tui_interface.py:84
+#, fuzzy
+msgid "Disk"
+msgstr "Medium:"
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, fuzzy, python-format
+msgid "Welcome to %s"
+msgstr "Herzlich Willkommen"
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Land"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Belegung"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variante"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Dateiindizes werden berechnet …"
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr "Installationsprogramm"
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Tastaturbelegung"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr "Welche Tastaturanordnung haben Sie?"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr "Benutzerkonto"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr "Wer sind Sie?"
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr "Installationsart"
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Wo möchten Sie 17G installieren?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Partitionierung"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Zusammenfassung"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr "Installation läuft"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+#, fuzzy
+msgid "Automated Install"
+msgstr "Automatische Installation"
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "zurück"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr "weiter"
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr "Hier tippen, um Ihre Tastaturbelegung zu testen"
+
+#: live-installer/frontend/gtk_interface.py:546
+#, fuzzy
+msgid "Erase a disk and install system on it."
+msgstr "Medium löschen und 17G darauf installieren."
+
+#: live-installer/frontend/gtk_interface.py:559
+#, fuzzy
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+"Partionen für 17G manuell erstellen, in der Größe ändern oder auswählen."
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Partitionen bearbeiten"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Gerät"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Betriebssystem"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Einhängepunkt"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Formatieren als"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Größe"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Freier Speicherplatz"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr "Achtung"
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr "Das wird alle Daten auf %s löschen. Sind Sie sicher?"
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Installieren"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr "Bitte geben Sie eine Passphrase für die Verschlüsselung an."
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Ihre Passwörter stimmen nicht überein."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Beenden?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Sind Sie sicher, dass Sie das Installationsprogramm beenden wollen?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Bitte eine Sprache auswählen"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Bitte geben Sie einen Namen für Ihren Rechner an."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Bitte Ihren vollständigen Namen eingeben."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Ihre Passwörter stimmen nicht überein."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "Die EFI-Partition ist zu klein. Sie muss mindestens 35 MB groß sein."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Bitte eine Wurzelpartition (/) auswählen."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, fuzzy, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+"Zur Installation von Linux Mint ist eine Root-Partition erforderlich.\n"
+"\n"
+" - Einhängepunkt: \n"
+" - Empfohlene Größe: 30 GB\n"
+" - Empfohlenes Dateisystemformat: ext4\n"
+"\n"
+"Hinweis: Die Funktion für Timeshift-btrfs-Schnappschüsse erfordert die "
+"Verwendung von:\n"
+" - Unterlaufwerkseinhängepunkt @\n"
+" - btrfs als Dateisystemformat\n"
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+"Die EFI-Partition ist nicht startfähig. Bitte bearbeiten Sie die "
+"Partitionsmarkierungen."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "Die EFI-Partition ist zu klein. Sie muss mindestens 35 MB groß sein."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "Die EFI-Partition muss als vfat formatiert werden."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Bitte eine EFI-Partition auswählen."
+
+#: live-installer/frontend/gtk_interface.py:1301
+#, fuzzy
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+"Eine EFI-Systempartition wird mit den folgenden Anforderungen benötigt:\n"
+"\n"
+" - Einhängepunkt: /boot/efi\n"
+" - Partitionsmarkierungen: startfähig\n"
+" - Größe: mindestens 35 MB (100 MB oder mehr empfohlen)\n"
+" - Format: vfat oder fat32\n"
+"\n"
+"Um die Kompatibilität mit Windows zu gewährleisten, empfehlen wir Ihnen, die "
+"erste Partition der Festplatte als EFI-Systempartition zu verwenden.\n"
+" "
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr "Bitte ein Medium auswählen."
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Bitte einen Benutzernamen eingeben."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Lokalisierung"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Sprache: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Zeitzone: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Tastaturbelegung: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Benutzereinstellungen"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Ihr Name: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Benutzername: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Automatische Anmeldung: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "aktiviert"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "deaktiviert"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Systemeinstellungen"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr "Rechnername: "
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+#, fuzzy
+msgid "Install updates after installation"
+msgstr "Automatische Installation"
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Dateisystemzugriffe"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Das Startprogramm auf %s installieren"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Kein Startprogramm installieren"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Bereits eingehängtes »/target« verwenden."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr "Automatisierte Installation auf %s"
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "%(path)s als %(filesystem)s formatieren"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "%(path)s als %(mount)s einhängen"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "%(path)s als %(mount)s einhängen"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr "LVM: "
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr "Festplattenverschlüsselung: "
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Installation abgeschlossen"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Die Installation ist jetzt vollständig. Möchten Sie den Rechner neu starten, "
+"um das neue System zu benutzen?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Fehler bei der Installation"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Entfernbar:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Bearbeiten"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Zuweisen zu /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"Die Partitionstabelle konnte nicht für %s geschrieben werden. Starten Sie "
+"den Rechner neu und versuchen Sie es erneut."
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"Die Partition %s konnte nicht erstellt werden. Die Installation wird "
+"abgebrochen. Starten Sie den Rechner neu und versuchen Sie es erneut."
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Logische Partition"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Erweiterte Partition"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Unbekannt"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Partition bearbeiten"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Partition bearbeiten"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Gerät:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Formatieren als:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Einhängepunkt:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
+msgstr ""
 
 #: live-installer/validate.py:12
 msgid "Please provide a username."
@@ -435,10 +1184,6 @@ msgstr "Ihre Passwörter stimmen nicht überein."
 msgid "Please provide a password for your user account."
 msgstr "Bitte ein Passwort für Ihr Benutzerkonto eingeben."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -466,7 +1211,7 @@ msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 "Die Einhängeinformationen des Dateisystems werden nach /etc/fstab geschrieben"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "%(partition)s wird in %(mountpoint)s eingehängt"
@@ -488,49 +1233,49 @@ msgstr "Partitionen werden auf %s erstellt"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "%(partition)s wird formatiert als %(format)s …"
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Rechnername wird eingestellt"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Lokale Einstellungen werden eingestellt"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Rechnername wird eingestellt"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Tastaturoptionen werden eingestellt"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Live-Konfiguration wird entfernt (Pakete)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Startprogramm wird installiert"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Startprogramm wird konfiguriert"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -538,676 +1283,17 @@ msgstr ""
 "ACHTUNG: Das GRUB-Startprogramm wurde nicht richtig konfiguriert! Sie müssen "
 "es manuell konfigurieren."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Installation abgeschlossen"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Startprogramm wird geprüft"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Land"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Sprache"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Belegung"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Variante"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Dateiindizes werden berechnet …"
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr "Installationsprogramm"
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr "Welche Sprache wollen Sie verwenden?"
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr "Wo befinden Sie sich?"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Tastaturbelegung"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr "Welche Tastaturanordnung haben Sie?"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr "Benutzerkonto"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr "Wer sind Sie?"
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr "Installationsart"
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Wo möchten Sie 17G installieren?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Partitionierung"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Zusammenfassung"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr "Installation läuft"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-#, fuzzy
-msgid "Automated install"
-msgstr "Automatische Installation"
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "zurück"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr "weiter"
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, fuzzy, python-format
-msgid "Welcome to the %s Installer."
-msgstr "Willkommen beim 17G-Installationsprogramm."
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr "Hier tippen, um Ihre Tastaturbelegung zu testen"
-
-#: live-installer/frontend/gtk_interface.py:542
-#, fuzzy
-msgid "Erase a disk and install system on it."
-msgstr "Medium löschen und 17G darauf installieren."
-
-#: live-installer/frontend/gtk_interface.py:555
-#, fuzzy
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-"Partionen für 17G manuell erstellen, in der Größe ändern oder auswählen."
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Partitionen bearbeiten"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Gerät"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Typ"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Betriebssystem"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Einhängepunkt"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Formatieren als"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Größe"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Freier Speicherplatz"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Installieren"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr "Bitte geben Sie eine Passphrase für die Verschlüsselung an."
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Ihre Passwörter stimmen nicht überein."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Beenden?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Sind Sie sicher, dass Sie das Installationsprogramm beenden wollen?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Bitte eine Sprache auswählen"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Bitte geben Sie einen Namen für Ihren Rechner an."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Bitte Ihren vollständigen Namen eingeben."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Ihre Passwörter stimmen nicht überein."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "Die EFI-Partition ist zu klein. Sie muss mindestens 35 MB groß sein."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Bitte eine Wurzelpartition (/) auswählen."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, fuzzy, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-"Zur Installation von Linux Mint ist eine Root-Partition erforderlich.\n"
-"\n"
-" - Einhängepunkt: \n"
-" - Empfohlene Größe: 30 GB\n"
-" - Empfohlenes Dateisystemformat: ext4\n"
-"\n"
-"Hinweis: Die Funktion für Timeshift-btrfs-Schnappschüsse erfordert die "
-"Verwendung von:\n"
-" - Unterlaufwerkseinhängepunkt @\n"
-" - btrfs als Dateisystemformat\n"
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-"Die EFI-Partition ist nicht startfähig. Bitte bearbeiten Sie die "
-"Partitionsmarkierungen."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "Die EFI-Partition ist zu klein. Sie muss mindestens 35 MB groß sein."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "Die EFI-Partition muss als vfat formatiert werden."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Bitte eine EFI-Partition auswählen."
-
-#: live-installer/frontend/gtk_interface.py:1226
-#, fuzzy
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-"Eine EFI-Systempartition wird mit den folgenden Anforderungen benötigt:\n"
-"\n"
-" - Einhängepunkt: /boot/efi\n"
-" - Partitionsmarkierungen: startfähig\n"
-" - Größe: mindestens 35 MB (100 MB oder mehr empfohlen)\n"
-" - Format: vfat oder fat32\n"
-"\n"
-"Um die Kompatibilität mit Windows zu gewährleisten, empfehlen wir Ihnen, die "
-"erste Partition der Festplatte als EFI-Systempartition zu verwenden.\n"
-" "
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr "Bitte ein Medium auswählen."
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr "Achtung"
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr "Das wird alle Daten auf %s löschen. Sind Sie sicher?"
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Bitte einen Benutzernamen eingeben."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Lokalisierung"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Sprache: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Zeitzone: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Tastaturbelegung: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Benutzereinstellungen"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Ihr Name: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Benutzername: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Automatische Anmeldung: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "aktiviert"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "deaktiviert"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Systemeinstellungen"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr "Rechnername: "
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-#, fuzzy
-msgid "Install updates after installation"
-msgstr "Automatische Installation"
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Dateisystemzugriffe"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Das Startprogramm auf %s installieren"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Kein Startprogramm installieren"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Bereits eingehängtes »/target« verwenden."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr "Automatisierte Installation auf %s"
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "%(path)s als %(filesystem)s formatieren"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "%(path)s als %(mount)s einhängen"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr "LVM: "
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr "Festplattenverschlüsselung: "
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Die Installation ist jetzt vollständig. Möchten Sie den Rechner neu starten, "
-"um das neue System zu benutzen?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Fehler bei der Installation"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, fuzzy, python-format
-msgid "Welcome to %s"
-msgstr "Herzlich Willkommen"
-
-#: live-installer/frontend/tui_interface.py:57
-#, fuzzy
-msgid "What keyboard would you like to use?"
-msgstr "Welche Sprache wollen Sie verwenden?"
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Tastaturmodell:"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Installationsart"
-
-#: live-installer/frontend/tui_interface.py:80
-#, fuzzy
-msgid "Select a disk?"
-msgstr "Bitte ein Medium auswählen."
-
-#: live-installer/frontend/tui_interface.py:84
-#, fuzzy
-msgid "Disk"
-msgstr "Medium:"
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Zeitzone"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Entfernbar:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Bearbeiten"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Zuweisen zu /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"Die Partitionstabelle konnte nicht für %s geschrieben werden. Starten Sie "
-"den Rechner neu und versuchen Sie es erneut."
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"Die Partition %s konnte nicht erstellt werden. Die Installation wird "
-"abgebrochen. Starten Sie den Rechner neu und versuchen Sie es erneut."
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Logische Partition"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Erweiterte Partition"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Unbekannt"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Partition bearbeiten"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Partition bearbeiten"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Gerät:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Formatieren als:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Einhängepunkt:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Abbrechen"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "Bestätigen"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Nein"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Ja"
 
 #~ msgid "Quit"
 #~ msgstr "Beenden"

--- a/po/live-installer-el.po
+++ b/po/live-installer-el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2020-02-29 07:13+0000\n"
 "Last-Translator: Vasilis Thomopoulos <Unknown>\n"
 "Language-Team: Greek <el@li.org>\n"
@@ -24,19 +24,19 @@ msgid "Welcome to the 17g Installer."
 msgstr "Καλωσορίσατε στον εγκαταστάτη του 17G."
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr "Μοντέλο πληκτρολογίου:"
 
@@ -46,10 +46,12 @@ msgid "Type here to test your keyboard"
 msgstr "Πληκτρολογήστε εδώ για να δοκιμάσετε τη διάταξη πληκτρολογίου σας"
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -58,13 +60,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Ωρολογιακή ζώνη"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr "Αυτοματοποιημένη Εγκατάσταση"
 
@@ -73,12 +75,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr "Δίσκος:"
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Επεξεργασία κατάτμησης"
@@ -89,42 +91,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr "Χρήση LVM (Logical Volume Management)"
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr "Κρυπτογράφηση του λειτουργικού συστήματος"
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr "Συνθηματική Φράση"
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr "Επιβεβαίωση φράσης πρόσβασης"
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr "Διαμέριση με το χέρι"
 
@@ -141,7 +143,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Λειτουργία για προχωρημένους"
@@ -151,144 +153,150 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 #, fuzzy
 msgid "Minimal installation"
 msgstr "Αυτοματοποιημένη Εγκατάσταση"
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Ανανέωση"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Μορφοποίηση ως"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr "Εγκατάσταση του μενού εκκίνησης GRUB στο:"
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Επεξεργασία κατατμήσεων"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr "Το όνομά σας:"
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr "Το όνομα του υπολογιστή σας:"
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr "Επιλέξτε ένα όνομα χρήστη:"
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr "Το όνομα που χρησιμοποιείται κατά την σύνδεση με άλλους υπολογιστές"
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr "Διαλέξτε ένα συνθηματικό (κωδικός πρόσβασης):"
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Αυτόματη είσοδος"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr "Να απαιτείται ο κωδικός πρόσβασης για είσοδο"
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr "Κρυπτογράφηση του προσωπικού μου φακέλου"
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr "Επιβεβαιώστε το συνθηματικό:"
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 #, fuzzy
 msgid "Automated installation enabled!"
 msgstr "Αυτοματοποιημένη Εγκατάσταση"
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr "Καλώς Ήλθατε"
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -319,6 +327,718 @@ msgstr ""
 #, fuzzy
 msgid "Welcome to 17g"
 msgstr "Καλώς Ήλθατε"
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "OK"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Όχι"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Ναι"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Ωρολογιακή ζώνη"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, fuzzy, python-format
+msgid "Welcome to the %s Installer."
+msgstr "Καλωσορίσατε στον εγκαταστάτη του 17G."
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr "Ποια γλώσσα θα θέλατε να χρησιμοποιήσετε;"
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Γλώσσα"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr "Πού βρίσκεστε;"
+
+#: live-installer/frontend/tui_interface.py:57
+#, fuzzy
+msgid "What keyboard would you like to use?"
+msgstr "Ποια γλώσσα θα θέλατε να χρησιμοποιήσετε;"
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Μοντέλο πληκτρολογίου:"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Είδος Εγκατάστασης"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Τύπος"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+#, fuzzy
+msgid "Disk"
+msgstr "Δίσκος:"
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, fuzzy, python-format
+msgid "Welcome to %s"
+msgstr "Καλώς Ήλθατε"
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Χώρα"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Διάταξη"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Παραλλαγή"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Υπολογισμός ευρετηρίων αρχείων ..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr "Εγκαταστάτης"
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Διάταξη πληκτρολογίου"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr "Ποια είναι η διάταξη πληκτρολογίου σας;"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr "Λογαριασμός χρήστη"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr "Ποιος είστε;"
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr "Είδος Εγκατάστασης"
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Θέλετε να εγκαταστήσετε το 17G;"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Κατάτμηση δίσκου"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Περίληψη"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr "Γίνεται Εγκατάσταση"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+#, fuzzy
+msgid "Automated Install"
+msgstr "Αυτοματοποιημένη Εγκατάσταση"
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Πίσω"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr "Επόμενο"
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr "Πληκτρολογήστε εδώ για να δοκιμάσετε τη διάταξη πληκτρολογίου σας"
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Επεξεργασία κατατμήσεων"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Συσκευή"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Λειτουργικό σύστημα"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Σημείο φόρτωσης (mount point)"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Μορφοποίηση ως"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Χωρητικότητα"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Ελεύθερος χώρος"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Εγκατάσταση"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Οι κωδικοί πρόσβασης δεν ταιριάζουν."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Έξοδος;"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Θέλετε σίγουρα να κλείσετε το βοηθό εγκατάστασης;"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Παρακαλώ επιλέξτε μια γλώσσα"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Εισάγετε έναν κωδικό πρόσβασης για τον λογαριασμό σας."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Παρακαλώ πληκτρολογήστε το πλήρες όνομά σας."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Οι κωδικοί πρόσβασης δεν ταιριάζουν."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+"Η κατάτμηση EFI δεν είναι εκκινήσημη. Διορθώστε τις σημαίες της κατάτμησης."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Παρακαλώ επιλέξτε μια κατάτμηση ρίζας (/)."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+"Η κατάτμηση EFI δεν είναι εκκινήσημη. Διορθώστε τις σημαίες της κατάτμησης."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "Το διαμέρισμα EFI πρέπει να διαμορφωθεί ως vfat."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "Το διαμέρισμα EFI πρέπει να διαμορφωθεί ως vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Παρακαλώ επιλέξτε μια κατάτμηση EFI."
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Εισάγετε ένα όνομα χρήστη."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Εντοπιότητα"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Γλώσσα: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Ώρα Ζώνης "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Διάταξη πληκτρολογίου "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Ρυθμίσεις χρήστη"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Πραγματικό Όνομα: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Όνομα Χρήστη: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Αυτόματη είσοδος: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "ενεργοποιημένο"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "απενεργοποιημένο"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Ρυθμίσεις συστήματος"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+#, fuzzy
+msgid "Install updates after installation"
+msgstr "Αυτοματοποιημένη Εγκατάσταση"
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Λειτουργίες συστήματος αρχείων"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Εγκατάσταση φορτωτή εκκίνησης στο %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Να μην εγκατασταθεί πρόγραμμα εκκίνησης"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Χρήση του ήδη υπάρχοντος κατατμημένου / στόχου"
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Διαμόρφωση %(path)s as %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Κατάτμηση %(path)s as %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Κατάτμηση %(path)s as %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Η εγκατάσταση ολοκληρώθηκε"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Η εγκατάσταση ολοκληρώθηκε. Επιθυμείτε να επανεκκινήσετε τον υπολογιστή σας "
+"ώστε να χρησιμοποιήσετε το νέο σύστημα;"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Σφάλμα εγκατάστασης"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Αφαιρούμενο"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Επεξεργασία"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Παραχώρηση στο /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Λογική κατάτμηση"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Εκτεταμένη κατάτμηση"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Άγνωστο"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Επεξεργασία κατάτμησης"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Επεξεργασία κατάτμησης"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Συσκευή:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Μορφοποίηση ως:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Σημείο προσάρτησης:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Άκυρο"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
+msgstr ""
 
 #: live-installer/validate.py:12
 msgid "Please provide a username."
@@ -427,10 +1147,6 @@ msgstr "Οι κωδικοί πρόσβασης δεν ταιριάζουν."
 msgid "Please provide a password for your user account."
 msgstr "Εισάγετε έναν κωδικό πρόσβασης για τον λογαριασμό σας."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -457,7 +1173,7 @@ msgstr "Προσθήκη νέου χρήστη στο σύστημα"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Εγγραφή πληροφοριών προσάρτησης συστήματος αρχείων στο /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Προσάρτηση του %(partition)s σε %(mountpoint)s"
@@ -477,49 +1193,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Μορφοποίηση %(partition)s σε %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Ορισμός hostname"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Ρύθμιση εντοπιότητας"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Ορισμός hostname"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Ρύθμιση επιλογών πληκτρολογίου"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Αφαίρεση \"ζωντανών\" ρυθμίσεων (πακέτων)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Εγκατάσταση προγράμματος εκκίνησης"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Διαμορφωνεται ο  εκκινητης συστηματος"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -527,647 +1243,17 @@ msgstr ""
 "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Ο εκκινητης συτηματος δεν διαμορφωθηκε κανονικα!Πρεπει να τον "
 "διαμορφωσεις μονος σου."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Η εγκατάσταση ολοκληρώθηκε"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Ελέγχει τον εκκινητη συστηματος"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Χώρα"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Γλώσσα"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Διάταξη"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Παραλλαγή"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Υπολογισμός ευρετηρίων αρχείων ..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr "Εγκαταστάτης"
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr "Ποια γλώσσα θα θέλατε να χρησιμοποιήσετε;"
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr "Πού βρίσκεστε;"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Διάταξη πληκτρολογίου"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr "Ποια είναι η διάταξη πληκτρολογίου σας;"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr "Λογαριασμός χρήστη"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr "Ποιος είστε;"
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr "Είδος Εγκατάστασης"
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Θέλετε να εγκαταστήσετε το 17G;"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Κατάτμηση δίσκου"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Περίληψη"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr "Γίνεται Εγκατάσταση"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-#, fuzzy
-msgid "Automated install"
-msgstr "Αυτοματοποιημένη Εγκατάσταση"
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Πίσω"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr "Επόμενο"
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, fuzzy, python-format
-msgid "Welcome to the %s Installer."
-msgstr "Καλωσορίσατε στον εγκαταστάτη του 17G."
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr "Πληκτρολογήστε εδώ για να δοκιμάσετε τη διάταξη πληκτρολογίου σας"
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Επεξεργασία κατατμήσεων"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Συσκευή"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Τύπος"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Λειτουργικό σύστημα"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Σημείο φόρτωσης (mount point)"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Μορφοποίηση ως"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Χωρητικότητα"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Ελεύθερος χώρος"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Εγκατάσταση"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Οι κωδικοί πρόσβασης δεν ταιριάζουν."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Έξοδος;"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Θέλετε σίγουρα να κλείσετε το βοηθό εγκατάστασης;"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Παρακαλώ επιλέξτε μια γλώσσα"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Εισάγετε έναν κωδικό πρόσβασης για τον λογαριασμό σας."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Παρακαλώ πληκτρολογήστε το πλήρες όνομά σας."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Οι κωδικοί πρόσβασης δεν ταιριάζουν."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-"Η κατάτμηση EFI δεν είναι εκκινήσημη. Διορθώστε τις σημαίες της κατάτμησης."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Παρακαλώ επιλέξτε μια κατάτμηση ρίζας (/)."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-"Η κατάτμηση EFI δεν είναι εκκινήσημη. Διορθώστε τις σημαίες της κατάτμησης."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "Το διαμέρισμα EFI πρέπει να διαμορφωθεί ως vfat."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "Το διαμέρισμα EFI πρέπει να διαμορφωθεί ως vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Παρακαλώ επιλέξτε μια κατάτμηση EFI."
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Εισάγετε ένα όνομα χρήστη."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Εντοπιότητα"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Γλώσσα: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Ώρα Ζώνης "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Διάταξη πληκτρολογίου "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Ρυθμίσεις χρήστη"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Πραγματικό Όνομα: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Όνομα Χρήστη: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Αυτόματη είσοδος: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "ενεργοποιημένο"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "απενεργοποιημένο"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Ρυθμίσεις συστήματος"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-#, fuzzy
-msgid "Install updates after installation"
-msgstr "Αυτοματοποιημένη Εγκατάσταση"
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Λειτουργίες συστήματος αρχείων"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Εγκατάσταση φορτωτή εκκίνησης στο %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Να μην εγκατασταθεί πρόγραμμα εκκίνησης"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Χρήση του ήδη υπάρχοντος κατατμημένου / στόχου"
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Διαμόρφωση %(path)s as %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Κατάτμηση %(path)s as %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Η εγκατάσταση ολοκληρώθηκε. Επιθυμείτε να επανεκκινήσετε τον υπολογιστή σας "
-"ώστε να χρησιμοποιήσετε το νέο σύστημα;"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Σφάλμα εγκατάστασης"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, fuzzy, python-format
-msgid "Welcome to %s"
-msgstr "Καλώς Ήλθατε"
-
-#: live-installer/frontend/tui_interface.py:57
-#, fuzzy
-msgid "What keyboard would you like to use?"
-msgstr "Ποια γλώσσα θα θέλατε να χρησιμοποιήσετε;"
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Μοντέλο πληκτρολογίου:"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Είδος Εγκατάστασης"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-#, fuzzy
-msgid "Disk"
-msgstr "Δίσκος:"
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Ωρολογιακή ζώνη"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Αφαιρούμενο"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Επεξεργασία"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Παραχώρηση στο /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Λογική κατάτμηση"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Εκτεταμένη κατάτμηση"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Άγνωστο"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Επεξεργασία κατάτμησης"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Επεξεργασία κατάτμησης"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Συσκευή:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Μορφοποίηση ως:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Σημείο προσάρτησης:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Άκυρο"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "OK"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Όχι"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Ναι"
 
 #~ msgid "Quit"
 #~ msgstr "Έξοδος"

--- a/po/live-installer-el.po
+++ b/po/live-installer-el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2020-02-29 07:13+0000\n"
 "Last-Translator: Vasilis Thomopoulos <Unknown>\n"
 "Language-Team: Greek <el@li.org>\n"
@@ -91,7 +91,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -192,9 +192,9 @@ msgid "Format"
 msgstr "Μορφοποίηση ως"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -299,6 +299,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Μορφοποίηση ως"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -330,8 +336,8 @@ msgstr "Καλώς Ήλθατε"
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "OK"
 
@@ -422,23 +428,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr "Καλώς Ήλθατε"
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Χώρα"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Διάταξη"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Παραλλαγή"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Υπολογισμός ευρετηρίων αρχείων ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Αφαιρούμενο"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Επεξεργασία"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Παραχώρηση στο /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -456,10 +533,104 @@ msgstr "Υπολογισμός ευρετηρίων αρχείων ..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr "Εγκαταστάτης"
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Ελεύθερος χώρος"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Λογική κατάτμηση"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Εκτεταμένη κατάτμηση"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Άγνωστο"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Επεξεργασία κατάτμησης"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Επεξεργασία κατάτμησης"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Συσκευή:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Μορφοποίηση ως:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Σημείο προσάρτησης:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Άκυρο"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Χώρα"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Διάταξη"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Παραλλαγή"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Υπολογισμός ευρετηρίων αρχείων ..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -575,18 +746,6 @@ msgstr "Μορφοποίηση ως"
 msgid "Size"
 msgstr "Χωρητικότητα"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Ελεύθερος χώρος"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -619,25 +778,6 @@ msgstr "Έξοδος;"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Θέλετε σίγουρα να κλείσετε το βοηθό εγκατάστασης;"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -880,7 +1020,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Η εγκατάσταση ολοκληρώθηκε"
 
@@ -901,139 +1041,6 @@ msgstr "Σφάλμα εγκατάστασης"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Αφαιρούμενο"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Επεξεργασία"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Παραχώρηση στο /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Λογική κατάτμηση"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Εκτεταμένη κατάτμηση"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Άγνωστο"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Επεξεργασία κατάτμησης"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Επεξεργασία κατάτμησης"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Συσκευή:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Μορφοποίηση ως:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Σημείο προσάρτησης:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Άκυρο"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1193,49 +1200,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Μορφοποίηση %(partition)s σε %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Ορισμός hostname"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Ρύθμιση εντοπιότητας"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Ορισμός hostname"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Ρύθμιση επιλογών πληκτρολογίου"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Αφαίρεση \"ζωντανών\" ρυθμίσεων (πακέτων)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Εγκατάσταση προγράμματος εκκίνησης"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Διαμορφωνεται ο  εκκινητης συστηματος"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1243,15 +1250,15 @@ msgstr ""
 "ΠΡΟΕΙΔΟΠΟΙΗΣΗ: Ο εκκινητης συτηματος δεν διαμορφωθηκε κανονικα!Πρεπει να τον "
 "διαμορφωσεις μονος σου."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Ελέγχει τον εκκινητη συστηματος"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-en_AU.po
+++ b/po/live-installer-en_AU.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2012-01-19 05:48+0000\n"
 "Last-Translator: Benjamin Donald-Wilson <benny@seffner.net>\n"
 "Language-Team: English (Australia) <en_AU@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -292,6 +292,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -322,8 +327,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -411,23 +416,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Layout"
-
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Variant"
-
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -445,9 +521,103 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Free space"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "System settings"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Layout"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -562,18 +732,6 @@ msgstr ""
 msgid "Size"
 msgstr "Size"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Free space"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -605,25 +763,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -858,7 +997,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Installation finished"
 
@@ -877,139 +1016,6 @@ msgstr "Installation error"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "System settings"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1155,49 +1161,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Setting hostname"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Setting locale"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Setting hostname"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Setting keyboard options"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Removing live configuration (packages)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Installing bootloader"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Configuring bootloader"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1205,15 +1211,15 @@ msgstr ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Checking bootloader"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-en_AU.po
+++ b/po/live-installer-en_AU.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2012-01-19 05:48+0000\n"
 "Last-Translator: Benjamin Donald-Wilson <benny@seffner.net>\n"
 "Language-Team: English (Australia) <en_AU@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,141 +149,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "System settings"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -310,6 +318,702 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Keyboard layout: "
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Installation error"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Type"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Layout"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Device"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Operating system"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Mount point"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Size"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Free space"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Localization"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Language: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Timezone: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Keyboard layout: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "User settings"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Real name: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Username: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "System settings"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Filesystem operations"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Do not install bootloader"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Mounting %(partition)s on %(mountpoint)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Installation finished"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Installation error"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "System settings"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -405,10 +1109,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -435,7 +1135,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Mounting %(partition)s on %(mountpoint)s"
@@ -455,49 +1155,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Setting hostname"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Setting locale"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Setting hostname"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Setting keyboard options"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Removing live configuration (packages)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Installing bootloader"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Configuring bootloader"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -505,630 +1205,16 @@ msgstr ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Installation finished"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Checking bootloader"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Layout"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Variant"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Device"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Type"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Operating system"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Mount point"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Size"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Free space"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Localization"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Language: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Timezone: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Keyboard layout: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "User settings"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Real name: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Username: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "System settings"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Filesystem operations"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Do not install bootloader"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Installation error"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Keyboard layout: "
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Installation error"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "System settings"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-en_CA.po
+++ b/po/live-installer-en_CA.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2011-10-07 21:36+0000\n"
 "Last-Translator: blueXrider <Unknown>\n"
 "Language-Team: English (Canada) <en_CA@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,141 +149,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "System settings"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -310,6 +318,702 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Keyboard layout: "
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Installation error"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Type"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Layout"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Device"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Operating system"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Mount point"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Size"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Free space"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Localization"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Language: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Timezone: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Keyboard layout: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "User settings"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Real name: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Username: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "System settings"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Filesystem operations"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Do not install bootloader"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Mounting %(partition)s on %(mountpoint)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Installation finished"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Installation error"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "System settings"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -405,10 +1109,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -435,7 +1135,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Mounting %(partition)s on %(mountpoint)s"
@@ -455,49 +1155,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Setting hostname"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Setting locale"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Setting hostname"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Setting keyboard options"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Removing live configuration (packages)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Installing bootloader"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Configuring bootloader"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -505,630 +1205,16 @@ msgstr ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Installation finished"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Checking bootloader"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Layout"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Variant"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Device"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Type"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Operating system"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Mount point"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Size"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Free space"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Localization"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Language: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Timezone: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Keyboard layout: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "User settings"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Real name: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Username: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "System settings"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Filesystem operations"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Do not install bootloader"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Installation error"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Keyboard layout: "
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Installation error"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "System settings"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-en_CA.po
+++ b/po/live-installer-en_CA.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2011-10-07 21:36+0000\n"
 "Last-Translator: blueXrider <Unknown>\n"
 "Language-Team: English (Canada) <en_CA@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -292,6 +292,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -322,8 +327,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -411,23 +416,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Layout"
-
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Variant"
-
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -445,9 +521,103 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Free space"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "System settings"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Layout"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -562,18 +732,6 @@ msgstr ""
 msgid "Size"
 msgstr "Size"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Free space"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -605,25 +763,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -858,7 +997,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Installation finished"
 
@@ -877,139 +1016,6 @@ msgstr "Installation error"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "System settings"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1155,49 +1161,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Setting hostname"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Setting locale"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Setting hostname"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Setting keyboard options"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Removing live configuration (packages)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Installing bootloader"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Configuring bootloader"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1205,15 +1211,15 @@ msgstr ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Checking bootloader"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-en_GB.po
+++ b/po/live-installer-en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2020-02-15 13:04+0000\n"
 "Last-Translator: Stephan Woidowski <swoidowski@t-online.de>\n"
 "Language-Team: English (United Kingdom) <en_GB@li.org>\n"
@@ -24,8 +24,8 @@ msgid "Welcome to the 17g Installer."
 msgstr "Welcome to the 17G Installer."
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 #, fuzzy
 msgid ""
 "This program will ask you some questions and set up system on your computer."
@@ -33,12 +33,12 @@ msgstr ""
 "This program will ask you some questions and set up 17G on your computer."
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr "Keyboard Model:"
 
@@ -48,10 +48,12 @@ msgid "Type here to test your keyboard"
 msgstr "Type here to test your keyboard layout"
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -60,13 +62,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Timezone"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr "Automated Installation"
 
@@ -76,12 +78,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr "Erase a disk and install 17G on it."
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr "Disk:"
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Edit partition"
@@ -92,42 +94,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr "Use LVM (Logical Volume Management)"
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr "Encrypt the operating system"
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr "Passphrase"
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr "Confirm passphrase"
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr "Manual Partitioning"
 
@@ -145,7 +147,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Expert mode"
@@ -155,144 +157,150 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 #, fuzzy
 msgid "Minimal installation"
 msgstr "Automated Installation"
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Refresh"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Format as"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr "Install the GRUB boot menu on:"
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Edit partitions"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr "Your name:"
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr "Your computer's name:"
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr "Pick a username:"
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr "The name it uses when it talks to other computers."
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr "Choose a password:"
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Log in automatically"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr "Require my password to log in"
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr "Encrypt my home folder"
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr "Confirm your password:"
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 #, fuzzy
 msgid "Automated installation enabled!"
 msgstr "Automated installation on %s"
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr "Welcome"
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -323,6 +331,739 @@ msgstr ""
 #, fuzzy
 msgid "Welcome to 17g"
 msgstr "Welcome"
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "OK"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "No"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Yes"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Timezone"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, fuzzy, python-format
+msgid "Welcome to the %s Installer."
+msgstr "Welcome to the 17G Installer."
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr "What language would you like to use?"
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Language"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr "Where are you?"
+
+#: live-installer/frontend/tui_interface.py:57
+#, fuzzy
+msgid "What keyboard would you like to use?"
+msgstr "What language would you like to use?"
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Keyboard Model:"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Installation Type"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Type"
+
+#: live-installer/frontend/tui_interface.py:80
+#, fuzzy
+msgid "Select a disk?"
+msgstr "Please select a disk."
+
+#: live-installer/frontend/tui_interface.py:84
+#, fuzzy
+msgid "Disk"
+msgstr "Disk:"
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, fuzzy, python-format
+msgid "Welcome to %s"
+msgstr "Welcome"
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Country"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Layout"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Calculating file indexes ..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr "Installer"
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Keyboard layout"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr "What is your keyboard layout?"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr "User account"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr "Who are you?"
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr "Installation Type"
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Where do you want to install 17G?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Partitioning"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Summary"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr "Installing"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+#, fuzzy
+msgid "Automated Install"
+msgstr "Automated Installation"
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Back"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr "Next"
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr "Type here to test your keyboard layout"
+
+#: live-installer/frontend/gtk_interface.py:546
+#, fuzzy
+msgid "Erase a disk and install system on it."
+msgstr "Erase a disk and install 17G on it."
+
+#: live-installer/frontend/gtk_interface.py:559
+#, fuzzy
+msgid "Manually create, resize or choose partitions for system."
+msgstr "Manually create, resize or choose partitions for 17G."
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Edit partitions"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Device"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Operating system"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Mount point"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Format as"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Size"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Free space"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr "Warning"
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr "This will delete all the data on %s. Are you sure?"
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Install"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr "Please provide a passphrase for the encryption."
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Your passwords do not match."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Quit?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Are you sure you want to quit the installer?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Please choose a language"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Please provide a password for your user account."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Please provide your full name."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Your passwords do not match."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "The EFI partition is too small. It must be at least 35MB."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Please select a root (/) partition."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, fuzzy, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+"A root partition is needed to install Linux Mint on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+"Note: The timeshift btrfs snapshots feature requires the use of:\n"
+" - subvolume Mount-point /@\n"
+" - btrfs as filesystem format\n"
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "The EFI partition is not bootable. Please edit the partition flags."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "The EFI partition is too small. It must be at least 35MB."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "The EFI partition must be formatted as vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Please select an EFI partition."
+
+#: live-installer/frontend/gtk_interface.py:1301
+#, fuzzy
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 35MB (100MB or more recommended)\n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr "Please select a disk."
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Please provide a username."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Localisation"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Language: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Timezone: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Keyboard layout: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "User settings"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Real name: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Username: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Automatic login: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "enabled"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "disabled"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "System settings"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+#, fuzzy
+msgid "Install updates after installation"
+msgstr "Automated Installation"
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Filesystem operations"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Install bootloader on %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Do not install bootloader"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Use already-mounted /target."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr "Automated installation on %s"
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Format %(path)s as %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Mount %(path)s as %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Mount %(path)s as %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr "LVM: "
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr "Disk Encryption: "
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Installation finished"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Installation error"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "KB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Removable:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Edit"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Assign to /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Logical partition"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Extended partition"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Unknown"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Edit partition"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Edit partition"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Device:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Format as:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Mount point:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Cancel"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
+msgstr ""
 
 #: live-installer/validate.py:12
 msgid "Please provide a username."
@@ -430,10 +1171,6 @@ msgstr "Your passwords do not match."
 msgid "Please provide a password for your user account."
 msgstr "Please provide a password for your user account."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -460,7 +1197,7 @@ msgstr "Adding new user to the system"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Writing filesystem mount information to /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Mounting %(partition)s on %(mountpoint)s"
@@ -480,49 +1217,49 @@ msgstr "Creating partitions on %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formatting %(partition)s as %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Setting hostname"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Setting locale"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Setting hostname"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Setting keyboard options"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Removing live configuration (packages)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Installing bootloader"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Configuring bootloader"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -530,668 +1267,17 @@ msgstr ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Installation finished"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Checking bootloader"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Country"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Language"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Layout"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Variant"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Calculating file indexes ..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr "Installer"
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr "What language would you like to use?"
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr "Where are you?"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Keyboard layout"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr "What is your keyboard layout?"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr "User account"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr "Who are you?"
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr "Installation Type"
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Where do you want to install 17G?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Partitioning"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Summary"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr "Installing"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-#, fuzzy
-msgid "Automated install"
-msgstr "Automated Installation"
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Back"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr "Next"
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, fuzzy, python-format
-msgid "Welcome to the %s Installer."
-msgstr "Welcome to the 17G Installer."
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr "Type here to test your keyboard layout"
-
-#: live-installer/frontend/gtk_interface.py:542
-#, fuzzy
-msgid "Erase a disk and install system on it."
-msgstr "Erase a disk and install 17G on it."
-
-#: live-installer/frontend/gtk_interface.py:555
-#, fuzzy
-msgid "Manually create, resize or choose partitions for system."
-msgstr "Manually create, resize or choose partitions for 17G."
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Edit partitions"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Device"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Type"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Operating system"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Mount point"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Format as"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Size"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Free space"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Install"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr "Please provide a passphrase for the encryption."
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Your passwords do not match."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Quit?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Are you sure you want to quit the installer?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Please choose a language"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Please provide a password for your user account."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Please provide your full name."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Your passwords do not match."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "The EFI partition is too small. It must be at least 35MB."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Please select a root (/) partition."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, fuzzy, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-"A root partition is needed to install Linux Mint on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-"Note: The timeshift btrfs snapshots feature requires the use of:\n"
-" - subvolume Mount-point /@\n"
-" - btrfs as filesystem format\n"
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "The EFI partition is not bootable. Please edit the partition flags."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "The EFI partition is too small. It must be at least 35MB."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "The EFI partition must be formatted as vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Please select an EFI partition."
-
-#: live-installer/frontend/gtk_interface.py:1226
-#, fuzzy
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 35MB (100MB or more recommended)\n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr "Please select a disk."
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr "Warning"
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr "This will delete all the data on %s. Are you sure?"
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Please provide a username."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Localisation"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Language: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Timezone: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Keyboard layout: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "User settings"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Real name: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Username: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Automatic login: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "enabled"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "disabled"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "System settings"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-#, fuzzy
-msgid "Install updates after installation"
-msgstr "Automated Installation"
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Filesystem operations"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Install bootloader on %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Do not install bootloader"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Use already-mounted /target."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr "Automated installation on %s"
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Format %(path)s as %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Mount %(path)s as %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr "LVM: "
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr "Disk Encryption: "
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Installation error"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, fuzzy, python-format
-msgid "Welcome to %s"
-msgstr "Welcome"
-
-#: live-installer/frontend/tui_interface.py:57
-#, fuzzy
-msgid "What keyboard would you like to use?"
-msgstr "What language would you like to use?"
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Keyboard Model:"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Installation Type"
-
-#: live-installer/frontend/tui_interface.py:80
-#, fuzzy
-msgid "Select a disk?"
-msgstr "Please select a disk."
-
-#: live-installer/frontend/tui_interface.py:84
-#, fuzzy
-msgid "Disk"
-msgstr "Disk:"
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Timezone"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "KB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Removable:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Edit"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Assign to /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Logical partition"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Extended partition"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Unknown"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Edit partition"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Edit partition"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Device:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Format as:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Mount point:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Cancel"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "OK"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "No"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Yes"
 
 #~ msgid "Quit"
 #~ msgstr "Quit"

--- a/po/live-installer-en_GB.po
+++ b/po/live-installer-en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2020-02-15 13:04+0000\n"
 "Last-Translator: Stephan Woidowski <swoidowski@t-online.de>\n"
 "Language-Team: English (United Kingdom) <en_GB@li.org>\n"
@@ -94,7 +94,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -196,9 +196,9 @@ msgid "Format"
 msgstr "Format as"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -303,6 +303,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Format as"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -334,8 +340,8 @@ msgstr "Welcome"
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "OK"
 
@@ -427,23 +433,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr "Welcome"
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Layout"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "KB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Variant"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Removable:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Edit"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Assign to /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -461,10 +538,104 @@ msgstr "Calculating file indexes ..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr "Installer"
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Free space"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Logical partition"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Extended partition"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Unknown"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Edit partition"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Edit partition"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Device:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Format as:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Mount point:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Cancel"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Country"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Layout"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Calculating file indexes ..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -582,18 +753,6 @@ msgstr "Format as"
 msgid "Size"
 msgstr "Size"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Free space"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -626,25 +785,6 @@ msgstr "Quit?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Are you sure you want to quit the installer?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -905,7 +1045,7 @@ msgid "Disk Encryption: "
 msgstr "Disk Encryption: "
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Installation finished"
 
@@ -926,139 +1066,6 @@ msgstr "Installation error"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "KB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Removable:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Edit"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Assign to /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Logical partition"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Extended partition"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Unknown"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Edit partition"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Edit partition"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Device:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Format as:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Mount point:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Cancel"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1217,49 +1224,49 @@ msgstr "Creating partitions on %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formatting %(partition)s as %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Setting hostname"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Setting locale"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Setting hostname"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Setting keyboard options"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Removing live configuration (packages)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Installing bootloader"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Configuring bootloader"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1267,15 +1274,15 @@ msgstr ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Checking bootloader"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-en_US.po
+++ b/po/live-installer-en_US.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2011-03-16 04:30+0000\n"
 "Last-Translator: Hnik <Unknown>\n"
 "Language-Team: English (United States) <en_US@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -291,6 +291,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -320,8 +325,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -407,23 +412,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -441,9 +517,102 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -558,18 +727,6 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -601,25 +758,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -854,7 +992,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr ""
 
@@ -873,138 +1011,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1150,60 +1156,60 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 msgid "Removing extra packages"
 msgstr ""
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""

--- a/po/live-installer-en_US.po
+++ b/po/live-installer-en_US.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2011-03-16 04:30+0000\n"
 "Last-Translator: Hnik <Unknown>\n"
 "Language-Team: English (United States) <en_US@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,140 +149,146 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 msgid "Edit Partitions"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -308,6 +316,699 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+msgid "Keyboard Model"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:73
+msgid "Installation type?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -403,10 +1104,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -433,7 +1130,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr ""
@@ -453,671 +1150,60 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 msgid "Removing extra packages"
 msgstr ""
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr ""
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-msgid "Keyboard Model"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:73
-msgid "Installation type?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""

--- a/po/live-installer-eo.po
+++ b/po/live-installer-eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2020-02-29 21:32+0000\n"
 "Last-Translator: Piet Coppens <Unknown>\n"
 "Language-Team: Esperanto <eo@li.org>\n"
@@ -24,8 +24,8 @@ msgid "Welcome to the 17g Installer."
 msgstr "Bonvenon al  la 17G-instalilo."
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 #, fuzzy
 msgid ""
 "This program will ask you some questions and set up system on your computer."
@@ -34,12 +34,12 @@ msgstr ""
 "komputilo."
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr "Klavara modelo:"
 
@@ -49,10 +49,12 @@ msgid "Type here to test your keyboard"
 msgstr "Tajpu ĉi tie por testi vian klavararanĝon"
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -61,13 +63,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Horzono"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr "Aŭtomatigita instalado"
 
@@ -77,12 +79,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr "Forviŝi diskon kaj instali 17G sur ĝin."
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr "Disko:"
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Redakti subdiskon"
@@ -93,42 +95,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr "Uzi LVM (Logika datumportilo-administrado)"
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr "Ĉifri la operaciumon"
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr "Pasfrazo"
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr "Konfirmi pasfrazon"
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr "Permana dispartigo"
 
@@ -146,7 +148,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Spertula reĝimo"
@@ -156,144 +158,150 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 #, fuzzy
 msgid "Minimal installation"
 msgstr "Aŭtomatigita instalado"
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Aktualigi"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Strukturi kiel"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr "Instali la GRUB-praŝargan menuon sur:"
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Redakti subdiskojn"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr "Via nomo:"
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr "Nomo de via komputilo:"
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr "Elektu uzantonomon:"
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr "La nomo, kiun ĝi uzas, kiam ĝi parolas al aliaj komputiloj."
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr "Elektu pasvorton:"
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Ensaluti aŭtomate"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr "Postuli mian pasvorton por ensaluti"
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr "Ĉifri mian hejman dosierujon"
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr "Konfirmu vian pasvorton:"
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 #, fuzzy
 msgid "Automated installation enabled!"
 msgstr "Aŭtomatigita instalado sur %s"
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr "Bonvenon"
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -324,6 +332,740 @@ msgstr ""
 #, fuzzy
 msgid "Welcome to 17g"
 msgstr "Bonvenon"
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "Bone"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Ne"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Jes"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Horzono"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, fuzzy, python-format
+msgid "Welcome to the %s Installer."
+msgstr "Bonvenon al  la 17G-instalilo."
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr "Kiun lingvon vi ŝatus uzi?"
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Lingvo"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr "Kie vi estas?"
+
+#: live-installer/frontend/tui_interface.py:57
+#, fuzzy
+msgid "What keyboard would you like to use?"
+msgstr "Kiun lingvon vi ŝatus uzi?"
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Klavara modelo:"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Tipo de instalo"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Tipo"
+
+#: live-installer/frontend/tui_interface.py:80
+#, fuzzy
+msgid "Select a disk?"
+msgstr "Bonvolu elekti diskon."
+
+#: live-installer/frontend/tui_interface.py:84
+#, fuzzy
+msgid "Disk"
+msgstr "Disko:"
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, fuzzy, python-format
+msgid "Welcome to %s"
+msgstr "Bonvenon"
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Lando"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Aranĝo"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Devio"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Kalkulado de dosieraj indeksoj ..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr "Instalilo"
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Klavararanĝo"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr "Kiu estas via klavararanĝo?"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr "Uzantokonto"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr "Kiu vi estas?"
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr "Tipo de instalo"
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Kie vi volas instali 17G?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Subdiskoj"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Resumo"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr "Instalado"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+#, fuzzy
+msgid "Automated Install"
+msgstr "Aŭtomatigita instalado"
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Reen"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr "Sekva"
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr "Tajpu ĉi tie por testi vian klavararanĝon"
+
+#: live-installer/frontend/gtk_interface.py:546
+#, fuzzy
+msgid "Erase a disk and install system on it."
+msgstr "Forviŝi diskon kaj instali 17G sur ĝin."
+
+#: live-installer/frontend/gtk_interface.py:559
+#, fuzzy
+msgid "Manually create, resize or choose partitions for system."
+msgstr "Permane krei, regrandigi aŭ elekti subdiskojn por 17G."
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Redakti subdiskojn"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Aparato"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Operaciumo"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Surmetingo"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Strukturi kiel"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Grando"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Libera spaco"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr "Averto"
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr "Ĉi tio forigos ĉiujn datumojn sur %s. Ĉu vi certas?"
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Instali"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr "Bonvolu provizi pasfrazon por la ĉifrado."
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Viaj pasvortoj ne kongruas."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Eliri?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Ĉu vi certas, ke vi deziras eliri el la instalilo?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Bonvolu elekti lingvon"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Bonvolu provizi nomon por via komputilo."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Bonvolu provizi vian plenan nomon."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Viaj pasvortoj ne kongruas."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "La EFI-subdisko estas tro malgranda. Ĝi estu almenaŭ 35MB."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Bonvolu elekti radikan (/) subdiskon."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, fuzzy, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+"Ĉefuzanta subdisko bezonatas por instali Linukson Minton sur tiu.\n"
+"\n"
+"- Surmetingo: /\n"
+"- Rekomendita grando: 30GB\n"
+"- Rekomendita dosiersistemformo: ext4\n"
+"\n"
+"Komento: La funkcio timeshift-btrfs-momentfotoj postulas la uzon de:\n"
+"- subdatumportila surmetingo /@\n"
+"- btrfs kiel dosiersistemformo\n"
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+"La EFI-subdisko ne estas praŝargebla. Bonvolu redakti la subdiskajn flagojn."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "La EFI-subdisko estas tro malgranda. Ĝi estu almenaŭ 35MB."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "La EFI-subdisko estu strukturita kiel vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Bonvolu elekti EFI-subdiskon."
+
+#: live-installer/frontend/gtk_interface.py:1301
+#, fuzzy
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+"EFI-sistemsubdisko bezonatas kun jenaj postuloj:\n"
+"\n"
+"- Surmetingo: /boot/efi\n"
+"- Subdiskaj flagoj: Praŝargebla\n"
+"- Grando: almenaŭ 35MB (100MB aŭ pli rekomendita)\n"
+"- Formo: vfat aŭ fat32\n"
+"\n"
+"Por certigi kongruon kun Vindozo ni rekomendas, ke vi uzu la unuan subdiskon "
+"kiel la EFI-sistemsubdiskon.\n"
+" "
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr "Bonvolu elekti diskon."
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Bonvolu provizi uzantonomon."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Asimilado"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Lingvo: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Tempzono: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Klavararanĝo: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Agordoj de uzanto"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Vera nomo: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Uzantnomo: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Aŭtomata ensaluto: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "ŝaltite"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "malebligite"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Sistemaj agordoj"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr "Nomo de komputilo: "
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+#, fuzzy
+msgid "Install updates after installation"
+msgstr "Aŭtomatigita instalado"
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Dosiersistemaj operacioj"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Instali praŝargilon sur %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Ne instalu paŝargilon"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Uzi jam-surmetitan /target."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr "Aŭtomatigita instalado sur %s"
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Strukturi %(path)s kiel %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Surmeti %(path)s kiel %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Surmeti %(path)s kiel %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr "LVM: "
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr "Diska ĉifrado: "
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Instalado finita"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"La instalado nun kompletas. Ĉu vi deziras restartigi vian komputilon por uzi "
+"la novan sistemon?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Instaleraro"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Demetebla:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Redakti"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Atribui al /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Logika subdisko"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Kromsubdisko"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Nekonate"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Redakti subdiskon"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Redakti subdiskon"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Aparato:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Strukturi kiel:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Surmetingo:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Nuligu"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
+msgstr ""
 
 #: live-installer/validate.py:12
 msgid "Please provide a username."
@@ -433,10 +1175,6 @@ msgstr "Viaj pasvortoj ne kongruas."
 msgid "Please provide a password for your user account."
 msgstr "Bonvol provizi pasvorton por via konto de uzanto."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -463,7 +1201,7 @@ msgstr "Aldonado de nova uzanto al la sistemo"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Skribado de dosiersistemaj surmetaj informoj al /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Surmetanta %(partition)s en %(mountpoint)s"
@@ -483,49 +1221,49 @@ msgstr "Kreado de subdiskoj sur %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Strukturado de %(partition)s kiel %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Agordanta nomon de gastiga komputilo"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Agordanta lokaĵaron"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Agordanta nomon de gastiga komputilo"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Agordanta klavarajn opciojn"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Foriganta rektan agordon (pakaĵoj)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Instalanta praŝargilon"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Agordanta praŝargilon"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -533,669 +1271,17 @@ msgstr ""
 "ATENTU: La GRUB-praŝargilo ne estis korekte agordita! Necesas, ke vi permane "
 "agordu tion."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Instalado finita"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Kontrolanta praŝargilon"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Lando"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Lingvo"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Aranĝo"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Devio"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Kalkulado de dosieraj indeksoj ..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr "Instalilo"
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr "Kiun lingvon vi ŝatus uzi?"
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr "Kie vi estas?"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Klavararanĝo"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr "Kiu estas via klavararanĝo?"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr "Uzantokonto"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr "Kiu vi estas?"
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr "Tipo de instalo"
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Kie vi volas instali 17G?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Subdiskoj"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Resumo"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr "Instalado"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-#, fuzzy
-msgid "Automated install"
-msgstr "Aŭtomatigita instalado"
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Reen"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr "Sekva"
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, fuzzy, python-format
-msgid "Welcome to the %s Installer."
-msgstr "Bonvenon al  la 17G-instalilo."
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr "Tajpu ĉi tie por testi vian klavararanĝon"
-
-#: live-installer/frontend/gtk_interface.py:542
-#, fuzzy
-msgid "Erase a disk and install system on it."
-msgstr "Forviŝi diskon kaj instali 17G sur ĝin."
-
-#: live-installer/frontend/gtk_interface.py:555
-#, fuzzy
-msgid "Manually create, resize or choose partitions for system."
-msgstr "Permane krei, regrandigi aŭ elekti subdiskojn por 17G."
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Redakti subdiskojn"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Aparato"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Tipo"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Operaciumo"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Surmetingo"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Strukturi kiel"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Grando"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Libera spaco"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Instali"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr "Bonvolu provizi pasfrazon por la ĉifrado."
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Viaj pasvortoj ne kongruas."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Eliri?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Ĉu vi certas, ke vi deziras eliri el la instalilo?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Bonvolu elekti lingvon"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Bonvolu provizi nomon por via komputilo."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Bonvolu provizi vian plenan nomon."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Viaj pasvortoj ne kongruas."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "La EFI-subdisko estas tro malgranda. Ĝi estu almenaŭ 35MB."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Bonvolu elekti radikan (/) subdiskon."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, fuzzy, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-"Ĉefuzanta subdisko bezonatas por instali Linukson Minton sur tiu.\n"
-"\n"
-"- Surmetingo: /\n"
-"- Rekomendita grando: 30GB\n"
-"- Rekomendita dosiersistemformo: ext4\n"
-"\n"
-"Komento: La funkcio timeshift-btrfs-momentfotoj postulas la uzon de:\n"
-"- subdatumportila surmetingo /@\n"
-"- btrfs kiel dosiersistemformo\n"
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-"La EFI-subdisko ne estas praŝargebla. Bonvolu redakti la subdiskajn flagojn."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "La EFI-subdisko estas tro malgranda. Ĝi estu almenaŭ 35MB."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "La EFI-subdisko estu strukturita kiel vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Bonvolu elekti EFI-subdiskon."
-
-#: live-installer/frontend/gtk_interface.py:1226
-#, fuzzy
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-"EFI-sistemsubdisko bezonatas kun jenaj postuloj:\n"
-"\n"
-"- Surmetingo: /boot/efi\n"
-"- Subdiskaj flagoj: Praŝargebla\n"
-"- Grando: almenaŭ 35MB (100MB aŭ pli rekomendita)\n"
-"- Formo: vfat aŭ fat32\n"
-"\n"
-"Por certigi kongruon kun Vindozo ni rekomendas, ke vi uzu la unuan subdiskon "
-"kiel la EFI-sistemsubdiskon.\n"
-" "
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr "Bonvolu elekti diskon."
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr "Averto"
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr "Ĉi tio forigos ĉiujn datumojn sur %s. Ĉu vi certas?"
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Bonvolu provizi uzantonomon."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Asimilado"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Lingvo: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Tempzono: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Klavararanĝo: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Agordoj de uzanto"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Vera nomo: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Uzantnomo: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Aŭtomata ensaluto: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "ŝaltite"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "malebligite"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Sistemaj agordoj"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr "Nomo de komputilo: "
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-#, fuzzy
-msgid "Install updates after installation"
-msgstr "Aŭtomatigita instalado"
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Dosiersistemaj operacioj"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Instali praŝargilon sur %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Ne instalu paŝargilon"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Uzi jam-surmetitan /target."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr "Aŭtomatigita instalado sur %s"
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Strukturi %(path)s kiel %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Surmeti %(path)s kiel %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr "LVM: "
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr "Diska ĉifrado: "
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"La instalado nun kompletas. Ĉu vi deziras restartigi vian komputilon por uzi "
-"la novan sistemon?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Instaleraro"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, fuzzy, python-format
-msgid "Welcome to %s"
-msgstr "Bonvenon"
-
-#: live-installer/frontend/tui_interface.py:57
-#, fuzzy
-msgid "What keyboard would you like to use?"
-msgstr "Kiun lingvon vi ŝatus uzi?"
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Klavara modelo:"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Tipo de instalo"
-
-#: live-installer/frontend/tui_interface.py:80
-#, fuzzy
-msgid "Select a disk?"
-msgstr "Bonvolu elekti diskon."
-
-#: live-installer/frontend/tui_interface.py:84
-#, fuzzy
-msgid "Disk"
-msgstr "Disko:"
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Horzono"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Demetebla:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Redakti"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Atribui al /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Logika subdisko"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Kromsubdisko"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Nekonate"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Redakti subdiskon"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Redakti subdiskon"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Aparato:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Strukturi kiel:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Surmetingo:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Nuligu"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "Bone"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Ne"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Jes"
 
 #~ msgid "Quit"
 #~ msgstr "Eliri"

--- a/po/live-installer-eo.po
+++ b/po/live-installer-eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2020-02-29 21:32+0000\n"
 "Last-Translator: Piet Coppens <Unknown>\n"
 "Language-Team: Esperanto <eo@li.org>\n"
@@ -95,7 +95,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -197,9 +197,9 @@ msgid "Format"
 msgstr "Strukturi kiel"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -304,6 +304,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Strukturi kiel"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -335,8 +341,8 @@ msgstr "Bonvenon"
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "Bone"
 
@@ -428,23 +434,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr "Bonvenon"
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Lando"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Aranĝo"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Devio"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Kalkulado de dosieraj indeksoj ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Demetebla:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Redakti"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Atribui al /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -462,10 +539,104 @@ msgstr "Kalkulado de dosieraj indeksoj ..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr "Instalilo"
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Libera spaco"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Logika subdisko"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Kromsubdisko"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Nekonate"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Redakti subdiskon"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Redakti subdiskon"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Aparato:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Strukturi kiel:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Surmetingo:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Nuligu"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Lando"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Aranĝo"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Devio"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Kalkulado de dosieraj indeksoj ..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -583,18 +754,6 @@ msgstr "Strukturi kiel"
 msgid "Size"
 msgstr "Grando"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Libera spaco"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -627,25 +786,6 @@ msgstr "Eliri?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Ĉu vi certas, ke vi deziras eliri el la instalilo?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -907,7 +1047,7 @@ msgid "Disk Encryption: "
 msgstr "Diska ĉifrado: "
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Instalado finita"
 
@@ -928,139 +1068,6 @@ msgstr "Instaleraro"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Demetebla:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Redakti"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Atribui al /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Logika subdisko"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Kromsubdisko"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Nekonate"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Redakti subdiskon"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Redakti subdiskon"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Aparato:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Strukturi kiel:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Surmetingo:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Nuligu"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1221,49 +1228,49 @@ msgstr "Kreado de subdiskoj sur %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Strukturado de %(partition)s kiel %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Agordanta nomon de gastiga komputilo"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Agordanta lokaĵaron"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Agordanta nomon de gastiga komputilo"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Agordanta klavarajn opciojn"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Foriganta rektan agordon (pakaĵoj)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Instalanta praŝargilon"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Agordanta praŝargilon"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1271,15 +1278,15 @@ msgstr ""
 "ATENTU: La GRUB-praŝargilo ne estis korekte agordita! Necesas, ke vi permane "
 "agordu tion."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Kontrolanta praŝargilon"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-es.po
+++ b/po/live-installer-es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2020-03-09 21:47+0000\n"
 "Last-Translator: Isidro Pisa <isidro@utils.info>\n"
 "Language-Team: Spanish <es@li.org>\n"
@@ -24,8 +24,8 @@ msgid "Welcome to the 17g Installer."
 msgstr "Bienvenid@ al instalador de 17G."
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 #, fuzzy
 msgid ""
 "This program will ask you some questions and set up system on your computer."
@@ -33,12 +33,12 @@ msgstr ""
 "Este programa le hará algunas preguntas y configurará 17G en su equipo."
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr "Modelo de teclado:"
 
@@ -48,10 +48,12 @@ msgid "Type here to test your keyboard"
 msgstr "Escriba aquí para probar la distribución del teclado"
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -60,13 +62,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Zona horaria"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr "Instalación automática"
 
@@ -76,12 +78,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr "Borrar un disco e instalar 17G en él."
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr "Disco:"
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Editar partición"
@@ -92,42 +94,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr "Utilizar LVM (gestión de volumen lógico)"
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr "Cifrar el sistema operativo"
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr "Frase de acceso"
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr "Confirme la frase de acceso"
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr "Proporciona seguridad extra, pero puede tardar horas."
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr "Llenar el disco con datos aleatorios"
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr "Particionado manual"
 
@@ -145,7 +147,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Modo avanzado"
@@ -155,144 +157,150 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 #, fuzzy
 msgid "Minimal installation"
 msgstr "Instalación automática"
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Actualizar"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Formatear como"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr "Instalar el menú de arranque GRUB en:"
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Editar particiones"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr "Su nombre:"
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr "El nombre de su equipo:"
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr "Elija un nombre de usuario:"
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr "El nombre que utiliza al comunicarse con otros equipos."
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr "Elija una contraseña:"
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Iniciar sesión automáticamente"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr "Requerir la contraseña para iniciar sesión"
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr "Cifrar mi carpeta personal"
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr "Confirme la contraseña:"
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 #, fuzzy
 msgid "Automated installation enabled!"
 msgstr "Instalación automatizada en %s"
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr "Bienvenid@"
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -323,6 +331,742 @@ msgstr ""
 #, fuzzy
 msgid "Welcome to 17g"
 msgstr "Bienvenid@"
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "Aceptar"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "No"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Sí"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Zona horaria"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, fuzzy, python-format
+msgid "Welcome to the %s Installer."
+msgstr "Bienvenid@ al instalador de 17G."
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr "¿Qué idioma desea usar?"
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Idioma"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr "¿Dónde se encuentra?"
+
+#: live-installer/frontend/tui_interface.py:57
+#, fuzzy
+msgid "What keyboard would you like to use?"
+msgstr "¿Qué idioma desea usar?"
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Modelo de teclado:"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Tipo de instalación"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Tipo"
+
+#: live-installer/frontend/tui_interface.py:80
+#, fuzzy
+msgid "Select a disk?"
+msgstr "Elija un disco."
+
+#: live-installer/frontend/tui_interface.py:84
+#, fuzzy
+msgid "Disk"
+msgstr "Disco:"
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, fuzzy, python-format
+msgid "Welcome to %s"
+msgstr "Bienvenid@"
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "País"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Distribución"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variante"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Indexando ficheros ..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr "Instalador"
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Distribución del teclado"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr "¿Cuál es la distribución de su teclado?"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr "Cuenta de usuario"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr "¿Quién es usted?"
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr "Tipo de instalación"
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "¿Dónde quiere instalar 17G?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Particionado"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Resumen"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr "Instalando"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+#, fuzzy
+msgid "Automated Install"
+msgstr "Instalación automática"
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Retroceder"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr "Siguiente"
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr "Escriba aquí para probar la distribución del teclado"
+
+#: live-installer/frontend/gtk_interface.py:546
+#, fuzzy
+msgid "Erase a disk and install system on it."
+msgstr "Borrar un disco e instalar 17G en él."
+
+#: live-installer/frontend/gtk_interface.py:559
+#, fuzzy
+msgid "Manually create, resize or choose partitions for system."
+msgstr "Crear, redimensionar o elegir particiones de 17G manualmente."
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Editar particiones"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Dispositivo"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Sistema operativo"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Punto de montaje"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Formatear como"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Tamaño"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Espacio libre"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr "Advertencia"
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr "Esto eliminará todos los datos en %s. ¿Está seguro?"
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Instalar"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr "Indique una frase de acceso para el cifrado."
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Sus contraseñas no coinciden."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "¿Salir?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "¿Seguro que quiere abandonar el instalador?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Elija un idioma"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Introduzca un nombre para su equipo."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Entre su nombre completo."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Sus contraseñas no coinciden."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "La partición EFI es demasiado pequeña. Debe tener al menos 35 MB."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Indique una partición raíz (/)."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, fuzzy, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+"Se necesita una partición raíz donde instalar Linux Mint.\n"
+"\n"
+" - Punto de montaje:/\n"
+" - Tamaño recomendado: 30 GB\n"
+" - Sistema de ficheros recomendado: ext4\n"
+"\n"
+"Nota: La función de instantáneas btrfs timeshift requiere el uso de:\n"
+" - Punto de montaje de subvolumen /@\n"
+" - Sistema de ficheros btrfs\n"
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+"La partición EFI no es de arranque. Por favor, edite las opciones de la "
+"partición."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "La partición EFI es demasiado pequeña. Debe tener al menos 35 MB."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "La partición EFI debe tener formato vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Seleccione una partición EFI."
+
+#: live-installer/frontend/gtk_interface.py:1301
+#, fuzzy
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+"Se necesita una partición de sistema EFI con los siguientes requisitos:\n"
+"\n"
+"  - Punto de montaje: /boot/efi\n"
+"  - Flags de partición: arrancable\n"
+"  - Tamaño: al menos 35 MB (se recomiendan 100 MB o más)\n"
+"  - Formato: vfat o fat32\n"
+" "
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr "Elija un disco."
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Entre un nombre de usuario."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Regionalización"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Idioma: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Zona horaria: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Distribución del teclado: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Configuración del usuario"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Nombre real: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Nombre de usuario: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Inicio de sesión automático: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "activado"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "desactivado"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Configuración del sistema"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr "Nombre del equipo: "
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+#, fuzzy
+msgid "Install updates after installation"
+msgstr "Instalación automática"
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Operaciones del sistema de archivos"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Instalar gestor de arranque en %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "No instalar el gestor de arranque"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Usar /target ya montado"
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr "Instalación automatizada en %s"
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Formatear %(path)s como %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Montar %(path)s como %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Montar %(path)s como %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr "LVM: "
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr "Cifrado de disco: "
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Instalación finalizada"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"La instalación se ha completado. ¿Quiere reiniciar el equipo para utilizar "
+"el nuevo sistema?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Error de instalación"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Extraíble:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Editar"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Asignar a /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"No se pudo escribir la tabla de partición de %s. Reinicie el equipo e "
+"inténtelo de nuevo."
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"No se pudo crear la partición %s. La instalación se detendrá. Reinicie el "
+"equipo e inténtelo de nuevo."
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Partición lógica"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Partición extendida"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Desconocido"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Editar partición"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Editar partición"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Dispositivo:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Formatear como:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Punto de montaje:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
+msgstr ""
 
 #: live-installer/validate.py:12
 msgid "Please provide a username."
@@ -432,10 +1176,6 @@ msgstr "Sus contraseñas no coinciden."
 msgid "Please provide a password for your user account."
 msgstr "Entre una contraseña para su cuenta de usuario."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -462,7 +1202,7 @@ msgstr "Creación de una cuenta de usuario"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Escritura de información de montaje en /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Montando %(partition)s en %(mountpoint)s"
@@ -484,49 +1224,49 @@ msgstr "Creando particiones en %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formateando %(partition)s como %(format)s..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Estableciendo nombre del equipo"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Estableciendo configuración regional"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Estableciendo nombre del equipo"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Estableciendo las opciones del teclado"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Eliminando la configuración viva (paquetes)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Instalando el gestor de arranque"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Configurando gestor de arranque"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -534,671 +1274,17 @@ msgstr ""
 "AVISO: El gestor de arranque GRUB no se ha configurado correctamente. Es "
 "necesario que lo configure de forma manual."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Instalación finalizada"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Comprobando gestor de arranque"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "País"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Idioma"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Distribución"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Variante"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Indexando ficheros ..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr "Instalador"
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr "¿Qué idioma desea usar?"
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr "¿Dónde se encuentra?"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Distribución del teclado"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr "¿Cuál es la distribución de su teclado?"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr "Cuenta de usuario"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr "¿Quién es usted?"
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr "Tipo de instalación"
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "¿Dónde quiere instalar 17G?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Particionado"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Resumen"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr "Instalando"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-#, fuzzy
-msgid "Automated install"
-msgstr "Instalación automática"
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Retroceder"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr "Siguiente"
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, fuzzy, python-format
-msgid "Welcome to the %s Installer."
-msgstr "Bienvenid@ al instalador de 17G."
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr "Escriba aquí para probar la distribución del teclado"
-
-#: live-installer/frontend/gtk_interface.py:542
-#, fuzzy
-msgid "Erase a disk and install system on it."
-msgstr "Borrar un disco e instalar 17G en él."
-
-#: live-installer/frontend/gtk_interface.py:555
-#, fuzzy
-msgid "Manually create, resize or choose partitions for system."
-msgstr "Crear, redimensionar o elegir particiones de 17G manualmente."
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Editar particiones"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Dispositivo"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Tipo"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Sistema operativo"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Punto de montaje"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Formatear como"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Tamaño"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Espacio libre"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Instalar"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr "Indique una frase de acceso para el cifrado."
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Sus contraseñas no coinciden."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "¿Salir?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "¿Seguro que quiere abandonar el instalador?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Elija un idioma"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Introduzca un nombre para su equipo."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Entre su nombre completo."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Sus contraseñas no coinciden."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "La partición EFI es demasiado pequeña. Debe tener al menos 35 MB."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Indique una partición raíz (/)."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, fuzzy, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-"Se necesita una partición raíz donde instalar Linux Mint.\n"
-"\n"
-" - Punto de montaje:/\n"
-" - Tamaño recomendado: 30 GB\n"
-" - Sistema de ficheros recomendado: ext4\n"
-"\n"
-"Nota: La función de instantáneas btrfs timeshift requiere el uso de:\n"
-" - Punto de montaje de subvolumen /@\n"
-" - Sistema de ficheros btrfs\n"
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-"La partición EFI no es de arranque. Por favor, edite las opciones de la "
-"partición."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "La partición EFI es demasiado pequeña. Debe tener al menos 35 MB."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "La partición EFI debe tener formato vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Seleccione una partición EFI."
-
-#: live-installer/frontend/gtk_interface.py:1226
-#, fuzzy
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-"Se necesita una partición de sistema EFI con los siguientes requisitos:\n"
-"\n"
-"  - Punto de montaje: /boot/efi\n"
-"  - Flags de partición: arrancable\n"
-"  - Tamaño: al menos 35 MB (se recomiendan 100 MB o más)\n"
-"  - Formato: vfat o fat32\n"
-" "
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr "Elija un disco."
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr "Advertencia"
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr "Esto eliminará todos los datos en %s. ¿Está seguro?"
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Entre un nombre de usuario."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Regionalización"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Idioma: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Zona horaria: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Distribución del teclado: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Configuración del usuario"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Nombre real: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Nombre de usuario: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Inicio de sesión automático: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "activado"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "desactivado"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Configuración del sistema"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr "Nombre del equipo: "
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-#, fuzzy
-msgid "Install updates after installation"
-msgstr "Instalación automática"
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Operaciones del sistema de archivos"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Instalar gestor de arranque en %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "No instalar el gestor de arranque"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Usar /target ya montado"
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr "Instalación automatizada en %s"
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Formatear %(path)s como %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Montar %(path)s como %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr "LVM: "
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr "Cifrado de disco: "
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"La instalación se ha completado. ¿Quiere reiniciar el equipo para utilizar "
-"el nuevo sistema?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Error de instalación"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, fuzzy, python-format
-msgid "Welcome to %s"
-msgstr "Bienvenid@"
-
-#: live-installer/frontend/tui_interface.py:57
-#, fuzzy
-msgid "What keyboard would you like to use?"
-msgstr "¿Qué idioma desea usar?"
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Modelo de teclado:"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Tipo de instalación"
-
-#: live-installer/frontend/tui_interface.py:80
-#, fuzzy
-msgid "Select a disk?"
-msgstr "Elija un disco."
-
-#: live-installer/frontend/tui_interface.py:84
-#, fuzzy
-msgid "Disk"
-msgstr "Disco:"
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Zona horaria"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Extraíble:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Editar"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Asignar a /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"No se pudo escribir la tabla de partición de %s. Reinicie el equipo e "
-"inténtelo de nuevo."
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"No se pudo crear la partición %s. La instalación se detendrá. Reinicie el "
-"equipo e inténtelo de nuevo."
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Partición lógica"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Partición extendida"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Desconocido"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Editar partición"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Editar partición"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Dispositivo:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Formatear como:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Punto de montaje:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "Aceptar"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "No"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Sí"
 
 #~ msgid "Quit"
 #~ msgstr "Salir"

--- a/po/live-installer-es.po
+++ b/po/live-installer-es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2020-03-09 21:47+0000\n"
 "Last-Translator: Isidro Pisa <isidro@utils.info>\n"
 "Language-Team: Spanish <es@li.org>\n"
@@ -94,7 +94,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -196,9 +196,9 @@ msgid "Format"
 msgstr "Formatear como"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -303,6 +303,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Formatear como"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -334,8 +340,8 @@ msgstr "Bienvenid@"
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "Aceptar"
 
@@ -427,23 +433,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr "Bienvenid@"
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "País"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Distribución"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Variante"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Indexando ficheros ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Extraíble:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Editar"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Asignar a /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -461,10 +538,108 @@ msgstr "Indexando ficheros ..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr "Instalador"
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Espacio libre"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"No se pudo escribir la tabla de partición de %s. Reinicie el equipo e "
+"inténtelo de nuevo."
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"No se pudo crear la partición %s. La instalación se detendrá. Reinicie el "
+"equipo e inténtelo de nuevo."
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Partición lógica"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Partición extendida"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Desconocido"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Editar partición"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Editar partición"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Dispositivo:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Formatear como:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Punto de montaje:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "País"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Distribución"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variante"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Indexando ficheros ..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -582,18 +757,6 @@ msgstr "Formatear como"
 msgid "Size"
 msgstr "Tamaño"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Espacio libre"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -626,25 +789,6 @@ msgstr "¿Salir?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "¿Seguro que quiere abandonar el instalador?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -904,7 +1048,7 @@ msgid "Disk Encryption: "
 msgstr "Cifrado de disco: "
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Instalación finalizada"
 
@@ -925,143 +1069,6 @@ msgstr "Error de instalación"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Extraíble:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Editar"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Asignar a /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"No se pudo escribir la tabla de partición de %s. Reinicie el equipo e "
-"inténtelo de nuevo."
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"No se pudo crear la partición %s. La instalación se detendrá. Reinicie el "
-"equipo e inténtelo de nuevo."
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Partición lógica"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Partición extendida"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Desconocido"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Editar partición"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Editar partición"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Dispositivo:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Formatear como:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Punto de montaje:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1224,49 +1231,49 @@ msgstr "Creando particiones en %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formateando %(partition)s como %(format)s..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Estableciendo nombre del equipo"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Estableciendo configuración regional"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Estableciendo nombre del equipo"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Estableciendo las opciones del teclado"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Eliminando la configuración viva (paquetes)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Instalando el gestor de arranque"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Configurando gestor de arranque"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1274,15 +1281,15 @@ msgstr ""
 "AVISO: El gestor de arranque GRUB no se ha configurado correctamente. Es "
 "necesario que lo configure de forma manual."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Comprobando gestor de arranque"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-et.po
+++ b/po/live-installer-et.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2018-08-17 07:03+0000\n"
 "Last-Translator: mahfiaz <mahfiaz@gmail.com>\n"
 "Language-Team: Estonian <et@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -189,9 +189,9 @@ msgid "Format"
 msgstr "Vorminda kui"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -295,6 +295,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Vorminda kui"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -325,8 +331,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "Olgu"
 
@@ -415,23 +421,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Riik"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Paigutus"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Variant"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Failiindeksite arvutamine ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Eemaldatav:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Redigeeri"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Määra haakepunktiks /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -449,10 +526,104 @@ msgstr "Failiindeksite arvutamine ..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Vaba ruum"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Loogiline partitsioon"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Laiendatud partitsioon"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Tundmatu"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Muuda partitsiooni"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Muuda partitsiooni"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Seade:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Vorminda kohas:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Ühenduspunkt:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Loobu"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Riik"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Paigutus"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Failiindeksite arvutamine ..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -567,18 +738,6 @@ msgstr "Vorminda kui"
 msgid "Size"
 msgstr "Suurus"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Vaba ruum"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -611,25 +770,6 @@ msgstr "Kas lõpetada?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Kas sa oled kindel, et tahad paigaldajast väljuda?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -869,7 +1009,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Paigaldamine on lõpetatud"
 
@@ -890,139 +1030,6 @@ msgstr "Paigaldamisviga"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Eemaldatav:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Redigeeri"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Määra haakepunktiks /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Loogiline partitsioon"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Laiendatud partitsioon"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Tundmatu"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Muuda partitsiooni"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Muuda partitsiooni"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Seade:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Vorminda kohas:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Ühenduspunkt:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Loobu"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1181,49 +1188,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Partitsiooni %(partition)s vormindamine (%(format)s) ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Arvuti nime määramine"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Lokaadi määramine"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Arvuti nime määramine"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Klahvistikuvalikute määramine"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Live seadete eemaldamine (paketid)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Alglaaduri paigaldamine"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Alglaaduri seadistamine"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1231,15 +1238,15 @@ msgstr ""
 "HOIATUS: Grubi alglaadur pole õigesti seadistatud! Sa pead selle käsitsi "
 "seadistama."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Alglaaduri kontrollimine"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-et.po
+++ b/po/live-installer-et.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2018-08-17 07:03+0000\n"
 "Last-Translator: mahfiaz <mahfiaz@gmail.com>\n"
 "Language-Team: Estonian <et@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Ajavöönd"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Muuda partitsiooni"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Ekspertrežiim"
@@ -149,142 +151,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Värskenda"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Vorminda kui"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Muuda partitsioone"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Automaatne sisselogimine"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -313,6 +321,712 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "Olgu"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Ei"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Jah"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Ajavöönd"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Keel"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Klaviatuuri paigutus"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Paigaldamine paetatud"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Tüüp"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Riik"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Paigutus"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Failiindeksite arvutamine ..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Klaviatuuri paigutus"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Kas sa oled kindel, et tahad paigaldajast väljuda?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Partitsioonid"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Kokkuvõte"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Tagasi"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Muuda partitsioone"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Seade"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Opsüsteem"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Haakepunkt"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Vorminda kui"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Suurus"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Vaba ruum"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Paigalda"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Sinu paroolid ei klapi."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Kas lõpetada?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Kas sa oled kindel, et tahad paigaldajast väljuda?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Palun vali keel"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Palun sisesta oma kasutajakonto jaoks parool."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Palun sisesta oma täisnimi."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Sinu paroolid ei klapi."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "EFI partitsioon ei ole alglaaditav. Palun muuda partitsiooni lippe."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Palun vali root (/) partitsioon."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "EFI partitsioon ei ole alglaaditav. Palun muuda partitsiooni lippe."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "EFI partitsiooni vorming peab olema vfat."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "EFI partitsiooni vorming peab olema vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Palun vali EFI partitsioon."
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Palun sisesta kasutajanimi."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Asukoha seadistamine"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Keel: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Ajavöönd: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Klaviatuuriasetus: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Kasutaja seaded"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Pärisnimi: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Kasutajanimi: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Automaatne logimine: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "lubatud"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "keelatud"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Süsteemi seaded"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Failisüsteemi toimingud"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Paigalda alglaadia %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Alglaadurit ei paigaldata"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Kasuta juba haagitud sihtkohta /target."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Vorminda %(path)s vormingusse %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Haagi %(path)s kohale %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Haagi %(path)s kohale %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Paigaldamine on lõpetatud"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Paigaldamine õnnestus. Kas soovite taaskäivitada oma arvuti ja kasutada uut "
+"süsteemi?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Paigaldamisviga"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Eemaldatav:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Redigeeri"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Määra haakepunktiks /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Loogiline partitsioon"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Laiendatud partitsioon"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Tundmatu"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Muuda partitsiooni"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Muuda partitsiooni"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Seade:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Vorminda kohas:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Ühenduspunkt:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Loobu"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -421,10 +1135,6 @@ msgstr "Sinu paroolid ei klapi."
 msgid "Please provide a password for your user account."
 msgstr "Palun sisesta oma kasutajakonto jaoks parool."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -451,7 +1161,7 @@ msgstr "Uue kasutaja lisamine süsteemi"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Failisüsteemide haakimise andmete kirjutamine faili /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Partitsiooni %(partition)s haakimine asukohta %(mountpoint)s"
@@ -471,49 +1181,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Partitsiooni %(partition)s vormindamine (%(format)s) ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Arvuti nime määramine"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Lokaadi määramine"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Arvuti nime määramine"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Klahvistikuvalikute määramine"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Live seadete eemaldamine (paketid)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Alglaaduri paigaldamine"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Alglaaduri seadistamine"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -521,641 +1231,17 @@ msgstr ""
 "HOIATUS: Grubi alglaadur pole õigesti seadistatud! Sa pead selle käsitsi "
 "seadistama."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Paigaldamine on lõpetatud"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Alglaaduri kontrollimine"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Riik"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Keel"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Paigutus"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Variant"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Failiindeksite arvutamine ..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Klaviatuuri paigutus"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Kas sa oled kindel, et tahad paigaldajast väljuda?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Partitsioonid"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Kokkuvõte"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Tagasi"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Muuda partitsioone"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Seade"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Tüüp"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Opsüsteem"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Haakepunkt"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Vorminda kui"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Suurus"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Vaba ruum"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Paigalda"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Sinu paroolid ei klapi."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Kas lõpetada?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Kas sa oled kindel, et tahad paigaldajast väljuda?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Palun vali keel"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Palun sisesta oma kasutajakonto jaoks parool."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Palun sisesta oma täisnimi."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Sinu paroolid ei klapi."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "EFI partitsioon ei ole alglaaditav. Palun muuda partitsiooni lippe."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Palun vali root (/) partitsioon."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "EFI partitsioon ei ole alglaaditav. Palun muuda partitsiooni lippe."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "EFI partitsiooni vorming peab olema vfat."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "EFI partitsiooni vorming peab olema vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Palun vali EFI partitsioon."
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Palun sisesta kasutajanimi."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Asukoha seadistamine"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Keel: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Ajavöönd: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Klaviatuuriasetus: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Kasutaja seaded"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Pärisnimi: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Kasutajanimi: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Automaatne logimine: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "lubatud"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "keelatud"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Süsteemi seaded"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Failisüsteemi toimingud"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Paigalda alglaadia %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Alglaadurit ei paigaldata"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Kasuta juba haagitud sihtkohta /target."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Vorminda %(path)s vormingusse %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Haagi %(path)s kohale %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Paigaldamine õnnestus. Kas soovite taaskäivitada oma arvuti ja kasutada uut "
-"süsteemi?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Paigaldamisviga"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Klaviatuuri paigutus"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Paigaldamine paetatud"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Ajavöönd"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Eemaldatav:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Redigeeri"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Määra haakepunktiks /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Loogiline partitsioon"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Laiendatud partitsioon"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Tundmatu"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Muuda partitsiooni"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Muuda partitsiooni"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Seade:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Vorminda kohas:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Ühenduspunkt:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Loobu"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "Olgu"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Ei"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Jah"
 
 #~ msgid "Quit"
 #~ msgstr "Sulge"

--- a/po/live-installer-eu.po
+++ b/po/live-installer-eu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2020-02-27 20:31+0000\n"
 "Last-Translator: Asier Iturralde Sarasola <Unknown>\n"
 "Language-Team: Basque <eu@li.org>\n"
@@ -95,7 +95,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -197,9 +197,9 @@ msgid "Format"
 msgstr "Formateatu honela"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -304,6 +304,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Formateatu honela"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -335,8 +341,8 @@ msgstr "Ongi etorri"
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "Ados"
 
@@ -428,23 +434,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr "Ongi etorri"
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Herrialdea"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Diseinua"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Aldaera"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Fitxategien indizeak kalkulatzen..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Aldagarria:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Editatu"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Esleitu honi: /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -462,10 +539,104 @@ msgstr "Fitxategien indizeak kalkulatzen..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr "Instalatzailea"
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Leku librea"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Partizio logikoa"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Partizio hedatua"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Ezezaguna"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Editatu partizioa"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Editatu partizioa"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Gailua:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Formateatu honela:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Muntatze-puntua:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Utzi"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Herrialdea"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Diseinua"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Aldaera"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Fitxategien indizeak kalkulatzen..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -583,18 +754,6 @@ msgstr "Formateatu honela"
 msgid "Size"
 msgstr "Tamaina"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Leku librea"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -627,25 +786,6 @@ msgstr "Irten?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Ziur zaude instalatzailetik irten nahi duzula?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -907,7 +1047,7 @@ msgid "Disk Encryption: "
 msgstr "Diskoa enkriptatzea: "
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Instalazioa bukatuta"
 
@@ -928,139 +1068,6 @@ msgstr "Instalazio-errorea"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Aldagarria:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Editatu"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Esleitu honi: /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Partizio logikoa"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Partizio hedatua"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Ezezaguna"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Editatu partizioa"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Editatu partizioa"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Gailua:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Formateatu honela:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Muntatze-puntua:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Utzi"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1221,49 +1228,49 @@ msgstr "Partizioak sortzen %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "%(partition)s partizioa %(format)s bezala formateatzen..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Ekipoaren izena prestatzen"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Konfigurazio lokala ezartzen"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Ekipoaren izena prestatzen"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Teklatuaren hautapenak ezartzen"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Konfigurazio bizia kentzen (paketeak)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Abioko kargatzailea instalatzen"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Abioko kargatzailea konfiguratzen"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1271,15 +1278,15 @@ msgstr ""
 "OHARRA: GRUB abioko kargatzailea ez da konfiguratu behar bezala! Eskuz "
 "konfiguratu behar duzu."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Abioko kargatzailea egiaztatzen"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-eu.po
+++ b/po/live-installer-eu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2020-02-27 20:31+0000\n"
 "Last-Translator: Asier Iturralde Sarasola <Unknown>\n"
 "Language-Team: Basque <eu@li.org>\n"
@@ -24,8 +24,8 @@ msgid "Welcome to the 17g Installer."
 msgstr "Ongi etorri 17G instalatzailera"
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 #, fuzzy
 msgid ""
 "This program will ask you some questions and set up system on your computer."
@@ -34,12 +34,12 @@ msgstr ""
 "ordenagailuan."
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr "Teklatu-modeloa:"
 
@@ -49,10 +49,12 @@ msgid "Type here to test your keyboard"
 msgstr "Idatzi hemen zure teklatuaren diseinua probatzeko"
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -61,13 +63,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Ordu-eremua"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr "Instalazio automatizatua"
 
@@ -77,12 +79,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr "Garbitu disko bat eta instalatu 17G bertan"
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr "Diskoa:"
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Editatu partizioa"
@@ -93,42 +95,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr "Erabili LVM (Logical Volume Management)"
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr "Enkriptatu sistema eragilea"
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr "Pasaesaldia"
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr "Berretsi pasaesaldia"
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr "Eskuzko partizioak"
 
@@ -146,7 +148,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Aditu modua"
@@ -156,144 +158,150 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 #, fuzzy
 msgid "Minimal installation"
 msgstr "Instalazio automatizatua"
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Freskatu"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Formateatu honela"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr "Instalatu GRUB abioko menua hemen:"
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Editatu partizioak"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr "Zure izena:"
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr "Zure ordenagailuaren izena:"
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr "Aukeratu erabiltzaile-izena:"
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr "Beste ordenagailuekin konektatzean erabiltzen den izena."
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr "Aukeratu pasahitza:"
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Hasi saioa automatikoki"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr "Eskatu pasahitza saioa hasteko"
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr "Enkriptatu karpeta nagusia"
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr "Berretsi zure pasahitza:"
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 #, fuzzy
 msgid "Automated installation enabled!"
 msgstr "Instalazio automatizatua %s(e)n"
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr "Ongi etorri"
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -324,6 +332,740 @@ msgstr ""
 #, fuzzy
 msgid "Welcome to 17g"
 msgstr "Ongi etorri"
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "Ados"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Ez"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Bai"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Ordu-eremua"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, fuzzy, python-format
+msgid "Welcome to the %s Installer."
+msgstr "Ongi etorri 17G instalatzailera"
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr "Ze hizkuntza erabili nahi duzu?"
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Hizkuntza"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr "Non zaude?"
+
+#: live-installer/frontend/tui_interface.py:57
+#, fuzzy
+msgid "What keyboard would you like to use?"
+msgstr "Ze hizkuntza erabili nahi duzu?"
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Teklatu-modeloa:"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Instalazio-mota"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Mota"
+
+#: live-installer/frontend/tui_interface.py:80
+#, fuzzy
+msgid "Select a disk?"
+msgstr "Sartu disko bat."
+
+#: live-installer/frontend/tui_interface.py:84
+#, fuzzy
+msgid "Disk"
+msgstr "Diskoa:"
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, fuzzy, python-format
+msgid "Welcome to %s"
+msgstr "Ongi etorri"
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Herrialdea"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Diseinua"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Aldaera"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Fitxategien indizeak kalkulatzen..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr "Instalatzailea"
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Teklatuaren diseinua"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr "Zein da zure teklatuaren diseinua?"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr "Erabiltzaile-kontua"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr "Nor zara?"
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr "Instalazio-mota"
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Non instalatu nahi duzu 17G?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Partizioak egitea"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Laburpena"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr "Instalatzen"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+#, fuzzy
+msgid "Automated Install"
+msgstr "Instalazio automatizatua"
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Atzera"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr "Hurrengoa"
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr "Idatzi hemen zure teklatuaren diseinua probatzeko"
+
+#: live-installer/frontend/gtk_interface.py:546
+#, fuzzy
+msgid "Erase a disk and install system on it."
+msgstr "Garbitu disko bat eta instalatu 17G bertan"
+
+#: live-installer/frontend/gtk_interface.py:559
+#, fuzzy
+msgid "Manually create, resize or choose partitions for system."
+msgstr "Eskuz sortu, aldatu tamainaz edo aukeratu 17Grentzako partizioak."
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Editatu partizioak"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Gailua"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Sistema eragilea"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Muntatze-puntua"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Formateatu honela"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Tamaina"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Leku librea"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr "Abisua"
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr "Honek %s(e)ko datu guztiak ezabatuko ditu. Ziur zaude?"
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Instalatu"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr "Sartu pasaesaldi bat enkriptatzeko."
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Pasahitzak ez datoz bat."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Irten?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Ziur zaude instalatzailetik irten nahi duzula?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Mesedez aukeratu hizkuntza"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Sartu zure ordenagailuak izango duen izena."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Mesedez idatzi zure izen osoa."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Pasahitzak ez datoz bat."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "EFI partizioa txikiegia da. Gutxienez 35MB izan behar ditu."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Hautatu erro (/) partizioa"
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, fuzzy, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+"Erro partizio bat behar da bertan Linux Mint instalatzeko.\n"
+"\n"
+" - Muntatze-puntua: /\n"
+" - Gomendatutako tamaina: 30GB\n"
+" - Gomendatutako fitxategi-sistema formatua: ext4\n"
+"\n"
+"Oharra: timeshift btrfs argazkien ezaugarriak ondorengoak erabiltzea "
+"eskatzen du:\n"
+" - azpi-bolumen muntatze-puntua /@\n"
+" - btrfs fitxategi-sistema formatu bezala\n"
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "EFI partizioa ez da abiagarria. Mesedez editatu partizioaren banderak."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "EFI partizioa txikiegia da. Gutxienez 35MB izan behar ditu."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "EFI partizioak vfat formatua izan behar du."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Mesedez hautatu EFI partizioa."
+
+#: live-installer/frontend/gtk_interface.py:1301
+#, fuzzy
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+"Ondorengo ezaugarriak dituen EFI sistema partizio bat behar da:\n"
+"\n"
+" - Muntatze-puntua: /boot/efi\n"
+" - Partizioaren banderak: Bootable\n"
+" - Tamaina: gutxienez 35MB (100MB edo gehiago gomendatzen da)\n"
+" - Formatua: vfat edo fat32\n"
+"\n"
+"Windowsekin bateragarritasuna ziurtatzeko, diskoko lehen partizioa EFI "
+"sistemako partizio bezala erabiltzea gomendatzen da.\n"
+" "
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr "Sartu disko bat."
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Mesedez idatzi zure erabiltzaile-izena."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Kokapena"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Hizkuntza "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Ordu zona: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Teklatuaren diseinua: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Erabiltzailearen ezarpenak"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Benetako izena: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Erabiltzaile-izena: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Saio-hasiera automatikoa: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "gaituta"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "desgaituta"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Sistemaren ezarpenak"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr "Ordenagailuaren izena: "
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+#, fuzzy
+msgid "Install updates after installation"
+msgstr "Instalazio automatizatua"
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Fitxategi-sistemaren eragiketak"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Instalatu abioko kargatzailea %s(e)n"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Ez instalatu abioko kargatzailerik"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Erabili dagoeneko muntatutako /target."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr "Instalazio automatizatua %s(e)n"
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Formateatu %(path)s %(filesystem)s bezala"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Muntatu %(path)s %(mount)s bezala"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Muntatu %(path)s %(mount)s bezala"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr "LVM: "
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr "Diskoa enkriptatzea: "
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Instalazioa bukatuta"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Instalazioa osatu da. Ordenagailua berrabiarazi nahi duzu zure sistema "
+"berria erabiltzen hasteko?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Instalazio-errorea"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Aldagarria:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Editatu"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Esleitu honi: /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Partizio logikoa"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Partizio hedatua"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Ezezaguna"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Editatu partizioa"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Editatu partizioa"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Gailua:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Formateatu honela:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Muntatze-puntua:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Utzi"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
+msgstr ""
 
 #: live-installer/validate.py:12
 msgid "Please provide a username."
@@ -433,10 +1175,6 @@ msgstr "Pasahitzak ez datoz bat."
 msgid "Please provide a password for your user account."
 msgstr "Mesedez idatzi zure kontuarentzako pasahitza."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -463,7 +1201,7 @@ msgstr "Sisteman erabiltzaile berria gehitzen"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Fitxategi-sistemaren muntatze informazioa /etc/fstab-en idazten"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "%(partition)s muntatzen %(mountpoint)s -(e)n"
@@ -483,49 +1221,49 @@ msgstr "Partizioak sortzen %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "%(partition)s partizioa %(format)s bezala formateatzen..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Ekipoaren izena prestatzen"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Konfigurazio lokala ezartzen"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Ekipoaren izena prestatzen"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Teklatuaren hautapenak ezartzen"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Konfigurazio bizia kentzen (paketeak)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Abioko kargatzailea instalatzen"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Abioko kargatzailea konfiguratzen"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -533,669 +1271,17 @@ msgstr ""
 "OHARRA: GRUB abioko kargatzailea ez da konfiguratu behar bezala! Eskuz "
 "konfiguratu behar duzu."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Instalazioa bukatuta"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Abioko kargatzailea egiaztatzen"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Herrialdea"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Hizkuntza"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Diseinua"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Aldaera"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Fitxategien indizeak kalkulatzen..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr "Instalatzailea"
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr "Ze hizkuntza erabili nahi duzu?"
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr "Non zaude?"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Teklatuaren diseinua"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr "Zein da zure teklatuaren diseinua?"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr "Erabiltzaile-kontua"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr "Nor zara?"
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr "Instalazio-mota"
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Non instalatu nahi duzu 17G?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Partizioak egitea"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Laburpena"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr "Instalatzen"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-#, fuzzy
-msgid "Automated install"
-msgstr "Instalazio automatizatua"
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Atzera"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr "Hurrengoa"
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, fuzzy, python-format
-msgid "Welcome to the %s Installer."
-msgstr "Ongi etorri 17G instalatzailera"
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr "Idatzi hemen zure teklatuaren diseinua probatzeko"
-
-#: live-installer/frontend/gtk_interface.py:542
-#, fuzzy
-msgid "Erase a disk and install system on it."
-msgstr "Garbitu disko bat eta instalatu 17G bertan"
-
-#: live-installer/frontend/gtk_interface.py:555
-#, fuzzy
-msgid "Manually create, resize or choose partitions for system."
-msgstr "Eskuz sortu, aldatu tamainaz edo aukeratu 17Grentzako partizioak."
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Editatu partizioak"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Gailua"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Mota"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Sistema eragilea"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Muntatze-puntua"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Formateatu honela"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Tamaina"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Leku librea"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Instalatu"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr "Sartu pasaesaldi bat enkriptatzeko."
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Pasahitzak ez datoz bat."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Irten?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Ziur zaude instalatzailetik irten nahi duzula?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Mesedez aukeratu hizkuntza"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Sartu zure ordenagailuak izango duen izena."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Mesedez idatzi zure izen osoa."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Pasahitzak ez datoz bat."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "EFI partizioa txikiegia da. Gutxienez 35MB izan behar ditu."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Hautatu erro (/) partizioa"
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, fuzzy, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-"Erro partizio bat behar da bertan Linux Mint instalatzeko.\n"
-"\n"
-" - Muntatze-puntua: /\n"
-" - Gomendatutako tamaina: 30GB\n"
-" - Gomendatutako fitxategi-sistema formatua: ext4\n"
-"\n"
-"Oharra: timeshift btrfs argazkien ezaugarriak ondorengoak erabiltzea "
-"eskatzen du:\n"
-" - azpi-bolumen muntatze-puntua /@\n"
-" - btrfs fitxategi-sistema formatu bezala\n"
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "EFI partizioa ez da abiagarria. Mesedez editatu partizioaren banderak."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "EFI partizioa txikiegia da. Gutxienez 35MB izan behar ditu."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "EFI partizioak vfat formatua izan behar du."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Mesedez hautatu EFI partizioa."
-
-#: live-installer/frontend/gtk_interface.py:1226
-#, fuzzy
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-"Ondorengo ezaugarriak dituen EFI sistema partizio bat behar da:\n"
-"\n"
-" - Muntatze-puntua: /boot/efi\n"
-" - Partizioaren banderak: Bootable\n"
-" - Tamaina: gutxienez 35MB (100MB edo gehiago gomendatzen da)\n"
-" - Formatua: vfat edo fat32\n"
-"\n"
-"Windowsekin bateragarritasuna ziurtatzeko, diskoko lehen partizioa EFI "
-"sistemako partizio bezala erabiltzea gomendatzen da.\n"
-" "
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr "Sartu disko bat."
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr "Abisua"
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr "Honek %s(e)ko datu guztiak ezabatuko ditu. Ziur zaude?"
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Mesedez idatzi zure erabiltzaile-izena."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Kokapena"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Hizkuntza "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Ordu zona: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Teklatuaren diseinua: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Erabiltzailearen ezarpenak"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Benetako izena: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Erabiltzaile-izena: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Saio-hasiera automatikoa: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "gaituta"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "desgaituta"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Sistemaren ezarpenak"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr "Ordenagailuaren izena: "
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-#, fuzzy
-msgid "Install updates after installation"
-msgstr "Instalazio automatizatua"
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Fitxategi-sistemaren eragiketak"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Instalatu abioko kargatzailea %s(e)n"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Ez instalatu abioko kargatzailerik"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Erabili dagoeneko muntatutako /target."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr "Instalazio automatizatua %s(e)n"
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Formateatu %(path)s %(filesystem)s bezala"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Muntatu %(path)s %(mount)s bezala"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr "LVM: "
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr "Diskoa enkriptatzea: "
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Instalazioa osatu da. Ordenagailua berrabiarazi nahi duzu zure sistema "
-"berria erabiltzen hasteko?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Instalazio-errorea"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, fuzzy, python-format
-msgid "Welcome to %s"
-msgstr "Ongi etorri"
-
-#: live-installer/frontend/tui_interface.py:57
-#, fuzzy
-msgid "What keyboard would you like to use?"
-msgstr "Ze hizkuntza erabili nahi duzu?"
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Teklatu-modeloa:"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Instalazio-mota"
-
-#: live-installer/frontend/tui_interface.py:80
-#, fuzzy
-msgid "Select a disk?"
-msgstr "Sartu disko bat."
-
-#: live-installer/frontend/tui_interface.py:84
-#, fuzzy
-msgid "Disk"
-msgstr "Diskoa:"
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Ordu-eremua"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Aldagarria:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Editatu"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Esleitu honi: /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Partizio logikoa"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Partizio hedatua"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Ezezaguna"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Editatu partizioa"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Editatu partizioa"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Gailua:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Formateatu honela:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Muntatze-puntua:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Utzi"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "Ados"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Ez"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Bai"
 
 #~ msgid "Quit"
 #~ msgstr "Irten"

--- a/po/live-installer-fa.po
+++ b/po/live-installer-fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2012-01-26 12:27+0000\n"
 "Last-Translator: Sari Galin <Unknown>\n"
 "Language-Team: Persian <fa@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -292,6 +292,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -322,8 +327,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -411,23 +416,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "چیدمان"
-
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "متغیر"
-
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -445,9 +521,103 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "فضای خالی"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "تنظیمات سیستم"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "چیدمان"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "متغیر"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -562,18 +732,6 @@ msgstr ""
 msgid "Size"
 msgstr "اندازه"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "فضای خالی"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -605,25 +763,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -858,7 +997,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "نصب به پایان رسید."
 
@@ -877,139 +1016,6 @@ msgstr "خطا در نصب"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "تنظیمات سیستم"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1155,49 +1161,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "در حال تنظیم نام میزبان"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "تنظیم بوم (محل)"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "در حال تنظیم نام میزبان"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "در حال تنظیم صفحه کلید"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "در حال حذف پیکربندی زنده (بسته‌ها)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "نصب بوت‌لودر"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "پیکربندی بوت لودر"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1205,15 +1211,15 @@ msgstr ""
 "اخطار: بوت لودر گراب به درستی پیکربندی نشده است! شما می بایست به صورت دستی "
 "آن را پیکر بندی کنید."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "بررسی بوت لودر"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-fa.po
+++ b/po/live-installer-fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2012-01-26 12:27+0000\n"
 "Last-Translator: Sari Galin <Unknown>\n"
 "Language-Team: Persian <fa@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,141 +149,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "تنظیمات سیستم"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -310,6 +318,702 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "چیدمان صفحه کلید: "
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "خطا در نصب"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "نوع"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "چیدمان"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "متغیر"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "دستگاه"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "سیستم عامل"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "نقطه‌ی سوارکردن"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "اندازه"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "فضای خالی"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "بومی کردن"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "زبان: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "ناحیه زمانی: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "چیدمان صفحه کلید: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "تنظیمات کاربر"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "نام واقعی: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "نام کاربری: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "تنظیمات سیستم"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "عملیات سیستم فایل"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "بوت‌کننده را نصب نکن"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "در حال نصب‌ %(partition)s روی %(mountpoint)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "نصب به پایان رسید."
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "خطا در نصب"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "تنظیمات سیستم"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -405,10 +1109,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -435,7 +1135,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "در حال نصب‌ %(partition)s روی %(mountpoint)s"
@@ -455,49 +1155,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "در حال تنظیم نام میزبان"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "تنظیم بوم (محل)"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "در حال تنظیم نام میزبان"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "در حال تنظیم صفحه کلید"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "در حال حذف پیکربندی زنده (بسته‌ها)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "نصب بوت‌لودر"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "پیکربندی بوت لودر"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -505,630 +1205,16 @@ msgstr ""
 "اخطار: بوت لودر گراب به درستی پیکربندی نشده است! شما می بایست به صورت دستی "
 "آن را پیکر بندی کنید."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "نصب به پایان رسید."
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "بررسی بوت لودر"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "چیدمان"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "متغیر"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "دستگاه"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "نوع"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "سیستم عامل"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "نقطه‌ی سوارکردن"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "اندازه"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "فضای خالی"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "بومی کردن"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "زبان: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "ناحیه زمانی: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "چیدمان صفحه کلید: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "تنظیمات کاربر"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "نام واقعی: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "نام کاربری: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "تنظیمات سیستم"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "عملیات سیستم فایل"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "بوت‌کننده را نصب نکن"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "خطا در نصب"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "چیدمان صفحه کلید: "
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "خطا در نصب"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "تنظیمات سیستم"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-fi.po
+++ b/po/live-installer-fi.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2020-03-04 21:19+0000\n"
 "Last-Translator: Kimmo Kujansuu <Unknown>\n"
 "Language-Team: Finnish <>\n"
@@ -25,8 +25,8 @@ msgid "Welcome to the 17g Installer."
 msgstr "Tervetuloa 17G-asennusohjelmaan"
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 #, fuzzy
 msgid ""
 "This program will ask you some questions and set up system on your computer."
@@ -35,12 +35,12 @@ msgstr ""
 "tietokoneeseesi."
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr "Näppäimistömalli:"
 
@@ -50,10 +50,12 @@ msgid "Type here to test your keyboard"
 msgstr "Kirjoita tähän testataksesi näppäimistön asettelua"
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -62,13 +64,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Aikavyöhyke"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr "Automatisoitu asennus"
 
@@ -78,12 +80,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr "Tyhjennä levy ja asenna sille 17G."
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr "Levy:"
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Muokkaa osiota"
@@ -94,42 +96,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "Gt"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr "Käytä LVM-asemanhallintaa (Logical Volume Management)"
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr "Salaa käyttöjärjestelmä"
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr "Tunnuslause"
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr "Vahvista tunnuslause"
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr "Luo oma osiorakenne"
 
@@ -147,7 +149,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Asiantuntijatila"
@@ -157,145 +159,151 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 #, fuzzy
 msgid "Minimal installation"
 msgstr "Automatisoitu asennus"
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Virkistä"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Alusta muotoon"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr "Asenna GRUB-käynnistysvalikko tänne:"
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Muokkaa osioita"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr "Nimesi:"
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr "Tietokoneen nimi:"
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr "Valitse käyttäjänimi:"
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 "Nimi jota käytetään tietokoneesi tunnistautumisessa toisille tietokoneille."
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr "Valitse salasana:"
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Kirjaudu sisään automaattisesti"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr "Vaadi salasana sisäänkirjautumiseen"
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr "Salaa kotikansioni"
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr "Vahvista salasanasi:"
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 #, fuzzy
 msgid "Automated installation enabled!"
 msgstr "Automatisoitu asennus kohteeseen %s"
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr "Tervetuloa"
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -326,6 +334,739 @@ msgstr ""
 #, fuzzy
 msgid "Welcome to 17g"
 msgstr "Tervetuloa"
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "OK"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Ei"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Kyllä"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Aikavyöhyke"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, fuzzy, python-format
+msgid "Welcome to the %s Installer."
+msgstr "Tervetuloa 17G-asennusohjelmaan"
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr "Mitä kieltä haluat käyttää?"
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Kieli"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr "Mikä on sijaintisi?"
+
+#: live-installer/frontend/tui_interface.py:57
+#, fuzzy
+msgid "What keyboard would you like to use?"
+msgstr "Mitä kieltä haluat käyttää?"
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Näppäimistömalli:"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Asennustapa"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Tyyppi"
+
+#: live-installer/frontend/tui_interface.py:80
+#, fuzzy
+msgid "Select a disk?"
+msgstr "Valitse levy."
+
+#: live-installer/frontend/tui_interface.py:84
+#, fuzzy
+msgid "Disk"
+msgstr "Levy:"
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, fuzzy, python-format
+msgid "Welcome to %s"
+msgstr "Tervetuloa"
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Maa"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Asettelu"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Muunnos"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Lasketaan tiedostoindeksejä..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr "Asennusohjelma"
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Näppäinasettelu"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr "Mikä on näppäimistösi asettelu?"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr "Käyttäjätili"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr "Kuka olet?"
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr "Asennustapa"
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Mihin haluat asentaa 17G:n?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Osiointi"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Yhteenveto"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr "Asennetaan"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+#, fuzzy
+msgid "Automated Install"
+msgstr "Automatisoitu asennus"
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Takaisin"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr "Seuraava"
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr "Kirjoita tähän testataksesi näppäimistön asettelua"
+
+#: live-installer/frontend/gtk_interface.py:546
+#, fuzzy
+msgid "Erase a disk and install system on it."
+msgstr "Tyhjennä levy ja asenna sille 17G."
+
+#: live-installer/frontend/gtk_interface.py:559
+#, fuzzy
+msgid "Manually create, resize or choose partitions for system."
+msgstr "Luo, muuta kokoa tai valitse osioita 17G:lle itsenäisesti."
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Muokkaa osioita"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Laite"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Käyttöjärjestelmä"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Liitospiste"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Alusta muotoon"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Koko"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Vapaa tila"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr "Varoitus"
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr "Tämä poistaa kaikki tiedot kohteessa %s. Oletko varma?"
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Asenna"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr "Luo tunnuslause salausta varten."
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Salasanat eivät täsmää."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Lopetetaanko?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Haluatko varmasti lopettaa asennuksen?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Valitse kieli"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Anna tietokoneellesi nimi."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Anna koko nimesi."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Salasanat eivät täsmää."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "EFI-osio on liian pieni. Sen tulee olla vähintään 35Mt."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Valitse juuriosio (/)."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, fuzzy, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+"Tarvitaan juuriosio johon Linux Mint asennetaan.\n"
+"\n"
+" - Kiinnityspiste: /\n"
+" - Suositeltu koko: 30Gt\n"
+" - Suositeltu tiedostojärjestelmän muoto: ext4\n"
+"\n"
+"Huomautus: Timeshift-ajassapalautus btrfs-järjestelmävedokset vaativat:\n"
+" - ali-aseman liitospisteen /@\n"
+" - btrfs tiedostojärjestelmämuodossa\n"
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "EFI-osio ei ole käynnistettävä. Muokkaa osion lippuja."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "EFI-osio on liian pieni. Sen tulee olla vähintään 35Mt."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "EFI-osion täytyy olla alustettu vfat-muotoon."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Valitse EFI-osio."
+
+#: live-installer/frontend/gtk_interface.py:1301
+#, fuzzy
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+"EFI-järjestelmäosio tarvitaan seuraavin vaatimuksin:\n"
+"\n"
+" - Liitospiste: /boot/efi\n"
+" - Osion liput: käynnistettävä\n"
+" - Koko: vähintään 35Mt (100Mt tai enemmän suositeltavaa)\n"
+" - Muoto: vfat tai fat32\n"
+"\n"
+"Varmistaaksesi yhteensopivuuden Windows:in kanssa, suosittelemme että käytät "
+"levyn ensimmäistä osiota EFI-järjestelmäosiona.\n"
+" "
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr "Valitse levy."
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Anna käyttäjätunnus."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Kotoistus"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Kieli: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Aikavyöhyke: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Näppäimistöasettelu: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Käyttäjäasetukset"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Oikea nimi: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Käyttäjänimi: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Automaattinen kirjautuminen: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "käytössä"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "poistettu käytöstä"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Järjestelmän asetukset"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr "Tietokoneen nimi: "
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+#, fuzzy
+msgid "Install updates after installation"
+msgstr "Automatisoitu asennus"
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Tiedostojärjestelmätoiminnot"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Asenna käynnistyslataaja levylle %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Älä asenna käynnistyslataajaa"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Käytä valmiiksi liitettyä /target:ia."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr "Automatisoitu asennus kohteeseen %s"
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Alusta %(path)s muotoon %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Liitä %(path)s kohtaan %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Liitä %(path)s kohtaan %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr "LVM: "
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr "Levysalaus: "
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Asennus on valmis"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Asennus on nyt valmis. Haluatko käynnistää tietokoneesi uudestaan ja käyttää "
+"uutta järjestelmää?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Asennusvirhe"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "t"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kt"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "Mt"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "Tt"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Irrotettava:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Muokkaa"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Liitä /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Looginen osio"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Laajennettu osio"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Tuntematon"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Muokkaa osiota"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Muokkaa osiota"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Laite:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Alusta muotoon:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Liitospiste:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Peru"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
+msgstr ""
 
 #: live-installer/validate.py:12
 msgid "Please provide a username."
@@ -435,10 +1176,6 @@ msgstr "Salasanat eivät täsmää."
 msgid "Please provide a password for your user account."
 msgstr "Anna käyttäjätilin salasana."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -465,7 +1202,7 @@ msgstr "Lisätään uusi käyttäjä järjestelmään"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Kirjoitetaan tiedostojärjestelmien liitostietoja tiedostoon /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Liitetään %(partition)s liitospisteeseen %(mountpoint)s"
@@ -485,49 +1222,49 @@ msgstr "Luodaan osioita %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Alustetaan %(partition)s %(format)s-tiedostojärjestelmäksi..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Asetetaan konenimi"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Asetetaan kieliasetukset"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Asetetaan konenimi"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Tehdään näppäimistöasetuksia"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Poistetaan live-asetukset (paketit)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Asennetaan käynnistyslataajaa"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Tehdään käynnistyslataajan asetuksia"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -535,668 +1272,17 @@ msgstr ""
 "VAROITUS: Grub-käynnistyslataajaa ei ole määritetty oikein! Sinun täytyy "
 "määrittää grubin asetukset käsin."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Asennus on valmis"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Tarkistetaan käynnistyslataajaa"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Maa"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Kieli"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Asettelu"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Muunnos"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Lasketaan tiedostoindeksejä..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr "Asennusohjelma"
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr "Mitä kieltä haluat käyttää?"
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr "Mikä on sijaintisi?"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Näppäinasettelu"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr "Mikä on näppäimistösi asettelu?"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr "Käyttäjätili"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr "Kuka olet?"
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr "Asennustapa"
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Mihin haluat asentaa 17G:n?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Osiointi"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Yhteenveto"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr "Asennetaan"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-#, fuzzy
-msgid "Automated install"
-msgstr "Automatisoitu asennus"
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Takaisin"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr "Seuraava"
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, fuzzy, python-format
-msgid "Welcome to the %s Installer."
-msgstr "Tervetuloa 17G-asennusohjelmaan"
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr "Kirjoita tähän testataksesi näppäimistön asettelua"
-
-#: live-installer/frontend/gtk_interface.py:542
-#, fuzzy
-msgid "Erase a disk and install system on it."
-msgstr "Tyhjennä levy ja asenna sille 17G."
-
-#: live-installer/frontend/gtk_interface.py:555
-#, fuzzy
-msgid "Manually create, resize or choose partitions for system."
-msgstr "Luo, muuta kokoa tai valitse osioita 17G:lle itsenäisesti."
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Muokkaa osioita"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Laite"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Tyyppi"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Käyttöjärjestelmä"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Liitospiste"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Alusta muotoon"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Koko"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Vapaa tila"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Asenna"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr "Luo tunnuslause salausta varten."
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Salasanat eivät täsmää."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Lopetetaanko?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Haluatko varmasti lopettaa asennuksen?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Valitse kieli"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Anna tietokoneellesi nimi."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Anna koko nimesi."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Salasanat eivät täsmää."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "EFI-osio on liian pieni. Sen tulee olla vähintään 35Mt."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Valitse juuriosio (/)."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, fuzzy, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-"Tarvitaan juuriosio johon Linux Mint asennetaan.\n"
-"\n"
-" - Kiinnityspiste: /\n"
-" - Suositeltu koko: 30Gt\n"
-" - Suositeltu tiedostojärjestelmän muoto: ext4\n"
-"\n"
-"Huomautus: Timeshift-ajassapalautus btrfs-järjestelmävedokset vaativat:\n"
-" - ali-aseman liitospisteen /@\n"
-" - btrfs tiedostojärjestelmämuodossa\n"
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "EFI-osio ei ole käynnistettävä. Muokkaa osion lippuja."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "EFI-osio on liian pieni. Sen tulee olla vähintään 35Mt."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "EFI-osion täytyy olla alustettu vfat-muotoon."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Valitse EFI-osio."
-
-#: live-installer/frontend/gtk_interface.py:1226
-#, fuzzy
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-"EFI-järjestelmäosio tarvitaan seuraavin vaatimuksin:\n"
-"\n"
-" - Liitospiste: /boot/efi\n"
-" - Osion liput: käynnistettävä\n"
-" - Koko: vähintään 35Mt (100Mt tai enemmän suositeltavaa)\n"
-" - Muoto: vfat tai fat32\n"
-"\n"
-"Varmistaaksesi yhteensopivuuden Windows:in kanssa, suosittelemme että käytät "
-"levyn ensimmäistä osiota EFI-järjestelmäosiona.\n"
-" "
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr "Valitse levy."
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr "Varoitus"
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr "Tämä poistaa kaikki tiedot kohteessa %s. Oletko varma?"
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Anna käyttäjätunnus."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Kotoistus"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Kieli: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Aikavyöhyke: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Näppäimistöasettelu: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Käyttäjäasetukset"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Oikea nimi: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Käyttäjänimi: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Automaattinen kirjautuminen: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "käytössä"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "poistettu käytöstä"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Järjestelmän asetukset"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr "Tietokoneen nimi: "
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-#, fuzzy
-msgid "Install updates after installation"
-msgstr "Automatisoitu asennus"
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Tiedostojärjestelmätoiminnot"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Asenna käynnistyslataaja levylle %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Älä asenna käynnistyslataajaa"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Käytä valmiiksi liitettyä /target:ia."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr "Automatisoitu asennus kohteeseen %s"
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Alusta %(path)s muotoon %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Liitä %(path)s kohtaan %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr "LVM: "
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr "Levysalaus: "
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Asennus on nyt valmis. Haluatko käynnistää tietokoneesi uudestaan ja käyttää "
-"uutta järjestelmää?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Asennusvirhe"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, fuzzy, python-format
-msgid "Welcome to %s"
-msgstr "Tervetuloa"
-
-#: live-installer/frontend/tui_interface.py:57
-#, fuzzy
-msgid "What keyboard would you like to use?"
-msgstr "Mitä kieltä haluat käyttää?"
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Näppäimistömalli:"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Asennustapa"
-
-#: live-installer/frontend/tui_interface.py:80
-#, fuzzy
-msgid "Select a disk?"
-msgstr "Valitse levy."
-
-#: live-installer/frontend/tui_interface.py:84
-#, fuzzy
-msgid "Disk"
-msgstr "Levy:"
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Aikavyöhyke"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "t"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kt"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "Mt"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "Tt"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Irrotettava:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Muokkaa"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Liitä /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Looginen osio"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Laajennettu osio"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Tuntematon"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Muokkaa osiota"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Muokkaa osiota"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Laite:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Alusta muotoon:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Liitospiste:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Peru"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "OK"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Ei"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Kyllä"
 
 #~ msgid "Quit"
 #~ msgstr "Lopeta"

--- a/po/live-installer-fi.po
+++ b/po/live-installer-fi.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2020-03-04 21:19+0000\n"
 "Last-Translator: Kimmo Kujansuu <Unknown>\n"
 "Language-Team: Finnish <>\n"
@@ -96,7 +96,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "Gt"
 
@@ -198,9 +198,9 @@ msgid "Format"
 msgstr "Alusta muotoon"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -306,6 +306,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Alusta muotoon"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -337,8 +343,8 @@ msgstr "Tervetuloa"
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "OK"
 
@@ -430,23 +436,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr "Tervetuloa"
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Maa"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "t"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Asettelu"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kt"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Muunnos"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "Mt"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Lasketaan tiedostoindeksejä..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "Tt"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Irrotettava:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Muokkaa"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Liitä /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -464,10 +541,104 @@ msgstr "Lasketaan tiedostoindeksejä..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr "Asennusohjelma"
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Vapaa tila"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Looginen osio"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Laajennettu osio"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Tuntematon"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Muokkaa osiota"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Muokkaa osiota"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Laite:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Alusta muotoon:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Liitospiste:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Peru"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Maa"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Asettelu"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Muunnos"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Lasketaan tiedostoindeksejä..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -585,18 +756,6 @@ msgstr "Alusta muotoon"
 msgid "Size"
 msgstr "Koko"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Vapaa tila"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -629,25 +788,6 @@ msgstr "Lopetetaanko?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Haluatko varmasti lopettaa asennuksen?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -908,7 +1048,7 @@ msgid "Disk Encryption: "
 msgstr "Levysalaus: "
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Asennus on valmis"
 
@@ -929,139 +1069,6 @@ msgstr "Asennusvirhe"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "t"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kt"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "Mt"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "Tt"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Irrotettava:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Muokkaa"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Liitä /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Looginen osio"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Laajennettu osio"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Tuntematon"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Muokkaa osiota"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Muokkaa osiota"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Laite:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Alusta muotoon:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Liitospiste:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Peru"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1222,49 +1229,49 @@ msgstr "Luodaan osioita %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Alustetaan %(partition)s %(format)s-tiedostojärjestelmäksi..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Asetetaan konenimi"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Asetetaan kieliasetukset"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Asetetaan konenimi"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Tehdään näppäimistöasetuksia"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Poistetaan live-asetukset (paketit)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Asennetaan käynnistyslataajaa"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Tehdään käynnistyslataajan asetuksia"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1272,15 +1279,15 @@ msgstr ""
 "VAROITUS: Grub-käynnistyslataajaa ei ole määritetty oikein! Sinun täytyy "
 "määrittää grubin asetukset käsin."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Tarkistetaan käynnistyslataajaa"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-fil.po
+++ b/po/live-installer-fil.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2015-03-22 17:14+0000\n"
 "Last-Translator: Ueliton <Unknown>\n"
 "Language-Team: Filipino <fil@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Sona ng oras"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,141 +149,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "I-refresh"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Mga setting para sa system"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -310,6 +318,703 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Sona ng oras"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Wika"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Pagkakalatag ng tipaan"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "May pagkakamali sa pag-iinstall"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Uri"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Bansa"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Ayos"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Baryante"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Pagkakalatag ng tipaan"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Paghahati"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Buod"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Aparato"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Operating system"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Mount point"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Laki"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Bakanteng espasyo"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Ikulong?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Lokalisasyon"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Wika: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Ang iyong Timezone: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Layout ng keyboard: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Mga setting para sa user"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Tunay na pangalan: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Username: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "hindi pinagana"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Mga setting para sa system"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Mga operasyon ng filesystem"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Huwag i-install ang bootloader"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Ikinakabit ang %(partition)s sa %(mountpoint)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Natapos na ang pag-iinstall"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "May pagkakamali sa pag-iinstall"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Mamatnugot"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Hindi alam"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Mga setting para sa system"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Aparato:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -405,10 +1110,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -435,7 +1136,7 @@ msgstr "Ang pagdaragdag ng bagong user sa system"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Ikinakabit ang %(partition)s sa %(mountpoint)s"
@@ -455,49 +1156,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Pag-format ng %(partition)s sa %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Itinatakda ang hostname"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Hanay ng lokasyon"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Itinatakda ang hostname"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Itinatakda ang mga option para sa keyboard"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Tinatanggal ang live configuration (packages)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Iniinstall ang bootloader"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Inaayos ang bootloader"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -505,631 +1206,16 @@ msgstr ""
 "BABALA: grub bootloader ay hindi naisaayos nang tama! Kailangan mo upang "
 "mano-manong i-configure ito."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Natapos na ang pag-iinstall"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Sinusuri bootloader"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Bansa"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Wika"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Ayos"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Baryante"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Pagkakalatag ng tipaan"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Paghahati"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Buod"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Aparato"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Uri"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Operating system"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Mount point"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Laki"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Bakanteng espasyo"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Ikulong?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Lokalisasyon"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Wika: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Ang iyong Timezone: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Layout ng keyboard: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Mga setting para sa user"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Tunay na pangalan: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Username: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "hindi pinagana"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Mga setting para sa system"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Mga operasyon ng filesystem"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Huwag i-install ang bootloader"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "May pagkakamali sa pag-iinstall"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Pagkakalatag ng tipaan"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "May pagkakamali sa pag-iinstall"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Sona ng oras"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Mamatnugot"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Hindi alam"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Mga setting para sa system"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Aparato:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-fil.po
+++ b/po/live-installer-fil.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2015-03-22 17:14+0000\n"
 "Last-Translator: Ueliton <Unknown>\n"
 "Language-Team: Filipino <fil@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -292,6 +292,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -322,8 +327,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -412,23 +417,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Bansa"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Ayos"
-
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Baryante"
-
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Mamatnugot"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -446,9 +522,103 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Bakanteng espasyo"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Hindi alam"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Mga setting para sa system"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Aparato:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Bansa"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Ayos"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Baryante"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -563,18 +733,6 @@ msgstr ""
 msgid "Size"
 msgstr "Laki"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Bakanteng espasyo"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -606,25 +764,6 @@ msgstr "Ikulong?"
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -859,7 +998,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Natapos na ang pag-iinstall"
 
@@ -878,139 +1017,6 @@ msgstr "May pagkakamali sa pag-iinstall"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Mamatnugot"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Hindi alam"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Mga setting para sa system"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Aparato:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1156,49 +1162,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Pag-format ng %(partition)s sa %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Itinatakda ang hostname"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Hanay ng lokasyon"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Itinatakda ang hostname"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Itinatakda ang mga option para sa keyboard"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Tinatanggal ang live configuration (packages)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Iniinstall ang bootloader"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Inaayos ang bootloader"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1206,15 +1212,15 @@ msgstr ""
 "BABALA: grub bootloader ay hindi naisaayos nang tama! Kailangan mo upang "
 "mano-manong i-configure ito."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Sinusuri bootloader"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-fo.po
+++ b/po/live-installer-fo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2011-08-20 10:11+0000\n"
 "Last-Translator: Gunleif Joensen <Unknown>\n"
 "Language-Team: Faroese <fo@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,141 +149,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Kervisstillingar"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -310,6 +318,702 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Knappaborðssnið: "
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Innleggingar brek"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Slag"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Snið"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Tóleind"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Stýrikervi"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Ísetingarpunkt"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Stødd"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Tøkt pláss"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Staðfesting"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Mál: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Tíðarøki: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Knappaborðssnið: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Brúkarainnstillingar"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Veruliga navn: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Brúkaranavn: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Kervisstillingar"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Fílukervsatgerðir"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Legg ikki inn byrjunarløðara"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Seti %(partition)s í á %(mountpoint)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Innlegging er liðug"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Innleggingar brek"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Kervisstillingar"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -405,10 +1109,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -435,7 +1135,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Seti %(partition)s í á %(mountpoint)s"
@@ -455,49 +1155,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Seti vertsnavn"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Seti staðfesti"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Seti vertsnavn"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Seti knappaborðskostir"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Taki burtur beinleiðis samanseting (pakkar)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Innleggi byrjunaløðara"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Samanseti byrjunarløðaran"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -505,630 +1205,16 @@ msgstr ""
 "ÁVARING: Grub-byrjunarløðarin varð ikki samansettur rætt! Tú verður nodd/ir "
 "samanseta hann handaliga."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Innlegging er liðug"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Royni byrjunarløðaran"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Snið"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Tóleind"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Slag"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Stýrikervi"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Ísetingarpunkt"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Stødd"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Tøkt pláss"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Staðfesting"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Mál: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Tíðarøki: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Knappaborðssnið: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Brúkarainnstillingar"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Veruliga navn: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Brúkaranavn: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Kervisstillingar"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Fílukervsatgerðir"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Legg ikki inn byrjunarløðara"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Innleggingar brek"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Knappaborðssnið: "
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Innleggingar brek"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Kervisstillingar"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-fo.po
+++ b/po/live-installer-fo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2011-08-20 10:11+0000\n"
 "Last-Translator: Gunleif Joensen <Unknown>\n"
 "Language-Team: Faroese <fo@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -292,6 +292,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -322,8 +327,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -411,23 +416,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Snið"
-
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -445,9 +521,103 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Tøkt pláss"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Kervisstillingar"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Snið"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -562,18 +732,6 @@ msgstr ""
 msgid "Size"
 msgstr "Stødd"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Tøkt pláss"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -605,25 +763,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -858,7 +997,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Innlegging er liðug"
 
@@ -877,139 +1016,6 @@ msgstr "Innleggingar brek"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Kervisstillingar"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1155,49 +1161,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Seti vertsnavn"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Seti staðfesti"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Seti vertsnavn"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Seti knappaborðskostir"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Taki burtur beinleiðis samanseting (pakkar)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Innleggi byrjunaløðara"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Samanseti byrjunarløðaran"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1205,15 +1211,15 @@ msgstr ""
 "ÁVARING: Grub-byrjunarløðarin varð ikki samansettur rætt! Tú verður nodd/ir "
 "samanseta hann handaliga."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Royni byrjunarløðaran"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-fr.po
+++ b/po/live-installer-fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2020-03-09 21:22+0000\n"
 "Last-Translator: Clement Lefebvre <root@linuxmint.com>\n"
 "Language-Team: French <fr@li.org>\n"
@@ -24,8 +24,8 @@ msgid "Welcome to the 17g Installer."
 msgstr "Bienvenue sur le programme d’installation de 17G"
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 #, fuzzy
 msgid ""
 "This program will ask you some questions and set up system on your computer."
@@ -34,12 +34,12 @@ msgstr ""
 "ordinateur."
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr "Modèle de clavier :"
 
@@ -49,10 +49,12 @@ msgid "Type here to test your keyboard"
 msgstr "Tapez ici pour tester la disposition de votre clavier"
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -61,13 +63,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Fuseau horaire"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr "Installation automatisée"
 
@@ -77,12 +79,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr "Effacer un disque et y installer 17G."
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr "Disque :"
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Modifier la partition"
@@ -93,42 +95,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "Go"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr "Utiliser LVM (gestion de volumes logiques)"
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr "Chiffrer le système d’exploitation"
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr "Phrase de passe"
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr "Confirmer la phrase de passe"
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr "Cela fournit d'avantage de sécurité mais ça peut prendre des heures."
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr "Remplir le disque avec des données aléatoires"
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr "Partitionnement manuel"
 
@@ -147,7 +149,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Mode expert"
@@ -157,144 +159,150 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 #, fuzzy
 msgid "Minimal installation"
 msgstr "Installation automatisée"
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Réactualiser"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Formater en"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr "Installer le menu d’amorçage GRUB sur :"
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Modifier les partitions"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr "Votre nom :"
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr "Le nom de votre ordinateur :"
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr "Choisissez un nom d’utilisateur :"
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr "Le nom qu’il utilise quand il communique avec d’autres ordinateurs."
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr "Choisissez un mot de passe :"
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Se connecter automatiquement"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr "Exiger mon mot de passe pour ouvrir une session"
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr "Chiffrer mon dossier personnel"
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr "Confirmez votre mot de passe :"
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 #, fuzzy
 msgid "Automated installation enabled!"
 msgstr "Installation automatisée sur %s"
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr "Bienvenue"
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -325,6 +333,745 @@ msgstr ""
 #, fuzzy
 msgid "Welcome to 17g"
 msgstr "Bienvenue"
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "OK"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Non"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Oui"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Fuseau horaire"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, fuzzy, python-format
+msgid "Welcome to the %s Installer."
+msgstr "Bienvenue sur le programme d’installation de 17G"
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr "Quelle langue souhaitez-vous utiliser ?"
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Langue"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr "Où vous trouvez-vous ?"
+
+#: live-installer/frontend/tui_interface.py:57
+#, fuzzy
+msgid "What keyboard would you like to use?"
+msgstr "Quelle langue souhaitez-vous utiliser ?"
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Modèle de clavier :"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Type d’installation"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Catégorie"
+
+#: live-installer/frontend/tui_interface.py:80
+#, fuzzy
+msgid "Select a disk?"
+msgstr "Veuillez sélectionner un disque."
+
+#: live-installer/frontend/tui_interface.py:84
+#, fuzzy
+msgid "Disk"
+msgstr "Disque :"
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, fuzzy, python-format
+msgid "Welcome to %s"
+msgstr "Bienvenue"
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Pays"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Disposition"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variante"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Indexation des fichiers ..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr "Programme d’installation"
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Disposition du clavier"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr "Quelle est la disposition de votre clavier ?"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr "Compte utilisateur"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr "Qui êtes-vous ?"
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr "Type d’installation"
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Où souhaitez-vous installer 17G ?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Partitionnement"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Résumé"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr "Installation"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+#, fuzzy
+msgid "Automated Install"
+msgstr "Installation automatisée"
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Retour"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr "Suivant"
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr "Tapez ici pour tester la disposition de votre clavier"
+
+#: live-installer/frontend/gtk_interface.py:546
+#, fuzzy
+msgid "Erase a disk and install system on it."
+msgstr "Effacer un disque et y installer 17G."
+
+#: live-installer/frontend/gtk_interface.py:559
+#, fuzzy
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+"Créez manuellement, redimensionnez ou sélectionnez des partitions pour 17G."
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Modifier les partitions"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Périphérique"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Système d'exploitation"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Point de montage"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Formater en"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Taille"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Espace libre"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr "Avertissement"
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+"Toutes les données de %s seront supprimées. Le souhaitez-vous vraiment ?"
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Installer"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr "Veuillez indiquer une phrase de passe pour le chiffrement."
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Vos mots de passe ne sont pas identiques."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Quitter ?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Voulez-vous vraiment quitter le programme d’installation ?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Veuillez choisir une langue"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Veuillez indiquer un nom pour votre ordinateur."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Veuillez indiquer votre nom complet."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Vos mots de passe ne sont pas identiques."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "La partition EFI est trop petite. Elle être au moins de 35 Mo."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Veuillez choisir une partition racine (/)."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, fuzzy, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+"Une partition racine est nécessaire pour y installer Linux Mint.\n"
+"\n"
+" - Point de montage : /\n"
+" - Taille recommandée : 30 Go\n"
+" - Format de système de fichiers recommandé : ext4\n"
+"\n"
+"Note : la fonction d’instantanés « timeshift » de Btrfs exige d’utiliser :\n"
+" - un point de montage de sous-volume /@\n"
+" - Btrfs comme format de système de fichiers\n"
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+"La partition EFI n'est pas bootable. Veuillez éditer les propriétés de la "
+"partition."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "La partition EFI est trop petite. Elle être au moins de 35 Mo."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "La partition EFI doit être formatée en vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Veuillez choisir une partition EFI."
+
+#: live-installer/frontend/gtk_interface.py:1301
+#, fuzzy
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+"Une partition système EFI est nécessaire avec les exigences suivantes :\n"
+"\n"
+" – Point de montage : /boot/efi\n"
+" – Drapeau de la partition : boot\n"
+" – Taille : au moins 35 Mo (100 Mo sont recommandés)\n"
+" – Format : vfat ou fat32\n"
+"\n"
+"Pour garantir la compatibilité avec Windows, nous recommandons d’utiliser la "
+"première partition du disque comme partition système EFI\n"
+" "
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr "Veuillez sélectionner un disque."
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Veuillez saisir un identifiant."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Régionalisation"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Langue : "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Fuseau horaire : "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Disposition du clavier : "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Paramètres utilisateur"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Nom complet : "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Nom d'utilisateur : "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Connexion automatique : "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "activée"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "désactivée"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Paramètres système"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr "Nom de l’ordinateur : "
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+#, fuzzy
+msgid "Install updates after installation"
+msgstr "Installation automatisée"
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Opérations du système de fichiers"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Installation du chargeur d'amorçage sur %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Ne pas installer de chargeur d'amorçage"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Utilisation de la partition /target déjà montée"
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr "Installation automatisée sur %s"
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Formatage de %(path)s en %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Montage de %(path)s dans %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Montage de %(path)s dans %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr "LVM : "
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr "Chiffrement du disque : "
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Installation terminée"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr "L'installation est terminée. Voulez-vous redémarrer l'ordinateur ?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Erreur lors de l'installation"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "O"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "ko"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "Mo"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "To"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Amovible :"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Modifier"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Attribuer à /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"La table de partitions n'a pas pu être écrite pour %s. Redémarrez "
+"l'ordinateur et réessayez."
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"La partition %s n'a pas pu être créée. L'installation va s'arrêter. "
+"Redémarrez l'ordinateur et réessayez."
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Partition logique"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Partition étendue"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Inconnu"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Modifier la partition"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Modifier la partition"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Périphérique :"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Formater en :"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Point de montage :"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Annuler"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
+msgstr ""
 
 #: live-installer/validate.py:12
 msgid "Please provide a username."
@@ -434,10 +1181,6 @@ msgstr "Vos mots de passe ne sont pas identiques."
 msgid "Please provide a password for your user account."
 msgstr "Veuillez saisir un mot de passe pour votre compte."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -464,7 +1207,7 @@ msgstr "Création du compte utilisateur"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Écriture des informations de montage dans /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Montage de %(partition)s sur %(mountpoint)s"
@@ -486,49 +1229,49 @@ msgstr "Création de partitions sur %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formatage de %(partition)s en %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Définition du nom d'hôte"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Configuration des paramètres régionaux"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Définition du nom d'hôte"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Configuration des options de clavier"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Suppression des paquets du système live"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Installation du chargeur d'amorçage"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Configuration du chargeur d'amorçage"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -536,674 +1279,17 @@ msgstr ""
 "ATTENTION : le chargeur d'amorçage GRUB n'a pas été configuré correctement ! "
 "Vous devez le configurer manuellement."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Installation terminée"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Vérification du chargeur d'amorçage"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Pays"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Langue"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Disposition"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Variante"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Indexation des fichiers ..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr "Programme d’installation"
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr "Quelle langue souhaitez-vous utiliser ?"
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr "Où vous trouvez-vous ?"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Disposition du clavier"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr "Quelle est la disposition de votre clavier ?"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr "Compte utilisateur"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr "Qui êtes-vous ?"
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr "Type d’installation"
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Où souhaitez-vous installer 17G ?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Partitionnement"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Résumé"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr "Installation"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-#, fuzzy
-msgid "Automated install"
-msgstr "Installation automatisée"
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Retour"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr "Suivant"
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, fuzzy, python-format
-msgid "Welcome to the %s Installer."
-msgstr "Bienvenue sur le programme d’installation de 17G"
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr "Tapez ici pour tester la disposition de votre clavier"
-
-#: live-installer/frontend/gtk_interface.py:542
-#, fuzzy
-msgid "Erase a disk and install system on it."
-msgstr "Effacer un disque et y installer 17G."
-
-#: live-installer/frontend/gtk_interface.py:555
-#, fuzzy
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-"Créez manuellement, redimensionnez ou sélectionnez des partitions pour 17G."
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Modifier les partitions"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Périphérique"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Catégorie"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Système d'exploitation"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Point de montage"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Formater en"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Taille"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Espace libre"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Installer"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr "Veuillez indiquer une phrase de passe pour le chiffrement."
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Vos mots de passe ne sont pas identiques."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Quitter ?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Voulez-vous vraiment quitter le programme d’installation ?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Veuillez choisir une langue"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Veuillez indiquer un nom pour votre ordinateur."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Veuillez indiquer votre nom complet."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Vos mots de passe ne sont pas identiques."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "La partition EFI est trop petite. Elle être au moins de 35 Mo."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Veuillez choisir une partition racine (/)."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, fuzzy, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-"Une partition racine est nécessaire pour y installer Linux Mint.\n"
-"\n"
-" - Point de montage : /\n"
-" - Taille recommandée : 30 Go\n"
-" - Format de système de fichiers recommandé : ext4\n"
-"\n"
-"Note : la fonction d’instantanés « timeshift » de Btrfs exige d’utiliser :\n"
-" - un point de montage de sous-volume /@\n"
-" - Btrfs comme format de système de fichiers\n"
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-"La partition EFI n'est pas bootable. Veuillez éditer les propriétés de la "
-"partition."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "La partition EFI est trop petite. Elle être au moins de 35 Mo."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "La partition EFI doit être formatée en vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Veuillez choisir une partition EFI."
-
-#: live-installer/frontend/gtk_interface.py:1226
-#, fuzzy
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-"Une partition système EFI est nécessaire avec les exigences suivantes :\n"
-"\n"
-" – Point de montage : /boot/efi\n"
-" – Drapeau de la partition : boot\n"
-" – Taille : au moins 35 Mo (100 Mo sont recommandés)\n"
-" – Format : vfat ou fat32\n"
-"\n"
-"Pour garantir la compatibilité avec Windows, nous recommandons d’utiliser la "
-"première partition du disque comme partition système EFI\n"
-" "
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr "Veuillez sélectionner un disque."
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr "Avertissement"
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-"Toutes les données de %s seront supprimées. Le souhaitez-vous vraiment ?"
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Veuillez saisir un identifiant."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Régionalisation"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Langue : "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Fuseau horaire : "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Disposition du clavier : "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Paramètres utilisateur"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Nom complet : "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Nom d'utilisateur : "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Connexion automatique : "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "activée"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "désactivée"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Paramètres système"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr "Nom de l’ordinateur : "
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-#, fuzzy
-msgid "Install updates after installation"
-msgstr "Installation automatisée"
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Opérations du système de fichiers"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Installation du chargeur d'amorçage sur %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Ne pas installer de chargeur d'amorçage"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Utilisation de la partition /target déjà montée"
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr "Installation automatisée sur %s"
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Formatage de %(path)s en %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Montage de %(path)s dans %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr "LVM : "
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr "Chiffrement du disque : "
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr "L'installation est terminée. Voulez-vous redémarrer l'ordinateur ?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Erreur lors de l'installation"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, fuzzy, python-format
-msgid "Welcome to %s"
-msgstr "Bienvenue"
-
-#: live-installer/frontend/tui_interface.py:57
-#, fuzzy
-msgid "What keyboard would you like to use?"
-msgstr "Quelle langue souhaitez-vous utiliser ?"
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Modèle de clavier :"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Type d’installation"
-
-#: live-installer/frontend/tui_interface.py:80
-#, fuzzy
-msgid "Select a disk?"
-msgstr "Veuillez sélectionner un disque."
-
-#: live-installer/frontend/tui_interface.py:84
-#, fuzzy
-msgid "Disk"
-msgstr "Disque :"
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Fuseau horaire"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "O"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "ko"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "Mo"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "To"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Amovible :"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Modifier"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Attribuer à /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"La table de partitions n'a pas pu être écrite pour %s. Redémarrez "
-"l'ordinateur et réessayez."
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"La partition %s n'a pas pu être créée. L'installation va s'arrêter. "
-"Redémarrez l'ordinateur et réessayez."
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Partition logique"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Partition étendue"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Inconnu"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Modifier la partition"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Modifier la partition"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Périphérique :"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Formater en :"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Point de montage :"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Annuler"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "OK"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Non"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Oui"
 
 #~ msgid "Quit"
 #~ msgstr "Quitter"

--- a/po/live-installer-fr.po
+++ b/po/live-installer-fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2020-03-09 21:22+0000\n"
 "Last-Translator: Clement Lefebvre <root@linuxmint.com>\n"
 "Language-Team: French <fr@li.org>\n"
@@ -95,7 +95,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "Go"
 
@@ -198,9 +198,9 @@ msgid "Format"
 msgstr "Formater en"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -305,6 +305,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Formater en"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -336,8 +342,8 @@ msgstr "Bienvenue"
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "OK"
 
@@ -429,23 +435,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr "Bienvenue"
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Pays"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "O"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Disposition"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "ko"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Variante"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "Mo"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Indexation des fichiers ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "To"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Amovible :"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Modifier"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Attribuer à /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -463,10 +540,108 @@ msgstr "Indexation des fichiers ..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr "Programme d’installation"
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Espace libre"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"La table de partitions n'a pas pu être écrite pour %s. Redémarrez "
+"l'ordinateur et réessayez."
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"La partition %s n'a pas pu être créée. L'installation va s'arrêter. "
+"Redémarrez l'ordinateur et réessayez."
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Partition logique"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Partition étendue"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Inconnu"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Modifier la partition"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Modifier la partition"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Périphérique :"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Formater en :"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Point de montage :"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Annuler"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Pays"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Disposition"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variante"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Indexation des fichiers ..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -585,18 +760,6 @@ msgstr "Formater en"
 msgid "Size"
 msgstr "Taille"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Espace libre"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -630,25 +793,6 @@ msgstr "Quitter ?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Voulez-vous vraiment quitter le programme d’installation ?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -911,7 +1055,7 @@ msgid "Disk Encryption: "
 msgstr "Chiffrement du disque : "
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Installation terminée"
 
@@ -930,143 +1074,6 @@ msgstr "Erreur lors de l'installation"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "O"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "ko"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "Mo"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "To"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Amovible :"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Modifier"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Attribuer à /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"La table de partitions n'a pas pu être écrite pour %s. Redémarrez "
-"l'ordinateur et réessayez."
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"La partition %s n'a pas pu être créée. L'installation va s'arrêter. "
-"Redémarrez l'ordinateur et réessayez."
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Partition logique"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Partition étendue"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Inconnu"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Modifier la partition"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Modifier la partition"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Périphérique :"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Formater en :"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Point de montage :"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Annuler"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1229,49 +1236,49 @@ msgstr "Création de partitions sur %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formatage de %(partition)s en %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Définition du nom d'hôte"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Configuration des paramètres régionaux"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Définition du nom d'hôte"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Configuration des options de clavier"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Suppression des paquets du système live"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Installation du chargeur d'amorçage"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Configuration du chargeur d'amorçage"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1279,15 +1286,15 @@ msgstr ""
 "ATTENTION : le chargeur d'amorçage GRUB n'a pas été configuré correctement ! "
 "Vous devez le configurer manuellement."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Vérification du chargeur d'amorçage"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-fr_CA.po
+++ b/po/live-installer-fr_CA.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2020-02-29 15:38+0000\n"
 "Last-Translator: AO <Unknown>\n"
 "Language-Team: French (Canada) <fr_CA@li.org>\n"
@@ -95,7 +95,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "Go"
 
@@ -198,9 +198,9 @@ msgid "Format"
 msgstr "Formater en"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -305,6 +305,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Formater en"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -336,8 +342,8 @@ msgstr "Bienvenue"
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "OK"
 
@@ -429,23 +435,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr "Bienvenue"
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Pays"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "O"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Disposition"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "Ko"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Variante"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "Mo"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Indexation des fichiers ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "To"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Amovible :"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Modifier"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Attribuer à /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -463,10 +540,104 @@ msgstr "Indexation des fichiers ..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr "Programme d’installation"
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Espace libre"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Partition logique"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Partition étendue"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Inconnu(e)"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Modifier la partition"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Modifier la partition"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Périphérique :"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Formater en :"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Point de montage :"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Annuler"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Pays"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Disposition"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variante"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Indexation des fichiers ..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -585,18 +756,6 @@ msgstr "Formater en"
 msgid "Size"
 msgstr "Taille"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Espace libre"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -630,25 +789,6 @@ msgstr "Quitter?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Voulez-vous vraiment quitter le programme d’installation ?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -911,7 +1051,7 @@ msgid "Disk Encryption: "
 msgstr "Chiffrement du disque : "
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Installation terminée"
 
@@ -930,139 +1070,6 @@ msgstr "Erreur lors de l'installation"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "O"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "Ko"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "Mo"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "To"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Amovible :"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Modifier"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Attribuer à /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Partition logique"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Partition étendue"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Inconnu(e)"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Modifier la partition"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Modifier la partition"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Périphérique :"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Formater en :"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Point de montage :"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Annuler"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1223,49 +1230,49 @@ msgstr "Création de partitions sur %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formatage de %(partition)s en %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Définition du nom d'hôte"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Configuration des paramètres régionaux"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Définition du nom d'hôte"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Configuration des options du clavier"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Suppression des paquets du système live"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Installation du chargeur d'amorçage"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Configuration du chargeur d'amorçage"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1273,15 +1280,15 @@ msgstr ""
 "ATTENTION : le chargeur d'amorçage GRUB n'a pas été configuré correctement ! "
 "Vous devez le configurer manuellement."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Vérification du chargeur d'amorçage"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-fr_CA.po
+++ b/po/live-installer-fr_CA.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2020-02-29 15:38+0000\n"
 "Last-Translator: AO <Unknown>\n"
 "Language-Team: French (Canada) <fr_CA@li.org>\n"
@@ -24,8 +24,8 @@ msgid "Welcome to the 17g Installer."
 msgstr "Bienvenue sur le programme d’installation de 17G"
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 #, fuzzy
 msgid ""
 "This program will ask you some questions and set up system on your computer."
@@ -34,12 +34,12 @@ msgstr ""
 "ordinateur."
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr "Modèle de clavier :"
 
@@ -49,10 +49,12 @@ msgid "Type here to test your keyboard"
 msgstr "Tapez ici pour tester la disposition de votre clavier"
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -61,13 +63,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Fuseau horaire"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr "Installation automatisée"
 
@@ -77,12 +79,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr "Effacer un disque et y installer 17G."
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr "Disque :"
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Modifier la partition"
@@ -93,42 +95,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "Go"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr "Utiliser LVM (gestion de volumes logiques)"
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr "Chiffrer le système d’exploitation"
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr "Phrase de passe"
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr "Confirmer la phrase de passe"
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr "Partitionnement manuel"
 
@@ -147,7 +149,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Mode avancé"
@@ -157,144 +159,150 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 #, fuzzy
 msgid "Minimal installation"
 msgstr "Installation automatisée"
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Actualiser"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Formater en"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr "Installer le menu d’amorçage GRUB sur :"
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Modifier les partitions"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr "Votre nom :"
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr "Le nom de votre ordinateur :"
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr "Choisissez un nom d’utilisateur :"
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr "Le nom qu’il utilise quand il communique avec d’autres ordinateurs."
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr "Choisissez un mot de passe :"
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Ouvrir la session automatiquement"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr "Exige mon mot de passe pour se connecter"
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr "Chiffrer mon dossier personnel"
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr "Confirmez votre mot de passe :"
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 #, fuzzy
 msgid "Automated installation enabled!"
 msgstr "Installation automatisée sur %s"
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr "Bienvenue"
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -325,6 +333,741 @@ msgstr ""
 #, fuzzy
 msgid "Welcome to 17g"
 msgstr "Bienvenue"
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "OK"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Non"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Oui"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Fuseau horaire"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, fuzzy, python-format
+msgid "Welcome to the %s Installer."
+msgstr "Bienvenue sur le programme d’installation de 17G"
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr "Quelle langue souhaitez-vous utiliser ?"
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Langue"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr "Où vous trouvez-vous ?"
+
+#: live-installer/frontend/tui_interface.py:57
+#, fuzzy
+msgid "What keyboard would you like to use?"
+msgstr "Quelle langue souhaitez-vous utiliser ?"
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Modèle de clavier :"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Type d’installation"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Type"
+
+#: live-installer/frontend/tui_interface.py:80
+#, fuzzy
+msgid "Select a disk?"
+msgstr "Veuillez sélectionner un disque."
+
+#: live-installer/frontend/tui_interface.py:84
+#, fuzzy
+msgid "Disk"
+msgstr "Disque :"
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, fuzzy, python-format
+msgid "Welcome to %s"
+msgstr "Bienvenue"
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Pays"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Disposition"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variante"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Indexation des fichiers ..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr "Programme d’installation"
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Disposition du clavier"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr "Quelle est la disposition de votre clavier ?"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr "Compte utilisateur"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr "Qui êtes-vous ?"
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr "Type d’installation"
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Où souhaitez-vous installer 17G ?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Partitionnement"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Résumé"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr "Installation"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+#, fuzzy
+msgid "Automated Install"
+msgstr "Installation automatisée"
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Retour"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr "Suivant"
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr "Tapez ici pour tester la disposition de votre clavier"
+
+#: live-installer/frontend/gtk_interface.py:546
+#, fuzzy
+msgid "Erase a disk and install system on it."
+msgstr "Effacer un disque et y installer 17G."
+
+#: live-installer/frontend/gtk_interface.py:559
+#, fuzzy
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+"Créez manuellement, redimensionnez ou sélectionnez des partitions pour 17G."
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Modifier les partitions"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Périphérique"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Système d'exploitation"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Point de montage"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Formater en"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Taille"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Espace libre"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr "Avertissement"
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+"Toutes les données de %s seront supprimées. Le souhaitez-vous vraiment ?"
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Installer"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr "Veuillez indiquer une phrase de passe pour le chiffrement."
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Vos mots de passes ne sont pas identiques."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Quitter?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Voulez-vous vraiment quitter le programme d’installation ?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Veuillez choisir une langue"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Veuillez indiquer un nom pour votre ordinateur."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Veuillez indiquer votre nom complet."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Vos mots de passes ne sont pas identiques."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "La partition EFI est trop petite. Elle être au moins de 35 Mo."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Veuillez choisir une partition racine (/)."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, fuzzy, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+"Une partition racine est nécessaire pour y installer Linux Mint.\n"
+"\n"
+" - Point de montage : /\n"
+" - Taille recommandée : 30 Go\n"
+" - Format de système de fichiers recommandé : ext4\n"
+"\n"
+"Note : la fonction d’instantanés « timeshift » de Btrfs exige d’utiliser :\n"
+" - un point de montage de sous-volume /@\n"
+" - Btrfs comme format de système de fichiers\n"
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+"La partition EFI ne peut être amorcée. Veuillez éditer les drapeaux de la "
+"partition."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "La partition EFI est trop petite. Elle être au moins de 35 Mo."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "La partition EFI doit être formatée en vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Veuillez choisir une partition EFI."
+
+#: live-installer/frontend/gtk_interface.py:1301
+#, fuzzy
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+"Une partition système EFI est nécessaire avec les exigences suivantes :\n"
+"\n"
+" – Point de montage : /boot/efi\n"
+" – Drapeau de la partition : boot\n"
+" – Taille : au moins 35 Mo (100 Mo sont recommandés)\n"
+" – Format : vfat ou fat32\n"
+"\n"
+"Pour garantir la compatibilité avec Windows, nous recommandons d’utiliser la "
+"première partition du disque comme partition système EFI\n"
+" "
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr "Veuillez sélectionner un disque."
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Veuillez saisir un nom d'utilisateur"
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Localisation"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Langue : "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Fuseau horaire : "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Agencement du clavier : "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Paramètres utilisateur"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Nom réel : "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Nom d'utilisateur : "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Connexion automatique : "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "activée"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "désactivée"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Paramètres système"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr "Nom de l’ordinateur : "
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+#, fuzzy
+msgid "Install updates after installation"
+msgstr "Installation automatisée"
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Opérations du système de fichiers"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Installation du chargeur d'amorçage sur %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Ne pas installer de chargeur d’amorçage"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Utilise la partition déjà montée  /target"
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr "Installation automatisée sur %s"
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Formatage de %(path)s en %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Montage de %(path)s à titre de %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Montage de %(path)s à titre de %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr "LVM : "
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr "Chiffrement du disque : "
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Installation terminée"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr "L'installation est terminée. Voulez-vous redémarrer l'ordinateur ?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Erreur lors de l'installation"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "O"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "Ko"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "Mo"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "To"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Amovible :"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Modifier"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Attribuer à /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Partition logique"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Partition étendue"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Inconnu(e)"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Modifier la partition"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Modifier la partition"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Périphérique :"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Formater en :"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Point de montage :"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Annuler"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
+msgstr ""
 
 #: live-installer/validate.py:12
 msgid "Please provide a username."
@@ -434,10 +1177,6 @@ msgstr "Vos mots de passes ne sont pas identiques."
 msgid "Please provide a password for your user account."
 msgstr "Veuillez saisir un mot de passe pour votre compte."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -464,7 +1203,7 @@ msgstr "Création du compte utilisateur"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Écriture des informations de montage dans /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Montage de %(partition)s sur %(mountpoint)s"
@@ -484,49 +1223,49 @@ msgstr "Création de partitions sur %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formatage de %(partition)s en %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Définition du nom d'hôte"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Configuration des paramètres régionaux"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Définition du nom d'hôte"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Configuration des options du clavier"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Suppression des paquets du système live"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Installation du chargeur d'amorçage"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Configuration du chargeur d'amorçage"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -534,670 +1273,17 @@ msgstr ""
 "ATTENTION : le chargeur d'amorçage GRUB n'a pas été configuré correctement ! "
 "Vous devez le configurer manuellement."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Installation terminée"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Vérification du chargeur d'amorçage"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Pays"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Langue"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Disposition"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Variante"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Indexation des fichiers ..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr "Programme d’installation"
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr "Quelle langue souhaitez-vous utiliser ?"
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr "Où vous trouvez-vous ?"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Disposition du clavier"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr "Quelle est la disposition de votre clavier ?"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr "Compte utilisateur"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr "Qui êtes-vous ?"
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr "Type d’installation"
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Où souhaitez-vous installer 17G ?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Partitionnement"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Résumé"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr "Installation"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-#, fuzzy
-msgid "Automated install"
-msgstr "Installation automatisée"
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Retour"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr "Suivant"
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, fuzzy, python-format
-msgid "Welcome to the %s Installer."
-msgstr "Bienvenue sur le programme d’installation de 17G"
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr "Tapez ici pour tester la disposition de votre clavier"
-
-#: live-installer/frontend/gtk_interface.py:542
-#, fuzzy
-msgid "Erase a disk and install system on it."
-msgstr "Effacer un disque et y installer 17G."
-
-#: live-installer/frontend/gtk_interface.py:555
-#, fuzzy
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-"Créez manuellement, redimensionnez ou sélectionnez des partitions pour 17G."
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Modifier les partitions"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Périphérique"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Type"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Système d'exploitation"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Point de montage"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Formater en"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Taille"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Espace libre"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Installer"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr "Veuillez indiquer une phrase de passe pour le chiffrement."
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Vos mots de passes ne sont pas identiques."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Quitter?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Voulez-vous vraiment quitter le programme d’installation ?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Veuillez choisir une langue"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Veuillez indiquer un nom pour votre ordinateur."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Veuillez indiquer votre nom complet."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Vos mots de passes ne sont pas identiques."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "La partition EFI est trop petite. Elle être au moins de 35 Mo."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Veuillez choisir une partition racine (/)."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, fuzzy, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-"Une partition racine est nécessaire pour y installer Linux Mint.\n"
-"\n"
-" - Point de montage : /\n"
-" - Taille recommandée : 30 Go\n"
-" - Format de système de fichiers recommandé : ext4\n"
-"\n"
-"Note : la fonction d’instantanés « timeshift » de Btrfs exige d’utiliser :\n"
-" - un point de montage de sous-volume /@\n"
-" - Btrfs comme format de système de fichiers\n"
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-"La partition EFI ne peut être amorcée. Veuillez éditer les drapeaux de la "
-"partition."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "La partition EFI est trop petite. Elle être au moins de 35 Mo."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "La partition EFI doit être formatée en vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Veuillez choisir une partition EFI."
-
-#: live-installer/frontend/gtk_interface.py:1226
-#, fuzzy
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-"Une partition système EFI est nécessaire avec les exigences suivantes :\n"
-"\n"
-" – Point de montage : /boot/efi\n"
-" – Drapeau de la partition : boot\n"
-" – Taille : au moins 35 Mo (100 Mo sont recommandés)\n"
-" – Format : vfat ou fat32\n"
-"\n"
-"Pour garantir la compatibilité avec Windows, nous recommandons d’utiliser la "
-"première partition du disque comme partition système EFI\n"
-" "
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr "Veuillez sélectionner un disque."
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr "Avertissement"
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-"Toutes les données de %s seront supprimées. Le souhaitez-vous vraiment ?"
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Veuillez saisir un nom d'utilisateur"
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Localisation"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Langue : "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Fuseau horaire : "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Agencement du clavier : "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Paramètres utilisateur"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Nom réel : "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Nom d'utilisateur : "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Connexion automatique : "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "activée"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "désactivée"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Paramètres système"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr "Nom de l’ordinateur : "
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-#, fuzzy
-msgid "Install updates after installation"
-msgstr "Installation automatisée"
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Opérations du système de fichiers"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Installation du chargeur d'amorçage sur %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Ne pas installer de chargeur d’amorçage"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Utilise la partition déjà montée  /target"
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr "Installation automatisée sur %s"
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Formatage de %(path)s en %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Montage de %(path)s à titre de %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr "LVM : "
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr "Chiffrement du disque : "
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr "L'installation est terminée. Voulez-vous redémarrer l'ordinateur ?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Erreur lors de l'installation"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, fuzzy, python-format
-msgid "Welcome to %s"
-msgstr "Bienvenue"
-
-#: live-installer/frontend/tui_interface.py:57
-#, fuzzy
-msgid "What keyboard would you like to use?"
-msgstr "Quelle langue souhaitez-vous utiliser ?"
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Modèle de clavier :"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Type d’installation"
-
-#: live-installer/frontend/tui_interface.py:80
-#, fuzzy
-msgid "Select a disk?"
-msgstr "Veuillez sélectionner un disque."
-
-#: live-installer/frontend/tui_interface.py:84
-#, fuzzy
-msgid "Disk"
-msgstr "Disque :"
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Fuseau horaire"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "O"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "Ko"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "Mo"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "To"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Amovible :"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Modifier"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Attribuer à /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Partition logique"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Partition étendue"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Inconnu(e)"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Modifier la partition"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Modifier la partition"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Périphérique :"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Formater en :"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Point de montage :"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Annuler"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "OK"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Non"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Oui"
 
 #~ msgid "Quit"
 #~ msgstr "Quitter"

--- a/po/live-installer-frp.po
+++ b/po/live-installer-frp.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2015-08-19 16:09+0000\n"
 "Last-Translator: Alekĉjo <Unknown>\n"
 "Language-Team: Franco-Provençal <frp@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Zona horèra"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Èditar les particions"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Mode d’èxpèrt"
@@ -149,141 +151,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Actualisar"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Èditar les particions"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -312,6 +320,703 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Zona horèra"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Lèngua"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Disposicion du clâvo"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Instalacion tèrminâ"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Payis"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Disposicion"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Varianta"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Après carcular la lista de fìchiérs…"
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Disposicion du clâvo"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Particionar"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Somèro"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Èditar les particions"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Après montar %(partition)s sur %(mountpoint)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Instalacion tèrminâ"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Èditar les particions"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -407,10 +1112,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -438,7 +1139,7 @@ msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 "Après èhcrire l’informacion de montâjo du sistèmo de fìchiérs /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Après montar %(partition)s sur %(mountpoint)s"
@@ -458,679 +1159,64 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Après formatar %(partition)s como %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Après dèfinir lo nom d’hôto"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Après dèfinir la lèngua locâla"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Après dèfinir lo nom d’hôto"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Après dèfinir les opcions de clâvo"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Après recotar la configuracion dos paquèts de vèrsion a chôd"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Après instalar lo charjòr d’encoblâjo"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Après configurar lo charjòr d’encoblâjo"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Instalacion tèrminâ"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Après vèrifier lo charjòr d’encoblâjo"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Payis"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Lèngua"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Disposicion"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Varianta"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Après carcular la lista de fìchiérs…"
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Disposicion du clâvo"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Particionar"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Somèro"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Èditar les particions"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Disposicion du clâvo"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Instalacion tèrminâ"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Zona horèra"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Èditar les particions"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #, fuzzy

--- a/po/live-installer-frp.po
+++ b/po/live-installer-frp.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2015-08-19 16:09+0000\n"
 "Last-Translator: Alekĉjo <Unknown>\n"
 "Language-Team: Franco-Provençal <frp@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -188,9 +188,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -294,6 +294,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -324,8 +329,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -414,23 +419,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Payis"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Disposicion"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Varianta"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Après carcular la lista de fìchiérs…"
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -448,10 +524,104 @@ msgstr "Après carcular la lista de fìchiérs…"
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Èditar les particions"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Payis"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Disposicion"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Varianta"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Après carcular la lista de fìchiérs…"
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -565,18 +735,6 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -608,25 +766,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -861,7 +1000,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Instalacion tèrminâ"
 
@@ -880,139 +1019,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Èditar les particions"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1159,63 +1165,63 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Après formatar %(partition)s como %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Après dèfinir lo nom d’hôto"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Après dèfinir la lèngua locâla"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Après dèfinir lo nom d’hôto"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Après dèfinir les opcions de clâvo"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Après recotar la configuracion dos paquèts de vèrsion a chôd"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Après instalar lo charjòr d’encoblâjo"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Après configurar lo charjòr d’encoblâjo"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Après vèrifier lo charjòr d’encoblâjo"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-ga.po
+++ b/po/live-installer-ga.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2013-06-21 21:38+0000\n"
 "Last-Translator: Gearóid  Ó Maelearcaidh <gearoid@omaelearcaidh.com>\n"
 "Language-Team: Irish <ga@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -292,6 +292,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -322,8 +327,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -411,23 +416,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Leagan Amach"
-
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Leagan eile"
-
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -445,9 +521,103 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Saorspás"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Socruithe córais"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Leagan Amach"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Leagan eile"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -562,18 +732,6 @@ msgstr ""
 msgid "Size"
 msgstr "Méid"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Saorspás"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -605,25 +763,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -858,7 +997,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Suiteáil críochnaithe"
 
@@ -877,139 +1016,6 @@ msgstr "Earráid suiteála"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Socruithe córais"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1155,49 +1161,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Ag socrú óstainme"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Ag socrú logchaighdeáin"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Ag socrú óstainme"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Ag socrú roghanna méarchláir"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Ag baint cumraíocht bheo (packages)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Ag suiteáil luchtálaí bútála"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Ag cumrú luchtálaí bútála"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1205,15 +1211,15 @@ msgstr ""
 "RABHADH: Níor cumraíodh an luchtálaí bútála grub i gceart! Caithfear é a "
 "chumrú de láimh"
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Ag seiceáil luchtálaí bútála"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-ga.po
+++ b/po/live-installer-ga.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2013-06-21 21:38+0000\n"
 "Last-Translator: Gearóid  Ó Maelearcaidh <gearoid@omaelearcaidh.com>\n"
 "Language-Team: Irish <ga@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,141 +149,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Socruithe córais"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -310,6 +318,702 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Leagan amach méarchláir: "
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Earráid suiteála"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Cineál"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Leagan Amach"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Leagan eile"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Gléas"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Córas oibriúcháin"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Pointe gléasta"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Méid"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Saorspás"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Logánú"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Teanga: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Amchrios "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Leagan amach méarchláir: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Socruithe úsáideora"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Fíor ainm: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Ainm úsáideora: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Socruithe córais"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Oibríochtaí an chórais chomhad"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Ná suiteáil luchtálaí bútála"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Ag gleasadh %(partition)s ar %(mountpoint)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Suiteáil críochnaithe"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Earráid suiteála"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Socruithe córais"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -405,10 +1109,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -435,7 +1135,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Ag gleasadh %(partition)s ar %(mountpoint)s"
@@ -455,49 +1155,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Ag socrú óstainme"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Ag socrú logchaighdeáin"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Ag socrú óstainme"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Ag socrú roghanna méarchláir"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Ag baint cumraíocht bheo (packages)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Ag suiteáil luchtálaí bútála"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Ag cumrú luchtálaí bútála"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -505,630 +1205,16 @@ msgstr ""
 "RABHADH: Níor cumraíodh an luchtálaí bútála grub i gceart! Caithfear é a "
 "chumrú de láimh"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Suiteáil críochnaithe"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Ag seiceáil luchtálaí bútála"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Leagan Amach"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Leagan eile"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Gléas"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Cineál"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Córas oibriúcháin"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Pointe gléasta"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Méid"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Saorspás"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Logánú"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Teanga: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Amchrios "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Leagan amach méarchláir: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Socruithe úsáideora"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Fíor ainm: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Ainm úsáideora: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Socruithe córais"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Oibríochtaí an chórais chomhad"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Ná suiteáil luchtálaí bútála"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Earráid suiteála"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Leagan amach méarchláir: "
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Earráid suiteála"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Socruithe córais"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-gd.po
+++ b/po/live-installer-gd.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2015-06-26 13:30+0000\n"
 "Last-Translator: GunChleoc <Unknown>\n"
 "Language-Team: Akerbeltz\n"
@@ -90,7 +90,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -190,9 +190,9 @@ msgid "Format"
 msgstr "Fòrmataich mar"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -296,6 +296,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Fòrmataich mar"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -326,8 +332,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -416,23 +422,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Dùthaich"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Co-dhealbhachd"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Eug-samhail"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Ag àireamhachadh inneacsan faidhle ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "So-ghiùlan:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Deasaich"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Iomruin dha /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -450,10 +527,104 @@ msgstr "Ag àireamhachadh inneacsan faidhle ..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Àite saor"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Pàirteachadh loidsigeach"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Pàirteachadh leudaichte"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Chan eil fhios"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Deasaich am pàirteachadh"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Deasaich am pàirteachadh"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Uidheam:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Fòrmataich mar:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Puing munntachaidh:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Dùthaich"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Co-dhealbhachd"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Eug-samhail"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Ag àireamhachadh inneacsan faidhle ..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -568,18 +739,6 @@ msgstr "Fòrmataich mar"
 msgid "Size"
 msgstr "Meud"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Àite saor"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -612,25 +771,6 @@ msgstr "Fàgail"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "A bheil thu cinneach gu bheil thu airson an stàlaichear fhàgail?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -874,7 +1014,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Chaidh an stàladh a choileanadh"
 
@@ -895,139 +1035,6 @@ msgstr "Mearachd stàlaidh"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "So-ghiùlan:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Deasaich"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Iomruin dha /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Pàirteachadh loidsigeach"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Pàirteachadh leudaichte"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Chan eil fhios"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Deasaich am pàirteachadh"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Deasaich am pàirteachadh"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Uidheam:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Fòrmataich mar:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Puing munntachaidh:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1188,49 +1195,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "A' fòrmatadh %(partition)s mar %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "A' suidheachadh ainm an òstair"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "A' suidheachadh an sgeama ionadail"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "A' suidheachadh ainm an òstair"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "A' suidheachadh roghainnean a' mheur-chlàir"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "A' toirt air falbh an rèiteachaidh bheò (pacaidean)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "A' stàladh a' bootloader"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "A' rèiteachadh a' bootloader"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1238,15 +1245,15 @@ msgstr ""
 "RABHADH: Cha deach an grub bootloader a rèiteachadh mar bu chòir! Feumaidh "
 "tu a rèiteachadh de làimh."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "A' sgrùdadh a' bootloader"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-gd.po
+++ b/po/live-installer-gd.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2015-06-26 13:30+0000\n"
 "Last-Translator: GunChleoc <Unknown>\n"
 "Language-Team: Akerbeltz\n"
@@ -24,19 +24,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -45,10 +45,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -57,13 +59,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Roinn-tìde"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -72,12 +74,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Deasaich am pàirteachadh"
@@ -88,42 +90,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -140,7 +142,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Modh an eòlaiche"
@@ -150,142 +152,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Ath-nuadhaich"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Fòrmataich mar"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Deasaich na pàirteachaidhean"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Clàraich a-steach gu fèin-obrachail"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -314,6 +322,716 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Roinn-tìde"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Cànan"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Co-dhealbhachd a' mheur-chlàir"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Chaidh an stàladh a chur 'na stad"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Seòrsa"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Dùthaich"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Co-dhealbhachd"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Eug-samhail"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Ag àireamhachadh inneacsan faidhle ..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Co-dhealbhachd a' mheur-chlàir"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "A bheil thu cinneach gu bheil thu airson an stàlaichear fhàgail?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Pàirteachadh"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Gearr-chunntas"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Deasaich na pàirteachaidhean"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Uidheam"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Siostam-obrachaidh"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Puing munntachaidh"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Fòrmataich mar"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Meud"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Àite saor"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Chan eil an dà fhacal-faire agad co-ionnann."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Fàgail"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "A bheil thu cinneach gu bheil thu airson an stàlaichear fhàgail?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Tagh cànan"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Thoir seachad facal-faire airson a' chunntais cleachdaiche agad."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Thoir seachad d' ainm slàn."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Chan eil an dà fhacal-faire agad co-ionnann."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+"Cha ghabh am pàirteachadh EFI a thòiseachadh. Deasaich brataichean nam "
+"pàirteachaidhean."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Sònraich pàirteachadh freumha (/)."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+"Cha ghabh am pàirteachadh EFI a thòiseachadh. Deasaich brataichean nam "
+"pàirteachaidhean."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "Feumaidh tu am pàirteachadh EFI fhòrmatadh mar vfat."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "Feumaidh tu am pàirteachadh EFI fhòrmatadh mar vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Tagh pàirteachadh EFI."
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Thoir seachad ainm cleachdaiche."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Ionadaileadh"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Cànan: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Roinn-tìde: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Co-dhealbhachd a' mheur-chlàir "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Roghainnean a' chleachdaiche"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Fìor-ainm: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Ainm-cleachdaiche: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Clàradh a-steach fèin-obrachail: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "an comas"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "à comas"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Roghainnean an t-siostaim"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Obrachaidhean an t-siostaim fhaidhlichean"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Stàlaich an luchdaichear-bùtaidh air %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Na stàlaich am bootloader"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Cleachd /target air a mhunntachadh mar-thà."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Fòrmataich %(path)s mar %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Munntaich %(path)s mar %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Munntaich %(path)s mar %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Chaidh an stàladh a choileanadh"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Tha an stàladh coileanta a-nis. A bheil thu airson an coimpiutair agad a "
+"thòiseachadh às ùr gus an siostam ùr a chleachdadh?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Mearachd stàlaidh"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "So-ghiùlan:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Deasaich"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Iomruin dha /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Pàirteachadh loidsigeach"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Pàirteachadh leudaichte"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Chan eil fhios"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Deasaich am pàirteachadh"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Deasaich am pàirteachadh"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Uidheam:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Fòrmataich mar:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Puing munntachaidh:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -422,10 +1140,6 @@ msgstr "Chan eil an dà fhacal-faire agad co-ionnann."
 msgid "Please provide a password for your user account."
 msgstr "Thoir seachad facal-faire airson a' chunntais cleachdaiche agad."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -454,7 +1168,7 @@ msgstr ""
 "A' sgrìobhadh fiosrachadh munntachadh an t-siostaim fhaidhlichean gu  /etc/"
 "fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Ag munntachadh %(partition)s air %(mountpoint)s"
@@ -474,49 +1188,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "A' fòrmatadh %(partition)s mar %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "A' suidheachadh ainm an òstair"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "A' suidheachadh an sgeama ionadail"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "A' suidheachadh ainm an òstair"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "A' suidheachadh roghainnean a' mheur-chlàir"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "A' toirt air falbh an rèiteachaidh bheò (pacaidean)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "A' stàladh a' bootloader"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "A' rèiteachadh a' bootloader"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -524,644 +1238,16 @@ msgstr ""
 "RABHADH: Cha deach an grub bootloader a rèiteachadh mar bu chòir! Feumaidh "
 "tu a rèiteachadh de làimh."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Chaidh an stàladh a choileanadh"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "A' sgrùdadh a' bootloader"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Dùthaich"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Cànan"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Co-dhealbhachd"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Eug-samhail"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Ag àireamhachadh inneacsan faidhle ..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Co-dhealbhachd a' mheur-chlàir"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "A bheil thu cinneach gu bheil thu airson an stàlaichear fhàgail?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Pàirteachadh"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Gearr-chunntas"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Deasaich na pàirteachaidhean"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Uidheam"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Seòrsa"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Siostam-obrachaidh"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Puing munntachaidh"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Fòrmataich mar"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Meud"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Àite saor"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Chan eil an dà fhacal-faire agad co-ionnann."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Fàgail"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "A bheil thu cinneach gu bheil thu airson an stàlaichear fhàgail?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Tagh cànan"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Thoir seachad facal-faire airson a' chunntais cleachdaiche agad."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Thoir seachad d' ainm slàn."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Chan eil an dà fhacal-faire agad co-ionnann."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-"Cha ghabh am pàirteachadh EFI a thòiseachadh. Deasaich brataichean nam "
-"pàirteachaidhean."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Sònraich pàirteachadh freumha (/)."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-"Cha ghabh am pàirteachadh EFI a thòiseachadh. Deasaich brataichean nam "
-"pàirteachaidhean."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "Feumaidh tu am pàirteachadh EFI fhòrmatadh mar vfat."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "Feumaidh tu am pàirteachadh EFI fhòrmatadh mar vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Tagh pàirteachadh EFI."
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Thoir seachad ainm cleachdaiche."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Ionadaileadh"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Cànan: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Roinn-tìde: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Co-dhealbhachd a' mheur-chlàir "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Roghainnean a' chleachdaiche"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Fìor-ainm: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Ainm-cleachdaiche: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Clàradh a-steach fèin-obrachail: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "an comas"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "à comas"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Roghainnean an t-siostaim"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Obrachaidhean an t-siostaim fhaidhlichean"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Stàlaich an luchdaichear-bùtaidh air %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Na stàlaich am bootloader"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Cleachd /target air a mhunntachadh mar-thà."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Fòrmataich %(path)s mar %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Munntaich %(path)s mar %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Tha an stàladh coileanta a-nis. A bheil thu airson an coimpiutair agad a "
-"thòiseachadh às ùr gus an siostam ùr a chleachdadh?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Mearachd stàlaidh"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Co-dhealbhachd a' mheur-chlàir"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Chaidh an stàladh a chur 'na stad"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Roinn-tìde"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "So-ghiùlan:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Deasaich"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Iomruin dha /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Pàirteachadh loidsigeach"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Pàirteachadh leudaichte"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Chan eil fhios"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Deasaich am pàirteachadh"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Deasaich am pàirteachadh"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Uidheam:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Fòrmataich mar:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Puing munntachaidh:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-gl.po
+++ b/po/live-installer-gl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2019-10-19 17:36+0000\n"
 "Last-Translator: Alberto Gómez <Unknown>\n"
 "Language-Team: Galician <gl@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Fuso horario"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Editar a partición"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Modo experto"
@@ -149,142 +151,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Actualizar"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Formatar como"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Editar as particións"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Acceder automaticamente"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -313,6 +321,712 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "Ben"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Non"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Si"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Fuso horario"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Idioma"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Distribución do teclado"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Instalación en pausa"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Escriba"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "País"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Disposición"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variante"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Calculando o indexado de ficheiros ..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Distribución do teclado"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Confirma que quere saír do instalador?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Particionando"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Resumo"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Voltar"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Editar as particións"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Dispositivo"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Sistema operativo"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Punto de montaxe"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Formatar como"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Tamaño"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Espazo libre"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Instalar"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Os contrasinais non coinciden."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Saír?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Confirma que quere saír do instalador?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Escolla un idioma"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Escriba un contrasinal para a súa conta de usuario."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Escriba o seu nome completo."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Os contrasinais non coinciden."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "A partición EFI non é de arrinque. Edite as opcións da partición."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Seleccione unha partición raíz (/)."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "A partición EFI non é de arrinque. Edite as opcións da partición."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "A partición EFI debe ter formato vfat."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "A partición EFI debe ter formato vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Seleccione unha partición EFI."
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Escriba un nome de usuario."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Localización"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Idioma: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Fuso horario: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Distribución do teclado: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Configuracións do usuario"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Nome real: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Nome de usuario: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Acceso automático: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "activado"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "desactivado"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Configuracións do sistema"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Operacións do sistema de ficheiros"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Instalar o cargador de arrinque en %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Non instalar cargador de arrinque"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Usar /target xa montado"
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Formatar %(path)s como %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Montar %(path)s como %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Montar %(path)s como %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Instalación rematada"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Completouse a instalación. Quere reiniciar o equipo para utilizar o novo "
+"sistema?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Produciuse un erro durante a instalación"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Extraíbel:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Editar"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Asignar a /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Partición lóxica"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Partición estendida"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Descoñecida"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Editar a partición"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Editar a partición"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Dispositivo"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Formatar como:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Punto de montaxe:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -421,10 +1135,6 @@ msgstr "Os contrasinais non coinciden."
 msgid "Please provide a password for your user account."
 msgstr "Escriba un contrasinal para a súa conta de usuario."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -451,7 +1161,7 @@ msgstr "Engadindo un novo usuario ao sistema"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Escribindo a información da montaxe en /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Montando %(partition)s en %(mountpoint)s"
@@ -471,49 +1181,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formatando %(partition)s como %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Configurando o nome do equipo"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Estabelecendo a configuración rexional"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Configurando o nome do equipo"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Configurando as opcións do teclado"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Retirando a configuración viva (paquetes)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Instalando o cargador de arrinque"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Configurando o cargador de arrinque"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -521,641 +1231,17 @@ msgstr ""
 "AVISO: o cargador de arrinque GRUB non foi configurado correctamente! Ten "
 "que configuralo manualmente."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Instalación rematada"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Comprobando o cargador de arrinque"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "País"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Idioma"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Disposición"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Variante"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Calculando o indexado de ficheiros ..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Distribución do teclado"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Confirma que quere saír do instalador?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Particionando"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Resumo"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Voltar"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Editar as particións"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Dispositivo"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Escriba"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Sistema operativo"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Punto de montaxe"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Formatar como"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Tamaño"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Espazo libre"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Instalar"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Os contrasinais non coinciden."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Saír?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Confirma que quere saír do instalador?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Escolla un idioma"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Escriba un contrasinal para a súa conta de usuario."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Escriba o seu nome completo."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Os contrasinais non coinciden."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "A partición EFI non é de arrinque. Edite as opcións da partición."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Seleccione unha partición raíz (/)."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "A partición EFI non é de arrinque. Edite as opcións da partición."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "A partición EFI debe ter formato vfat."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "A partición EFI debe ter formato vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Seleccione unha partición EFI."
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Escriba un nome de usuario."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Localización"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Idioma: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Fuso horario: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Distribución do teclado: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Configuracións do usuario"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Nome real: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Nome de usuario: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Acceso automático: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "activado"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "desactivado"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Configuracións do sistema"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Operacións do sistema de ficheiros"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Instalar o cargador de arrinque en %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Non instalar cargador de arrinque"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Usar /target xa montado"
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Formatar %(path)s como %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Montar %(path)s como %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Completouse a instalación. Quere reiniciar o equipo para utilizar o novo "
-"sistema?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Produciuse un erro durante a instalación"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Distribución do teclado"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Instalación en pausa"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Fuso horario"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Extraíbel:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Editar"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Asignar a /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Partición lóxica"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Partición estendida"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Descoñecida"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Editar a partición"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Editar a partición"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Dispositivo"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Formatar como:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Punto de montaxe:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "Ben"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Non"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Si"
 
 #~ msgid "Quit"
 #~ msgstr "Saír"

--- a/po/live-installer-gl.po
+++ b/po/live-installer-gl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2019-10-19 17:36+0000\n"
 "Last-Translator: Alberto Gómez <Unknown>\n"
 "Language-Team: Galician <gl@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -189,9 +189,9 @@ msgid "Format"
 msgstr "Formatar como"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -295,6 +295,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Formatar como"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -325,8 +331,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "Ben"
 
@@ -415,23 +421,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "País"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Disposición"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Variante"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Calculando o indexado de ficheiros ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Extraíbel:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Editar"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Asignar a /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -449,10 +526,104 @@ msgstr "Calculando o indexado de ficheiros ..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Espazo libre"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Partición lóxica"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Partición estendida"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Descoñecida"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Editar a partición"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Editar a partición"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Dispositivo"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Formatar como:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Punto de montaxe:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "País"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Disposición"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variante"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Calculando o indexado de ficheiros ..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -567,18 +738,6 @@ msgstr "Formatar como"
 msgid "Size"
 msgstr "Tamaño"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Espazo libre"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -611,25 +770,6 @@ msgstr "Saír?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Confirma que quere saír do instalador?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -869,7 +1009,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Instalación rematada"
 
@@ -890,139 +1030,6 @@ msgstr "Produciuse un erro durante a instalación"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Extraíbel:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Editar"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Asignar a /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Partición lóxica"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Partición estendida"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Descoñecida"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Editar a partición"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Editar a partición"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Dispositivo"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Formatar como:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Punto de montaxe:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1181,49 +1188,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formatando %(partition)s como %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Configurando o nome do equipo"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Estabelecendo a configuración rexional"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Configurando o nome do equipo"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Configurando as opcións do teclado"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Retirando a configuración viva (paquetes)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Instalando o cargador de arrinque"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Configurando o cargador de arrinque"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1231,15 +1238,15 @@ msgstr ""
 "AVISO: o cargador de arrinque GRUB non foi configurado correctamente! Ten "
 "que configuralo manualmente."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Comprobando o cargador de arrinque"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-gv.po
+++ b/po/live-installer-gv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2010-10-12 15:32+0000\n"
 "Last-Translator: Reuben Potts <Unknown>\n"
 "Language-Team: Manx <gv@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -292,6 +292,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -322,8 +327,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -411,23 +416,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Aght cur magh"
-
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -445,9 +521,103 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Reihghyn corys"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Aght cur magh"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -562,18 +732,6 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -605,25 +763,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -858,7 +997,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Cur 'sy co`earrooder jeant"
 
@@ -877,139 +1016,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Reihghyn corys"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1155,63 +1161,63 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Cur er ennym cuirreyder"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Cur er Locale"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Cur er ennym cuirreyder"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Cur er reihghyn mair-chlaa"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Geddyn rey lesh reihghyn bio (bundeilyn)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Cur laadeyderbrebbal 'sy co`earrooder"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-gv.po
+++ b/po/live-installer-gv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2010-10-12 15:32+0000\n"
 "Last-Translator: Reuben Potts <Unknown>\n"
 "Language-Team: Manx <gv@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,141 +149,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Reihghyn corys"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -310,6 +318,702 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Aght cur magh mair-chlaa: "
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Greie cur 'sy co`earrooder"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Aght cur magh"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Saase"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Ynnydaghys"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "çhengey: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Crysstraa: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Aght cur magh mair-chlaa: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Reihghyn ymmydeyr"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Ennym kiart: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Ennym ymmydeyr: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Reihghyn corys"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Obbreeaghtyn corys coadanyn"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Ny jean cur laadeyderbrebbal 'sy co`earrooder"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Cur 'sy co`earrooder jeant"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Reihghyn corys"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -405,10 +1109,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -435,7 +1135,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr ""
@@ -455,678 +1155,64 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Cur er ennym cuirreyder"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Cur er Locale"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Cur er ennym cuirreyder"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Cur er reihghyn mair-chlaa"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Geddyn rey lesh reihghyn bio (bundeilyn)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Cur laadeyderbrebbal 'sy co`earrooder"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Cur 'sy co`earrooder jeant"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Aght cur magh"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Saase"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Ynnydaghys"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "çhengey: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Crysstraa: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Aght cur magh mair-chlaa: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Reihghyn ymmydeyr"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Ennym kiart: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Ennym ymmydeyr: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Reihghyn corys"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Obbreeaghtyn corys coadanyn"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Ny jean cur laadeyderbrebbal 'sy co`earrooder"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Aght cur magh mair-chlaa: "
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Greie cur 'sy co`earrooder"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Reihghyn corys"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #, fuzzy

--- a/po/live-installer-he.po
+++ b/po/live-installer-he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2018-08-14 08:10+0000\n"
 "Last-Translator: Yaron <sh.yaron@gmail.com>\n"
 "Language-Team: Hebrew <he@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "ג״ב"
 
@@ -189,9 +189,9 @@ msgid "Format"
 msgstr "פרמט כ:"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -295,6 +295,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "פרמט כ:"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -325,8 +331,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "אישור"
 
@@ -415,23 +421,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "מדינה"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "בייט"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "פריסה"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "ק\"ב"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "חלופה"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "מ\"ב"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "מפתחות הקבצים מחושבים…"
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "ט״ב"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "התקנים נשלפים:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "עריכה"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "מוקצה ל־/"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -449,10 +526,104 @@ msgstr "מפתחות הקבצים מחושבים…"
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "ייתרה"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "מחיצה לוגית"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "מחיצה מורחבת"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "לא ידוע"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "עריכת מחיצה"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "עריכת מחיצה"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "התקן:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "אתחול בתור:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "נקודת עגינה:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "ביטול"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "מדינה"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "פריסה"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "חלופה"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "מפתחות הקבצים מחושבים…"
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -567,18 +738,6 @@ msgstr "פרמט כ:"
 msgid "Size"
 msgstr "נפח"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "ייתרה"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -611,25 +770,6 @@ msgstr "לצאת?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "אתה בטוח שברצונך לצאת מההתקנה?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -869,7 +1009,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "ההתקנה הסתיימה"
 
@@ -888,139 +1028,6 @@ msgstr "שגיאה במהלך ההתקנה"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "בייט"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "ק\"ב"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "מ\"ב"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "ט״ב"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "התקנים נשלפים:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "עריכה"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "מוקצה ל־/"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "מחיצה לוגית"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "מחיצה מורחבת"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "לא ידוע"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "עריכת מחיצה"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "עריכת מחיצה"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "התקן:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "אתחול בתור:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "נקודת עגינה:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "ביטול"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1179,63 +1186,63 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "מפרמט %(partition)s כ %(format)s .."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "הגדרת כינוי המחשב"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "הגדרת מיקום"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "הגדרת כינוי המחשב"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "הגדרות מקלדת"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "מסיר קונפיגירצייה חיה (חבילות)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "מתקין את מנהל האיתחול"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "מגדיר את מנהל האיתחול"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr "אזהרה: grub bootloader לא הוגדר כראוי! אתה צריך להגדיר אותו ידנית."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "בודק את מנהל האיתחול"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-he.po
+++ b/po/live-installer-he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2018-08-14 08:10+0000\n"
 "Last-Translator: Yaron <sh.yaron@gmail.com>\n"
 "Language-Team: Hebrew <he@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "אזור זמן"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "עריכת מחיצה"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "ג״ב"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "מצב מומחה"
@@ -149,142 +151,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "רענון"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "פרמט כ:"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "ערוך מחיצות"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "הכנס אוטומטית"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -313,6 +321,710 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "אישור"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "אזור זמן"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "שפה"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "פריסת המקלדת"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "ההתקנה הופסקה"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "סוג"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "מדינה"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "פריסה"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "חלופה"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "מפתחות הקבצים מחושבים…"
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "פריסת המקלדת"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "אתה בטוח שברצונך לצאת מההתקנה?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "הפרדה למחיצות"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "תקציר"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "חזרה"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "ערוך מחיצות"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "התקן"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "מערכת הפעלה"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "נקודת עגינה"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "פרמט כ:"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "נפח"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "ייתרה"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "הסיסמאות שלך אינן תואמות"
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "לצאת?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "אתה בטוח שברצונך לצאת מההתקנה?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "בחר את השפה שלך"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "בחר סיסמה לחשבון המשתמש"
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "אנא רשום את השם המלא שלך"
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "הסיסמאות שלך אינן תואמות"
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "מחיצת ה־EFI אינה אפשרית לאתחול. ערוך את דגלי המחיצות."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "בחר מערכת קבצים לפרמוט נתיב השורש"
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "מחיצת ה־EFI אינה אפשרית לאתחול. ערוך את דגלי המחיצות."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "מחיצת ה־EFI חייבת להיות בפורמט vfat"
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "מחיצת ה־EFI חייבת להיות בפורמט vfat"
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "נא לבחור במחיצת EFI"
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "בחר שם משתמש."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "הגדרות תלויות מיקום"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "שפה: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "אזור זמן: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "פריסת מקלדת: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "הגדרות משתמש"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "שם (אמיתי): "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "כינוי משתמש: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "התחברות אוטומטית: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "מאופשר"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "מנוטרל"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "הגדרות מערכת"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "פעולות מערכת קבצים"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "התקן את מנהל האתחול (bootloader) ב־%s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "אל תתקין bootloader"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "שימוש ב־‎/target שכבר נעגן."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "אתחול %(path)s בתור %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "עיגון %(path)s בתור %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "עיגון %(path)s בתור %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "ההתקנה הסתיימה"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr "ההתקנה הושלמה. להפעיל מחדש את המחשב למערכת החדשה?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "שגיאה במהלך ההתקנה"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "בייט"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "ק\"ב"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "מ\"ב"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "ט״ב"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "התקנים נשלפים:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "עריכה"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "מוקצה ל־/"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "מחיצה לוגית"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "מחיצה מורחבת"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "לא ידוע"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "עריכת מחיצה"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "עריכת מחיצה"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "התקן:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "אתחול בתור:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "נקודת עגינה:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "ביטול"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -421,10 +1133,6 @@ msgstr "הסיסמאות שלך אינן תואמות"
 msgid "Please provide a password for your user account."
 msgstr "בחר סיסמה לחשבון המשתמש"
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -451,7 +1159,7 @@ msgstr "מוסיף משתמש חדש למערכת"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "כותב מידע של טעינת מערכת הקבצים ל /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "%(partition)s מעוגנת בתור%(mountpoint)s"
@@ -471,686 +1179,64 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "מפרמט %(partition)s כ %(format)s .."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "הגדרת כינוי המחשב"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "הגדרת מיקום"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "הגדרת כינוי המחשב"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "הגדרות מקלדת"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "מסיר קונפיגירצייה חיה (חבילות)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "מתקין את מנהל האיתחול"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "מגדיר את מנהל האיתחול"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr "אזהרה: grub bootloader לא הוגדר כראוי! אתה צריך להגדיר אותו ידנית."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "ההתקנה הסתיימה"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "בודק את מנהל האיתחול"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "מדינה"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "שפה"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "פריסה"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "חלופה"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "מפתחות הקבצים מחושבים…"
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "פריסת המקלדת"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "אתה בטוח שברצונך לצאת מההתקנה?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "הפרדה למחיצות"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "תקציר"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "חזרה"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "ערוך מחיצות"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "התקן"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "סוג"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "מערכת הפעלה"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "נקודת עגינה"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "פרמט כ:"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "נפח"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "ייתרה"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "הסיסמאות שלך אינן תואמות"
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "לצאת?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "אתה בטוח שברצונך לצאת מההתקנה?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "בחר את השפה שלך"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "בחר סיסמה לחשבון המשתמש"
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "אנא רשום את השם המלא שלך"
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "הסיסמאות שלך אינן תואמות"
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "מחיצת ה־EFI אינה אפשרית לאתחול. ערוך את דגלי המחיצות."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "בחר מערכת קבצים לפרמוט נתיב השורש"
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "מחיצת ה־EFI אינה אפשרית לאתחול. ערוך את דגלי המחיצות."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "מחיצת ה־EFI חייבת להיות בפורמט vfat"
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "מחיצת ה־EFI חייבת להיות בפורמט vfat"
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "נא לבחור במחיצת EFI"
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "בחר שם משתמש."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "הגדרות תלויות מיקום"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "שפה: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "אזור זמן: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "פריסת מקלדת: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "הגדרות משתמש"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "שם (אמיתי): "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "כינוי משתמש: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "התחברות אוטומטית: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "מאופשר"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "מנוטרל"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "הגדרות מערכת"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "פעולות מערכת קבצים"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "התקן את מנהל האתחול (bootloader) ב־%s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "אל תתקין bootloader"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "שימוש ב־‎/target שכבר נעגן."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "אתחול %(path)s בתור %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "עיגון %(path)s בתור %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr "ההתקנה הושלמה. להפעיל מחדש את המחשב למערכת החדשה?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "שגיאה במהלך ההתקנה"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "פריסת המקלדת"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "ההתקנה הופסקה"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "אזור זמן"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "בייט"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "ק\"ב"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "מ\"ב"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "ט״ב"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "התקנים נשלפים:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "עריכה"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "מוקצה ל־/"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "מחיצה לוגית"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "מחיצה מורחבת"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "לא ידוע"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "עריכת מחיצה"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "עריכת מחיצה"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "התקן:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "אתחול בתור:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "נקודת עגינה:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "ביטול"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "אישור"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Quit"

--- a/po/live-installer-hi.po
+++ b/po/live-installer-hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2018-09-28 07:34+0000\n"
 "Last-Translator: Panwar <Unknown>\n"
 "Language-Team: Hindi <hi@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -189,9 +189,9 @@ msgid "Format"
 msgstr "के रूप में फॉर्मेट करें"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -295,6 +295,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "के रूप में फॉर्मेट करें"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -325,8 +331,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "ठीक है"
 
@@ -415,23 +421,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "देश"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "अभिन्यास"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "प्रकार"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "फ़ाइल के अनुक्रमण की गणना की जा रही है"
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "हटाने योग्य"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "संपादित करें"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "/ को आवंटित करें"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -449,10 +526,104 @@ msgstr "फ़ाइल के अनुक्रमण की गणना की 
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "ख़ाली स्पेस"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "तार्किक विभाजन"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "विस्तृत विभाजन"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "अज्ञात"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "विभाजन संपादित करें"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "विभाजन संपादित करें"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "डिवाइस :"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "के रूप में फॉर्मेट करें :"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "माउंट पॉइंट :"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "रद्द करें"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "देश"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "अभिन्यास"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "प्रकार"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "फ़ाइल के अनुक्रमण की गणना की जा रही है"
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -567,18 +738,6 @@ msgstr "के रूप में फॉर्मेट करें"
 msgid "Size"
 msgstr "आकार"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "ख़ाली स्पेस"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -611,25 +770,6 @@ msgstr "छोड़ें?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "क्या आप वाकई इंस्टॉलर को बंद करना चाहते है?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -869,7 +1009,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "इंस्टॉल समाप्त"
 
@@ -889,139 +1029,6 @@ msgstr "इंस्टॉल त्रुटि"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "हटाने योग्य"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "संपादित करें"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "/ को आवंटित करें"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "तार्किक विभाजन"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "विस्तृत विभाजन"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "अज्ञात"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "विभाजन संपादित करें"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "विभाजन संपादित करें"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "डिवाइस :"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "के रूप में फॉर्मेट करें :"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "माउंट पॉइंट :"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "रद्द करें"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1180,49 +1187,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "%(partition)s को फॉर्मेट किया जा रहा है %(format)s के रूप में ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "होस्ट नाम सेट हो रहा है"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "स्थानिकी सेट हो रही है"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "होस्ट नाम सेट हो रहा है"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "कुंजीपटल विकल्प सेट किए जा रहे हैं"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "लाइव विन्यस्त (पैकेज) हटाएँ जा रहे हैं"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "बूट लोडर इंस्टॉल किया जा रहा है"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "बूट लोडर विन्यस्त किया जा रहा है"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1230,15 +1237,15 @@ msgstr ""
 "चेतावनी: grub बूट लोडर ठीक से विन्यस्त नहीं हुआ है। आपको इसे मैनुअल रूप से खुद ही करना "
 "पड़ेगा।"
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "बूट लोडर जाँचा जा रहा है"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-hi.po
+++ b/po/live-installer-hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2018-09-28 07:34+0000\n"
 "Last-Translator: Panwar <Unknown>\n"
 "Language-Team: Hindi <hi@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "समय क्षेत्र"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "विभाजन संपादित करें"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "विशेषज्ञ मोड"
@@ -149,142 +151,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "रिफ्रेश करें"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "के रूप में फॉर्मेट करें"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "विभाजन संपादित करें"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "स्वतः लॉग इन करें"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -313,6 +321,711 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "ठीक है"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "नहीं"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "हाँ"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "समय क्षेत्र"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "भाषा"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "कुंजीपटल अभिन्यास"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "इंस्टॉल रोका गया"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "प्रकार"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "देश"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "अभिन्यास"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "प्रकार"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "फ़ाइल के अनुक्रमण की गणना की जा रही है"
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "कुंजीपटल अभिन्यास"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "क्या आप वाकई इंस्टॉलर को बंद करना चाहते है?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "डिस्क विभाजन किया जा रहा है"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "सार"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "वापस जाएँ"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "विभाजन संपादित करें"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "डिवाइस"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "ऑपरेटिंग सिस्टम"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "माउंट पॉइंट"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "के रूप में फॉर्मेट करें"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "आकार"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "ख़ाली स्पेस"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "इंस्‍टॉल करें"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "कूटशब्द मेल नहीं खाते।"
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "छोड़ें?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "क्या आप वाकई इंस्टॉलर को बंद करना चाहते है?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "भाषा चुनें"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "कृपया उपयोक्ता अकाउंट हेतु कूटशब्द दर्ज करें।"
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "कृपया पूरा नाम दर्ज करें।"
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "कूटशब्द मेल नहीं खाते।"
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "EFI विभाजन बूट योग्य नहीं है। कृपया विभाजन flags संपादित करें।"
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "रुट(/) विभाजन चुनें।"
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "EFI विभाजन बूट योग्य नहीं है। कृपया विभाजन flags संपादित करें।"
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "EFI विभाजन vfat के रूप में फॉर्मेट होना चाहिए।"
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "EFI विभाजन vfat के रूप में फॉर्मेट होना चाहिए।"
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "EFI विभाजन चुनें।"
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "कृपया उपयोक्ता नाम दर्ज करें।"
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "स्थानीयकरण"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "भाषा: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "समय क्षेत्र: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "कुंजीपटल अभिन्यास: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "उपयोक्ता सेटिंग्स"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "असली नाम: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "उपयोक्ता नाम: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "स्वतः लॉगिन: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "चालू है"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "बंद है"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "सिस्टम सेटिंग्स"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "फ़ाइल सिस्टम कार्य"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "बूट लोडर %s पर इंस्टॉल करें"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "बूट लोडर न इंस्टॉल करें"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "पहले माउंट हो रखे /target का उपयोग करें"
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "%(path)s को %(filesystem)s के रूप में फॉर्मेट करें"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "%(path)s को %(mount)s पर माउंट करें"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "%(path)s को %(mount)s पर माउंट करें"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "इंस्टॉल समाप्त"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"इंस्टॉल पूर्ण हुआ। क्या अब आप कंप्यूटर को पुनः आरंभ कर नया सिस्टम उपयोग करना चाहते हैं?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "इंस्टॉल त्रुटि"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "हटाने योग्य"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "संपादित करें"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "/ को आवंटित करें"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "तार्किक विभाजन"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "विस्तृत विभाजन"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "अज्ञात"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "विभाजन संपादित करें"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "विभाजन संपादित करें"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "डिवाइस :"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "के रूप में फॉर्मेट करें :"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "माउंट पॉइंट :"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "रद्द करें"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -421,10 +1134,6 @@ msgstr "कूटशब्द मेल नहीं खाते।"
 msgid "Please provide a password for your user account."
 msgstr "कृपया उपयोक्ता अकाउंट हेतु कूटशब्द दर्ज करें।"
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -451,7 +1160,7 @@ msgstr "नए उपयोक्ता को सिस्टम में ज�
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "फ़ाइल सिस्टम माउंट की जानकारी /etc/fstab पर राइट की जा रही है"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "%(partition)s को %(mountpoint)s पर माउंट किया जा रहा है"
@@ -471,49 +1180,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "%(partition)s को फॉर्मेट किया जा रहा है %(format)s के रूप में ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "होस्ट नाम सेट हो रहा है"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "स्थानिकी सेट हो रही है"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "होस्ट नाम सेट हो रहा है"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "कुंजीपटल विकल्प सेट किए जा रहे हैं"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "लाइव विन्यस्त (पैकेज) हटाएँ जा रहे हैं"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "बूट लोडर इंस्टॉल किया जा रहा है"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "बूट लोडर विन्यस्त किया जा रहा है"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -521,640 +1230,17 @@ msgstr ""
 "चेतावनी: grub बूट लोडर ठीक से विन्यस्त नहीं हुआ है। आपको इसे मैनुअल रूप से खुद ही करना "
 "पड़ेगा।"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "इंस्टॉल समाप्त"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "बूट लोडर जाँचा जा रहा है"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "देश"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "भाषा"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "अभिन्यास"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "प्रकार"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "फ़ाइल के अनुक्रमण की गणना की जा रही है"
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "कुंजीपटल अभिन्यास"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "क्या आप वाकई इंस्टॉलर को बंद करना चाहते है?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "डिस्क विभाजन किया जा रहा है"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "सार"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "वापस जाएँ"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "विभाजन संपादित करें"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "डिवाइस"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "प्रकार"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "ऑपरेटिंग सिस्टम"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "माउंट पॉइंट"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "के रूप में फॉर्मेट करें"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "आकार"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "ख़ाली स्पेस"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "इंस्‍टॉल करें"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "कूटशब्द मेल नहीं खाते।"
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "छोड़ें?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "क्या आप वाकई इंस्टॉलर को बंद करना चाहते है?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "भाषा चुनें"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "कृपया उपयोक्ता अकाउंट हेतु कूटशब्द दर्ज करें।"
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "कृपया पूरा नाम दर्ज करें।"
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "कूटशब्द मेल नहीं खाते।"
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "EFI विभाजन बूट योग्य नहीं है। कृपया विभाजन flags संपादित करें।"
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "रुट(/) विभाजन चुनें।"
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "EFI विभाजन बूट योग्य नहीं है। कृपया विभाजन flags संपादित करें।"
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "EFI विभाजन vfat के रूप में फॉर्मेट होना चाहिए।"
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "EFI विभाजन vfat के रूप में फॉर्मेट होना चाहिए।"
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "EFI विभाजन चुनें।"
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "कृपया उपयोक्ता नाम दर्ज करें।"
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "स्थानीयकरण"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "भाषा: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "समय क्षेत्र: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "कुंजीपटल अभिन्यास: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "उपयोक्ता सेटिंग्स"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "असली नाम: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "उपयोक्ता नाम: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "स्वतः लॉगिन: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "चालू है"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "बंद है"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "सिस्टम सेटिंग्स"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "फ़ाइल सिस्टम कार्य"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "बूट लोडर %s पर इंस्टॉल करें"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "बूट लोडर न इंस्टॉल करें"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "पहले माउंट हो रखे /target का उपयोग करें"
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "%(path)s को %(filesystem)s के रूप में फॉर्मेट करें"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "%(path)s को %(mount)s पर माउंट करें"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"इंस्टॉल पूर्ण हुआ। क्या अब आप कंप्यूटर को पुनः आरंभ कर नया सिस्टम उपयोग करना चाहते हैं?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "इंस्टॉल त्रुटि"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "कुंजीपटल अभिन्यास"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "इंस्टॉल रोका गया"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "समय क्षेत्र"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "हटाने योग्य"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "संपादित करें"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "/ को आवंटित करें"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "तार्किक विभाजन"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "विस्तृत विभाजन"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "अज्ञात"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "विभाजन संपादित करें"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "विभाजन संपादित करें"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "डिवाइस :"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "के रूप में फॉर्मेट करें :"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "माउंट पॉइंट :"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "रद्द करें"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "ठीक है"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "नहीं"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "हाँ"
 
 #~ msgid "Quit"
 #~ msgstr "छोड़ें"

--- a/po/live-installer-hr.po
+++ b/po/live-installer-hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2020-03-10 11:55+0000\n"
 "Last-Translator: gogo <trebelnik2@gmail.com>\n"
 "Language-Team: Croatian <hr@li.org>\n"
@@ -24,8 +24,8 @@ msgid "Welcome to the 17g Installer."
 msgstr "Dobrodošli u 17G instalacijski program."
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 #, fuzzy
 msgid ""
 "This program will ask you some questions and set up system on your computer."
@@ -34,12 +34,12 @@ msgstr ""
 "računalu."
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr "Model tipkovnice:"
 
@@ -49,10 +49,12 @@ msgid "Type here to test your keyboard"
 msgstr "Upišite nešto ovdje kako bi testirali raspored tipkovnice"
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -61,13 +63,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Vremenska zona"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr "Automatska instalacija"
 
@@ -77,12 +79,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr "Obriši disk i instaliraj 17G na njega."
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr "Disk:"
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Uređivanje particije"
@@ -93,42 +95,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr "Koristi ULU (Upravitelja Logičkim Uređajima)"
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr "Šifriraj operativni sustav"
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr "Lozinka"
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr "Potvrdi lozinku"
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr "Ovo omogućuje dodatnu sigurnost, ali može potrajati satima."
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr "Napuni disk naizmjeničnim podacima"
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr "Ručno particioniranje"
 
@@ -146,7 +148,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Napredni način"
@@ -156,144 +158,150 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 #, fuzzy
 msgid "Minimal installation"
 msgstr "Automatska instalacija"
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Osvježi"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Formatiraj kao"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr "Instaliraj GRUB izbornik pokretanja sustava na:"
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Uredi particije"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr "Vaše ime:"
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr "Naziv vašeg računala:"
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr "Odaberite korisničko ime:"
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr "Naziv koji će se koristiti za komunikaciju s ostalim računalima."
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr "Odaberite lozinku:"
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Automatska prijava"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr "Zatraži moju lozinku prilikom prijave"
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr "Šifriraj moju osobnu mapu"
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr "Potvrdite vašu lozinku:"
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 #, fuzzy
 msgid "Automated installation enabled!"
 msgstr "Automatska instalacija na %s"
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr "Dobrodošli"
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -324,6 +332,744 @@ msgstr ""
 #, fuzzy
 msgid "Welcome to 17g"
 msgstr "Dobrodošli"
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "U redu"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Ne"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Da"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Vremenska zona"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, fuzzy, python-format
+msgid "Welcome to the %s Installer."
+msgstr "Dobrodošli u 17G instalacijski program."
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr "Koji jezik želite koristiti?"
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Jezik"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr "Gdje se nalazite?"
+
+#: live-installer/frontend/tui_interface.py:57
+#, fuzzy
+msgid "What keyboard would you like to use?"
+msgstr "Koji jezik želite koristiti?"
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Model tipkovnice:"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Vrsta instalacije"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Vrsta"
+
+#: live-installer/frontend/tui_interface.py:80
+#, fuzzy
+msgid "Select a disk?"
+msgstr "Odaberite disk."
+
+#: live-installer/frontend/tui_interface.py:84
+#, fuzzy
+msgid "Disk"
+msgstr "Disk:"
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, fuzzy, python-format
+msgid "Welcome to %s"
+msgstr "Dobrodošli"
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Zemlja"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Raspored"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Varijanta"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Stvaranje popisa datoteka..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr "Instalacijski program"
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Raspored tipkovnice"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr "Koji je vaš raspored tipkovnice?"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr "Korisnički račun"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr "Tko ste vi?"
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr "Vrsta instalacije"
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Gdje želite instalirati 17G?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Particioniranje"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Sažetak"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr "Instalacija"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+#, fuzzy
+msgid "Automated Install"
+msgstr "Automatska instalacija"
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Prijašnje"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr "Sljedeće"
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr "Upišite nešto ovdje kako bi testirali raspored tipkovnice"
+
+#: live-installer/frontend/gtk_interface.py:546
+#, fuzzy
+msgid "Erase a disk and install system on it."
+msgstr "Obriši disk i instaliraj 17G na njega."
+
+#: live-installer/frontend/gtk_interface.py:559
+#, fuzzy
+msgid "Manually create, resize or choose partitions for system."
+msgstr "Ručno, stvorite, promijenite veličinu ili odaberite particije za 17G."
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Uredi particije"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Uređaj"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Operativni sustav"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Točka montiranja"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Formatiraj kao"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Veličina"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Slobodan prostor"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr "Upozorenje"
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr "Ovo će obrisati sve podatake na %s. Jeste li sigurni?"
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Instaliraj"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr "Navedite lozinku za šifriranje."
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Vaša lozinka se ne podudara."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Zatvori?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Sigurno želite zatvoriti instalacijski program?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Odaberite jezik"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Upišite naziv vašeg računala."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Upišite svoje ime i prezime."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Vaša lozinka se ne podudara."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "EFI particija je premala. Mora biti najmanje 35MB velika."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Odaberite korijensku (/) particiju."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, fuzzy, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+"Korijenska particija je potrebna za instalciju Linux Minta.\n"
+"\n"
+" - Točka montiranja: /\n"
+" - Preporučljiva veličina: 30GB\n"
+" - Preporučljivi format datotečnog sustava: ext4\n"
+"\n"
+"Napomena: Značajka stvaranja Timeshift btrfs snimka sustava zahtijeva "
+"korištenje:\n"
+" - točke montiranja poduređaja /@\n"
+" - btrfs kao format datotečnog sustava\n"
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "EFI particija ne može pokrenuti sustav. Uredite oznake particije."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "EFI particija je premala. Mora biti najmanje 35MB velika."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "EFI particija mora biti formatirana u vfat datotečnom sustavu."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Odaberite EFI particiju."
+
+#: live-installer/frontend/gtk_interface.py:1301
+#, fuzzy
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+"EFI particija sustava je potrebna sa sljedećim značajkama:\n"
+"\n"
+" - Točka montiranja: /boot/efi\n"
+" - Oznaka particije: Bootable\n"
+" - Veličina: najmanje 35MB (100MB ili više je preporučljivo)\n"
+" - Format datotečnog sustava: vfat ili fat32\n"
+"\n"
+"Kako bi osigurali kompatibilnost sa Windowsima preporučujemo vam korištenje "
+"prve particije na disku kao EFI particije sustava.\n"
+" "
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr "Odaberite disk."
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Upišite svoje korisničko ime."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Lokalizacija"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Jezik: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Vremenska zona: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Raspodred tipkovnice: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Korisničke postavke"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Vaše ime: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Korisničko ime: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Automatska prijava: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "omogućena"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "onemogućena"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Postavke sustava"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr "Naziv računala: "
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+#, fuzzy
+msgid "Install updates after installation"
+msgstr "Automatska instalacija"
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Radnje datotečnog sustava"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Instaliraj učitača pokretanja sustava na %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Nemoj instalalirati učitača pokretanja sustava"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Koristi već montirano /odredište."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr "Automatska instalacija na %s"
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Formatiraj %(path)s kao %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Montiraj %(path)s na %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Montiraj %(path)s na %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr "ULU: "
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr "Šifriranje diska: "
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Instalacija završena"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Instalacija je sada završena. Želite li ponovno pokrenuti vaše računalo kako "
+"bi počeli koristiti vaš novi sustav?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Greška instalacije"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Uklonjivo:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Uredi"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Dodijeli /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"Particijska tablica se ne može zapisati na %s. Ponovno pokrenite računalo i "
+"pokušajte ponovno."
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"Particija %s se ne može stvoriti. Instalacija će se zaustaviti. Ponovno "
+"pokrenite računalo i pokušajte ponovno."
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Logička particija"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Proširena particija"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Nepoznata"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Uređivanje particije"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Uređivanje particije"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Uređaj:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Formatiraj kao:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Točka montiranja:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Odustani"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
+msgstr ""
 
 #: live-installer/validate.py:12
 msgid "Please provide a username."
@@ -433,10 +1179,6 @@ msgstr "Vaša lozinka se ne podudara."
 msgid "Please provide a password for your user account."
 msgstr "Upišite lozinku za vaš korisnički račun."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -463,7 +1205,7 @@ msgstr "Dodavanje novog korisnika u sustav"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Zapisivanje informacija montiranja datotečnog sustava u /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Montiranje %(partition)s na %(mountpoint)s"
@@ -485,49 +1227,49 @@ msgstr "Stvaranje particije na %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formatiranje %(partition)s kao %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Postavljanje naziva računala"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Postavljanje lokalnih postavki"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Postavljanje naziva računala"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Postavljanje mogućnosti tipkovnice"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Uklanjanje live podešavanja (paketi)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Instalacija učitača pokretanja sustava"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Podešavam učitača pokretanja sustava"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -535,673 +1277,17 @@ msgstr ""
 "UPOZORENJE: Grub učitač pokretanja sustava nije ispravno prilagođen! "
 "Prilagodite ga ručno."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Instalacija završena"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Provjeravam učitača pokretanja sustava"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Zemlja"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Jezik"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Raspored"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Varijanta"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Stvaranje popisa datoteka..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr "Instalacijski program"
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr "Koji jezik želite koristiti?"
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr "Gdje se nalazite?"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Raspored tipkovnice"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr "Koji je vaš raspored tipkovnice?"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr "Korisnički račun"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr "Tko ste vi?"
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr "Vrsta instalacije"
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Gdje želite instalirati 17G?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Particioniranje"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Sažetak"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr "Instalacija"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-#, fuzzy
-msgid "Automated install"
-msgstr "Automatska instalacija"
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Prijašnje"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr "Sljedeće"
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, fuzzy, python-format
-msgid "Welcome to the %s Installer."
-msgstr "Dobrodošli u 17G instalacijski program."
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr "Upišite nešto ovdje kako bi testirali raspored tipkovnice"
-
-#: live-installer/frontend/gtk_interface.py:542
-#, fuzzy
-msgid "Erase a disk and install system on it."
-msgstr "Obriši disk i instaliraj 17G na njega."
-
-#: live-installer/frontend/gtk_interface.py:555
-#, fuzzy
-msgid "Manually create, resize or choose partitions for system."
-msgstr "Ručno, stvorite, promijenite veličinu ili odaberite particije za 17G."
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Uredi particije"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Uređaj"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Vrsta"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Operativni sustav"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Točka montiranja"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Formatiraj kao"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Veličina"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Slobodan prostor"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Instaliraj"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr "Navedite lozinku za šifriranje."
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Vaša lozinka se ne podudara."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Zatvori?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Sigurno želite zatvoriti instalacijski program?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Odaberite jezik"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Upišite naziv vašeg računala."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Upišite svoje ime i prezime."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Vaša lozinka se ne podudara."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "EFI particija je premala. Mora biti najmanje 35MB velika."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Odaberite korijensku (/) particiju."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, fuzzy, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-"Korijenska particija je potrebna za instalciju Linux Minta.\n"
-"\n"
-" - Točka montiranja: /\n"
-" - Preporučljiva veličina: 30GB\n"
-" - Preporučljivi format datotečnog sustava: ext4\n"
-"\n"
-"Napomena: Značajka stvaranja Timeshift btrfs snimka sustava zahtijeva "
-"korištenje:\n"
-" - točke montiranja poduređaja /@\n"
-" - btrfs kao format datotečnog sustava\n"
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "EFI particija ne može pokrenuti sustav. Uredite oznake particije."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "EFI particija je premala. Mora biti najmanje 35MB velika."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "EFI particija mora biti formatirana u vfat datotečnom sustavu."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Odaberite EFI particiju."
-
-#: live-installer/frontend/gtk_interface.py:1226
-#, fuzzy
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-"EFI particija sustava je potrebna sa sljedećim značajkama:\n"
-"\n"
-" - Točka montiranja: /boot/efi\n"
-" - Oznaka particije: Bootable\n"
-" - Veličina: najmanje 35MB (100MB ili više je preporučljivo)\n"
-" - Format datotečnog sustava: vfat ili fat32\n"
-"\n"
-"Kako bi osigurali kompatibilnost sa Windowsima preporučujemo vam korištenje "
-"prve particije na disku kao EFI particije sustava.\n"
-" "
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr "Odaberite disk."
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr "Upozorenje"
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr "Ovo će obrisati sve podatake na %s. Jeste li sigurni?"
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Upišite svoje korisničko ime."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Lokalizacija"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Jezik: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Vremenska zona: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Raspodred tipkovnice: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Korisničke postavke"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Vaše ime: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Korisničko ime: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Automatska prijava: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "omogućena"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "onemogućena"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Postavke sustava"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr "Naziv računala: "
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-#, fuzzy
-msgid "Install updates after installation"
-msgstr "Automatska instalacija"
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Radnje datotečnog sustava"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Instaliraj učitača pokretanja sustava na %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Nemoj instalalirati učitača pokretanja sustava"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Koristi već montirano /odredište."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr "Automatska instalacija na %s"
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Formatiraj %(path)s kao %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Montiraj %(path)s na %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr "ULU: "
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr "Šifriranje diska: "
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Instalacija je sada završena. Želite li ponovno pokrenuti vaše računalo kako "
-"bi počeli koristiti vaš novi sustav?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Greška instalacije"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, fuzzy, python-format
-msgid "Welcome to %s"
-msgstr "Dobrodošli"
-
-#: live-installer/frontend/tui_interface.py:57
-#, fuzzy
-msgid "What keyboard would you like to use?"
-msgstr "Koji jezik želite koristiti?"
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Model tipkovnice:"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Vrsta instalacije"
-
-#: live-installer/frontend/tui_interface.py:80
-#, fuzzy
-msgid "Select a disk?"
-msgstr "Odaberite disk."
-
-#: live-installer/frontend/tui_interface.py:84
-#, fuzzy
-msgid "Disk"
-msgstr "Disk:"
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Vremenska zona"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Uklonjivo:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Uredi"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Dodijeli /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"Particijska tablica se ne može zapisati na %s. Ponovno pokrenite računalo i "
-"pokušajte ponovno."
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"Particija %s se ne može stvoriti. Instalacija će se zaustaviti. Ponovno "
-"pokrenite računalo i pokušajte ponovno."
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Logička particija"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Proširena particija"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Nepoznata"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Uređivanje particije"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Uređivanje particije"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Uređaj:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Formatiraj kao:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Točka montiranja:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Odustani"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "U redu"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Ne"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Da"
 
 #~ msgid "Quit"
 #~ msgstr "Zatvori"

--- a/po/live-installer-hr.po
+++ b/po/live-installer-hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2020-03-10 11:55+0000\n"
 "Last-Translator: gogo <trebelnik2@gmail.com>\n"
 "Language-Team: Croatian <hr@li.org>\n"
@@ -95,7 +95,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -197,9 +197,9 @@ msgid "Format"
 msgstr "Formatiraj kao"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -304,6 +304,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Formatiraj kao"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -335,8 +341,8 @@ msgstr "Dobrodošli"
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "U redu"
 
@@ -428,23 +434,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr "Dobrodošli"
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Zemlja"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Raspored"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Varijanta"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Stvaranje popisa datoteka..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Uklonjivo:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Uredi"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Dodijeli /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -462,10 +539,108 @@ msgstr "Stvaranje popisa datoteka..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr "Instalacijski program"
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Slobodan prostor"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"Particijska tablica se ne može zapisati na %s. Ponovno pokrenite računalo i "
+"pokušajte ponovno."
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"Particija %s se ne može stvoriti. Instalacija će se zaustaviti. Ponovno "
+"pokrenite računalo i pokušajte ponovno."
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Logička particija"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Proširena particija"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Nepoznata"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Uređivanje particije"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Uređivanje particije"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Uređaj:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Formatiraj kao:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Točka montiranja:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Odustani"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Zemlja"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Raspored"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Varijanta"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Stvaranje popisa datoteka..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -583,18 +758,6 @@ msgstr "Formatiraj kao"
 msgid "Size"
 msgstr "Veličina"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Slobodan prostor"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -627,25 +790,6 @@ msgstr "Zatvori?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Sigurno želite zatvoriti instalacijski program?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -907,7 +1051,7 @@ msgid "Disk Encryption: "
 msgstr "Šifriranje diska: "
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Instalacija završena"
 
@@ -928,143 +1072,6 @@ msgstr "Greška instalacije"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Uklonjivo:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Uredi"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Dodijeli /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"Particijska tablica se ne može zapisati na %s. Ponovno pokrenite računalo i "
-"pokušajte ponovno."
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"Particija %s se ne može stvoriti. Instalacija će se zaustaviti. Ponovno "
-"pokrenite računalo i pokušajte ponovno."
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Logička particija"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Proširena particija"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Nepoznata"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Uređivanje particije"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Uređivanje particije"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Uređaj:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Formatiraj kao:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Točka montiranja:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Odustani"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1227,49 +1234,49 @@ msgstr "Stvaranje particije na %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formatiranje %(partition)s kao %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Postavljanje naziva računala"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Postavljanje lokalnih postavki"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Postavljanje naziva računala"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Postavljanje mogućnosti tipkovnice"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Uklanjanje live podešavanja (paketi)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Instalacija učitača pokretanja sustava"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Podešavam učitača pokretanja sustava"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1277,15 +1284,15 @@ msgstr ""
 "UPOZORENJE: Grub učitač pokretanja sustava nije ispravno prilagođen! "
 "Prilagodite ga ručno."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Provjeravam učitača pokretanja sustava"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-hu.po
+++ b/po/live-installer-hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mintbackup\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2019-07-23 16:24+0000\n"
 "Last-Translator: KAMI <kami911@gmail.com>\n"
 "Language-Team: Hungarian\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Időzóna"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Partíció szerkesztése"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Haladó"
@@ -149,142 +151,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Frissítés"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Fájlrendszer"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Partíciók szerkesztése"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Automatikus bejelentkezés"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -313,6 +321,716 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "OK"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Nem"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Igen"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Időzóna"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Nyelv"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Billentyűzetkiosztás"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Telepítés megállítva"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Típus"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Ország"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Kiosztás"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Változat"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Fájlok indexelése…"
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Billentyűzetkiosztás"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Biztosan ki akar lépni a telepítőből?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Particionálás"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Összefoglaló"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Vissza"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Partíciók szerkesztése"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Eszköz"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Operációs rendszer"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Csatolási pont"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Fájlrendszer"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Méret"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Szabad hely"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Telepítés"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "A jelszavak nem egyeznek."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Kilép?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Biztosan ki akar lépni a telepítőből?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Válasszon nyelvet"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Adja meg a jelszót ehhez a felhasználónevéhez."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Adja meg a teljes nevét."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "A jelszavak nem egyeznek."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+"Az EFI partíció nincs indíthatónak jelölve. Kérjük állítsa be a partíció "
+"jelöléseket."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Adja meg a root („/”) partíciót."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+"Az EFI partíció nincs indíthatónak jelölve. Kérjük állítsa be a partíció "
+"jelöléseket."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "Az EFI partíciót VFAT vagy FAT32 fájlrendszerre kell formázni."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "Az EFI partíciót VFAT vagy FAT32 fájlrendszerre kell formázni."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Válassza ki az EFI partíciót."
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Adja meg a felhasználónevét."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Honosítás"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Nyelv: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Időzóna: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Billentyűzetkiosztás: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Felhasználói beállítások"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Teljes név: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Felhasználónév: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Automatikus bejelentkezés: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "engedélyezve"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "letiltva"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Rendszerbeállítások"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Fájlrendszer műveletek"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Rendszerbetöltő telepítése ide: %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Ne telepítsen rendszerbetöltőt"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "A már csatolt „/target” használata."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "%(path)s formázása %(filesystem)s fájlrendszerre"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Csatolás %(path)s a következő helyre: %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Csatolás %(path)s a következő helyre: %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "A telepítés sikeresen befejeződött"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"A telepítés befejeződött. Újra kívánja indítani a számítógépet az új "
+"rendszer elindításához?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Telepítési hiba"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "KB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Eltávolítható:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Szerkesztés"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Hozzárendelés: „/”"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Logikai partíció"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Kiterjesztett partíció"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Ismeretlen"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Partíció szerkesztése"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Partíció szerkesztése"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Eszköz:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Fájlrendszer"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Csatolási pont:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Mégse"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -423,10 +1141,6 @@ msgstr "A jelszavak nem egyeznek."
 msgid "Please provide a password for your user account."
 msgstr "Adja meg a jelszót ehhez a felhasználónevéhez."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -453,7 +1167,7 @@ msgstr "Új felhasználó hozzáadása a rendszerhez"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Fájlrendszer csatolási információk írása a „/etc/fstab” fájlba"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "%(partition)s partíció csatolása ide: %(mountpoint)s"
@@ -473,49 +1187,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "%(partition)s formázása %(format)s fájlrendszerre…"
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Gépnév beállítása"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Nyelv beállítása"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Gépnév beállítása"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Billentyűzet beállítása"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "A Live beállítások eltávolítása (csomagok)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Rendszerbetöltő telepítése"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Rendszerbetöltő beállítása"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -523,645 +1237,17 @@ msgstr ""
 "FIGYELEM! A GRUB rendszerbetöltő beállítása nem megfelelő! Kézzel kell "
 "beállítania."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "A telepítés sikeresen befejeződött"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Rendszerbetöltő ellenőrzése"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Ország"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Nyelv"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Kiosztás"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Változat"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Fájlok indexelése…"
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Billentyűzetkiosztás"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Biztosan ki akar lépni a telepítőből?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Particionálás"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Összefoglaló"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Vissza"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Partíciók szerkesztése"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Eszköz"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Típus"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Operációs rendszer"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Csatolási pont"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Fájlrendszer"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Méret"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Szabad hely"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Telepítés"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "A jelszavak nem egyeznek."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Kilép?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Biztosan ki akar lépni a telepítőből?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Válasszon nyelvet"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Adja meg a jelszót ehhez a felhasználónevéhez."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Adja meg a teljes nevét."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "A jelszavak nem egyeznek."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-"Az EFI partíció nincs indíthatónak jelölve. Kérjük állítsa be a partíció "
-"jelöléseket."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Adja meg a root („/”) partíciót."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-"Az EFI partíció nincs indíthatónak jelölve. Kérjük állítsa be a partíció "
-"jelöléseket."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "Az EFI partíciót VFAT vagy FAT32 fájlrendszerre kell formázni."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "Az EFI partíciót VFAT vagy FAT32 fájlrendszerre kell formázni."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Válassza ki az EFI partíciót."
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Adja meg a felhasználónevét."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Honosítás"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Nyelv: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Időzóna: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Billentyűzetkiosztás: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Felhasználói beállítások"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Teljes név: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Felhasználónév: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Automatikus bejelentkezés: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "engedélyezve"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "letiltva"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Rendszerbeállítások"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Fájlrendszer műveletek"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Rendszerbetöltő telepítése ide: %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Ne telepítsen rendszerbetöltőt"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "A már csatolt „/target” használata."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "%(path)s formázása %(filesystem)s fájlrendszerre"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Csatolás %(path)s a következő helyre: %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"A telepítés befejeződött. Újra kívánja indítani a számítógépet az új "
-"rendszer elindításához?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Telepítési hiba"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Billentyűzetkiosztás"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Telepítés megállítva"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Időzóna"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "KB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Eltávolítható:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Szerkesztés"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Hozzárendelés: „/”"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Logikai partíció"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Kiterjesztett partíció"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Ismeretlen"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Partíció szerkesztése"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Partíció szerkesztése"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Eszköz:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Fájlrendszer"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Csatolási pont:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Mégse"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "OK"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Nem"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Igen"
 
 #~ msgid "Quit"
 #~ msgstr "Kilépés"

--- a/po/live-installer-hu.po
+++ b/po/live-installer-hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mintbackup\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2019-07-23 16:24+0000\n"
 "Last-Translator: KAMI <kami911@gmail.com>\n"
 "Language-Team: Hungarian\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -189,9 +189,9 @@ msgid "Format"
 msgstr "Fájlrendszer"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -295,6 +295,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Fájlrendszer"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -325,8 +331,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "OK"
 
@@ -415,23 +421,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Ország"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Kiosztás"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "KB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Változat"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Fájlok indexelése…"
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Eltávolítható:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Szerkesztés"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Hozzárendelés: „/”"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -449,10 +526,104 @@ msgstr "Fájlok indexelése…"
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Szabad hely"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Logikai partíció"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Kiterjesztett partíció"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Ismeretlen"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Partíció szerkesztése"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Partíció szerkesztése"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Eszköz:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Fájlrendszer"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Csatolási pont:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Mégse"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Ország"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Kiosztás"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Változat"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Fájlok indexelése…"
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -567,18 +738,6 @@ msgstr "Fájlrendszer"
 msgid "Size"
 msgstr "Méret"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Szabad hely"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -611,25 +770,6 @@ msgstr "Kilép?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Biztosan ki akar lépni a telepítőből?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -873,7 +1013,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "A telepítés sikeresen befejeződött"
 
@@ -894,139 +1034,6 @@ msgstr "Telepítési hiba"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "KB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Eltávolítható:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Szerkesztés"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Hozzárendelés: „/”"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Logikai partíció"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Kiterjesztett partíció"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Ismeretlen"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Partíció szerkesztése"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Partíció szerkesztése"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Eszköz:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Fájlrendszer"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Csatolási pont:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Mégse"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1187,49 +1194,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "%(partition)s formázása %(format)s fájlrendszerre…"
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Gépnév beállítása"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Nyelv beállítása"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Gépnév beállítása"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Billentyűzet beállítása"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "A Live beállítások eltávolítása (csomagok)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Rendszerbetöltő telepítése"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Rendszerbetöltő beállítása"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1237,15 +1244,15 @@ msgstr ""
 "FIGYELEM! A GRUB rendszerbetöltő beállítása nem megfelelő! Kézzel kell "
 "beállítania."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Rendszerbetöltő ellenőrzése"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-ia.po
+++ b/po/live-installer-ia.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2018-08-08 14:56+0000\n"
 "Last-Translator: karm <melo@carmu.com>\n"
 "Language-Team: Interlingua <ia@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -189,9 +189,9 @@ msgid "Format"
 msgstr "Formattar como"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -295,6 +295,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Formattar como"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -325,8 +331,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "OK"
 
@@ -415,23 +421,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Pais"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Mappa"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Variante"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Calculo de indices de file ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Removibile:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Modificar"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Assignar a /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -449,10 +526,104 @@ msgstr "Calculo de indices de file ..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Spatio libere"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Partition logic"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Partition extense"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Incognite"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Modificar le partition"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Modificar le partition"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Dispositivo:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Formatar como:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Puncto de montage:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Cancellar"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Pais"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Mappa"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variante"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Calculo de indices de file ..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -567,18 +738,6 @@ msgstr "Formattar como"
 msgid "Size"
 msgstr "Dimension"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Spatio libere"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -611,25 +770,6 @@ msgstr "Quitar?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Desira tu vermente quitar le installator?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -871,7 +1011,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Installation finite"
 
@@ -892,139 +1032,6 @@ msgstr "Error de installation"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Removibile:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Modificar"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Assignar a /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Partition logic"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Partition extense"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Incognite"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Modificar le partition"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Modificar le partition"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Dispositivo:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Formatar como:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Puncto de montage:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Cancellar"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1184,49 +1191,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formattation del %(partition)s como %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Configuration del nomine de hospite"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Configuration local"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Configuration del nomine de hospite"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Configuration del optiones de claviero"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Remotion del configuration (pacchettos) al vivo"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Installation del bootloader"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Configuration del bootloader"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1234,15 +1241,15 @@ msgstr ""
 "ATTENTION: le bootloader grub non era configurate correctemente! Il besonia "
 "que tu lo configura manualmente."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Controlo del bootloader"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-ia.po
+++ b/po/live-installer-ia.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2018-08-08 14:56+0000\n"
 "Last-Translator: karm <melo@carmu.com>\n"
 "Language-Team: Interlingua <ia@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Fuso horari"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Modificar le partition"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Modo experte"
@@ -149,142 +151,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Refrescar"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Formattar como"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Modificar le partitiones"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Como te connecter automaticamente"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -313,6 +321,714 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "OK"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "No"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Si"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Fuso horari"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Lingua"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Mappa de claviero"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Installation pausate"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Typo"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Pais"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Mappa"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variante"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Calculo de indices de file ..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Mappa de claviero"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Desira tu vermente quitar le installator?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Partition"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Summario"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Receder"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Modificar le partitiones"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Dispositivo"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Systema operative"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Puncto de montage"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Formattar como"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Dimension"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Spatio libere"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Installar"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Tu contrasignos non concorda."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Quitar?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Desira tu vermente quitar le installator?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Per favor elige un lingua"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Per favor provide un contrasigno pro tu conto de usator."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Per favor provide tu nomine complete."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Tu contrasignos non concorda."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+"Le partition EFI non es bootabile. Per favor modifica le flags de partition."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Per favor elige un partition de radice (/)"
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+"Le partition EFI non es bootabile. Per favor modifica le flags de partition."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "Le partition EFI debe ser formattate como vfat."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "Le partition EFI debe ser formattate como vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Per favor elige un partition EFI."
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Per favor provide un nomine de usator."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Localisation"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Lingua: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Fuso horari: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Mappa de claviero: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Configurationes del usator"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Nomine real: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Nomine de usator: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Apertura de session automatic: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "activate"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "disactivate"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Configurationes de systema"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Operationes de systema de files"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Installar le bootloader sur %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Non installar le bootloader"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Usar le /target ja montate."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Formattar %(path)s como %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Montar %(path)s como %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Montar %(path)s como %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Installation finite"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Le installation es ora complete. Desira tu reinitiar tu computator pro usar "
+"le nove systema?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Error de installation"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Removibile:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Modificar"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Assignar a /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Partition logic"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Partition extense"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Incognite"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Modificar le partition"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Modificar le partition"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Dispositivo:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Formatar como:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Puncto de montage:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Cancellar"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -421,10 +1137,6 @@ msgstr "Tu contrasignos non concorda."
 msgid "Please provide a password for your user account."
 msgstr "Per favor provide un contrasigno pro tu conto de usator."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -452,7 +1164,7 @@ msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 "Scriptura del informationes de montage del systema de files a /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Montage del %(partition)s sur %(mountpoint)s"
@@ -472,49 +1184,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formattation del %(partition)s como %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Configuration del nomine de hospite"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Configuration local"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Configuration del nomine de hospite"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Configuration del optiones de claviero"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Remotion del configuration (pacchettos) al vivo"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Installation del bootloader"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Configuration del bootloader"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -522,643 +1234,17 @@ msgstr ""
 "ATTENTION: le bootloader grub non era configurate correctemente! Il besonia "
 "que tu lo configura manualmente."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Installation finite"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Controlo del bootloader"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Pais"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Lingua"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Mappa"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Variante"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Calculo de indices de file ..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Mappa de claviero"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Desira tu vermente quitar le installator?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Partition"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Summario"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Receder"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Modificar le partitiones"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Dispositivo"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Typo"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Systema operative"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Puncto de montage"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Formattar como"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Dimension"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Spatio libere"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Installar"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Tu contrasignos non concorda."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Quitar?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Desira tu vermente quitar le installator?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Per favor elige un lingua"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Per favor provide un contrasigno pro tu conto de usator."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Per favor provide tu nomine complete."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Tu contrasignos non concorda."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-"Le partition EFI non es bootabile. Per favor modifica le flags de partition."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Per favor elige un partition de radice (/)"
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-"Le partition EFI non es bootabile. Per favor modifica le flags de partition."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "Le partition EFI debe ser formattate como vfat."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "Le partition EFI debe ser formattate como vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Per favor elige un partition EFI."
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Per favor provide un nomine de usator."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Localisation"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Lingua: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Fuso horari: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Mappa de claviero: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Configurationes del usator"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Nomine real: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Nomine de usator: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Apertura de session automatic: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "activate"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "disactivate"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Configurationes de systema"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Operationes de systema de files"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Installar le bootloader sur %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Non installar le bootloader"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Usar le /target ja montate."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Formattar %(path)s como %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Montar %(path)s como %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Le installation es ora complete. Desira tu reinitiar tu computator pro usar "
-"le nove systema?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Error de installation"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Mappa de claviero"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Installation pausate"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Fuso horari"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Removibile:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Modificar"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Assignar a /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Partition logic"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Partition extense"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Incognite"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Modificar le partition"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Modificar le partition"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Dispositivo:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Formatar como:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Puncto de montage:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Cancellar"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "OK"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "No"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Si"
 
 #~ msgid "Quit"
 #~ msgstr "Quitar"

--- a/po/live-installer-id.po
+++ b/po/live-installer-id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2019-12-22 23:08+0000\n"
 "Last-Translator: Arief Setiadi Wibowo <q_thrynx@yahoo.com>\n"
 "Language-Team: Indonesian <id@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Wilayah waktu"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Sunting Partisi"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Mode ahli"
@@ -149,142 +151,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Segarkan"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Format sebagai"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Edit partisi"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Login secara otomatis"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -313,6 +321,712 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "OK"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Tidak"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Ya"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Wilayah waktu"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "bahasa"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Tata letak papan ketik"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Pemasangan ditunda"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Tipe"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Negara"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Tata letak"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Varian"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Menghitung indeks file..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Tata letak papan ketik"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Anda yakin ingin menghentikan installer?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Pembagian"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Ringkasan"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Mundur"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Edit partisi"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Perangkat"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Sistem operasi"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Titik kait"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Format sebagai"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Ukuran"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Ruang kosong"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Pasang"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Password anda tidak sesuai."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Berhenti?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Anda yakin ingin menghentikan installer?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Silakan pilih sebuah bahasa."
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Silakan masukkan kata sandi untuk akun pengguna anda."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Silakan masukkan nama lengkap anda."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Password anda tidak sesuai."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "Partisi EFI tidak bisa di-boot. Silakan ubah flag partisi."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Silakan pilih sebuah partisi root (/)."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "Partisi EFI tidak bisa di-boot. Silakan ubah flag partisi."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "Partisi EFI harus diformat dalam vfat."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "Partisi EFI harus diformat dalam vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Silakan pilih partisi EFI."
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Silakan masukkan sebuah nama pengguna."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Pengaturan Kedaerahan"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Bahasa: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Zona Waktu "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Susunan papan ketik "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Pengaturan pengguna"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Nama asli "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Nama Pengguna: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Login otomatis: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "diaktifkan"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "dinonaktifkan"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Pengaturan-pengaturan sistem"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Pekerjaan-pekerjaan sistem berkas"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Install bootloader pada %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Jangan pasang bootloader"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Gunakan /target yang telah dipasang"
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Format %(path)s sebagai %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Mount %(path)s as %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Mount %(path)s as %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Instalasi selesai"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Instalasi sekarang telah lengkap. Apakah anda ingin me-restart komputer anda "
+"untuk menggunakan sistem baru?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Instalasi mengalami gangguan"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Removable:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Sunting"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Tempatkan pada /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Partisi Logical"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Partisi Extended"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Tidak diketahui"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Sunting Partisi"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Sunting Partisi"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Perangkat:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Format sebagai:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Titik mount:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Batal"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -421,10 +1135,6 @@ msgstr "Password anda tidak sesuai."
 msgid "Please provide a password for your user account."
 msgstr "Silakan masukkan kata sandi untuk akun pengguna anda."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -451,7 +1161,7 @@ msgstr "Menambahkan pengguna baru ke dalam sistem..."
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Menuliskan informasi mount filesystem ke /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Mengaitkan %(partition)s pada %(mountpoint)s"
@@ -471,49 +1181,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Memformat %(partition)s sebagai %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Pengaturan hostname"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Pengaturan lokal"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Pengaturan hostname"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Pengaturan pilihan keyboard"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Menghapus konfigurasi yang aktif (paket-paket)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Memasang bootloader"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Mengkonfigurasi bootloader"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -521,641 +1231,17 @@ msgstr ""
 "PERINGATAN: grub bootloader tidak dikonfigurasi sebagaimana mestinya! Anda "
 "perlu mengkonfigurasinya secara manual."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Instalasi selesai"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Mengecek bootloader"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Negara"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "bahasa"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Tata letak"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Varian"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Menghitung indeks file..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Tata letak papan ketik"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Anda yakin ingin menghentikan installer?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Pembagian"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Ringkasan"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Mundur"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Edit partisi"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Perangkat"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Tipe"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Sistem operasi"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Titik kait"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Format sebagai"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Ukuran"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Ruang kosong"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Pasang"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Password anda tidak sesuai."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Berhenti?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Anda yakin ingin menghentikan installer?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Silakan pilih sebuah bahasa."
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Silakan masukkan kata sandi untuk akun pengguna anda."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Silakan masukkan nama lengkap anda."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Password anda tidak sesuai."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "Partisi EFI tidak bisa di-boot. Silakan ubah flag partisi."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Silakan pilih sebuah partisi root (/)."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "Partisi EFI tidak bisa di-boot. Silakan ubah flag partisi."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "Partisi EFI harus diformat dalam vfat."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "Partisi EFI harus diformat dalam vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Silakan pilih partisi EFI."
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Silakan masukkan sebuah nama pengguna."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Pengaturan Kedaerahan"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Bahasa: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Zona Waktu "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Susunan papan ketik "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Pengaturan pengguna"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Nama asli "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Nama Pengguna: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Login otomatis: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "diaktifkan"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "dinonaktifkan"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Pengaturan-pengaturan sistem"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Pekerjaan-pekerjaan sistem berkas"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Install bootloader pada %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Jangan pasang bootloader"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Gunakan /target yang telah dipasang"
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Format %(path)s sebagai %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Mount %(path)s as %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Instalasi sekarang telah lengkap. Apakah anda ingin me-restart komputer anda "
-"untuk menggunakan sistem baru?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Instalasi mengalami gangguan"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Tata letak papan ketik"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Pemasangan ditunda"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Wilayah waktu"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Removable:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Sunting"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Tempatkan pada /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Partisi Logical"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Partisi Extended"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Tidak diketahui"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Sunting Partisi"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Sunting Partisi"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Perangkat:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Format sebagai:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Titik mount:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Batal"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "OK"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Tidak"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Ya"
 
 #~ msgid "Quit"
 #~ msgstr "Keluar"

--- a/po/live-installer-id.po
+++ b/po/live-installer-id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2019-12-22 23:08+0000\n"
 "Last-Translator: Arief Setiadi Wibowo <q_thrynx@yahoo.com>\n"
 "Language-Team: Indonesian <id@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -189,9 +189,9 @@ msgid "Format"
 msgstr "Format sebagai"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -295,6 +295,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Format sebagai"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -325,8 +331,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "OK"
 
@@ -415,23 +421,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Negara"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Tata letak"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Varian"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Menghitung indeks file..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Removable:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Sunting"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Tempatkan pada /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -449,10 +526,104 @@ msgstr "Menghitung indeks file..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Ruang kosong"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Partisi Logical"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Partisi Extended"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Tidak diketahui"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Sunting Partisi"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Sunting Partisi"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Perangkat:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Format sebagai:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Titik mount:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Batal"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Negara"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Tata letak"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Varian"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Menghitung indeks file..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -567,18 +738,6 @@ msgstr "Format sebagai"
 msgid "Size"
 msgstr "Ukuran"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Ruang kosong"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -611,25 +770,6 @@ msgstr "Berhenti?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Anda yakin ingin menghentikan installer?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -869,7 +1009,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Instalasi selesai"
 
@@ -890,139 +1030,6 @@ msgstr "Instalasi mengalami gangguan"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Removable:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Sunting"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Tempatkan pada /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Partisi Logical"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Partisi Extended"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Tidak diketahui"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Sunting Partisi"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Sunting Partisi"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Perangkat:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Format sebagai:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Titik mount:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Batal"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1181,49 +1188,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Memformat %(partition)s sebagai %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Pengaturan hostname"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Pengaturan lokal"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Pengaturan hostname"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Pengaturan pilihan keyboard"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Menghapus konfigurasi yang aktif (paket-paket)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Memasang bootloader"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Mengkonfigurasi bootloader"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1231,15 +1238,15 @@ msgstr ""
 "PERINGATAN: grub bootloader tidak dikonfigurasi sebagaimana mestinya! Anda "
 "perlu mengkonfigurasinya secara manual."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Mengecek bootloader"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-is.po
+++ b/po/live-installer-is.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: live-installer_live-installer-is\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2020-02-25 13:31+0000\n"
 "Last-Translator: Sveinn í Felli <sv1@fellsnet.is>\n"
 "Language-Team: Icelandic <translation-team-is@lists.sourceforge.net>\n"
@@ -93,7 +93,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -195,9 +195,9 @@ msgid "Format"
 msgstr "Forsníða sem"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -302,6 +302,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Forsníða sem"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -333,8 +339,8 @@ msgstr "Velkomin"
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "Í lagi"
 
@@ -426,23 +432,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr "Velkomin"
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Land"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Uppsetning"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Tilbrigði"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Reikna skráayfirlit ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Útskiptanlegt:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Breyta"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Úthluta sem /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -460,10 +537,104 @@ msgstr "Reikna skráayfirlit ..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr "Uppsetningarforrit"
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Laust pláss"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Rökræn disksneið"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Útvíkkuð disksneið"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Óþekkt"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Breyta disksneið"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Breyta disksneið"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Tæki:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Forsníða sem:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Tengipunktur:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Hætta við"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Land"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Uppsetning"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Tilbrigði"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Reikna skráayfirlit ..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -581,18 +752,6 @@ msgstr "Forsníða sem"
 msgid "Size"
 msgstr "Stærð"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Laust pláss"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -625,25 +784,6 @@ msgstr "Hætta?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Ertu viss að þú viljir hætta í uppsetningarforritinu?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -908,7 +1048,7 @@ msgid "Disk Encryption: "
 msgstr "Dulritun disks: "
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Uppsetningu lokið"
 
@@ -929,139 +1069,6 @@ msgstr "Uppsetningarvilla"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Útskiptanlegt:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Breyta"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Úthluta sem /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Rökræn disksneið"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Útvíkkuð disksneið"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Óþekkt"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Breyta disksneið"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Breyta disksneið"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Tæki:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Forsníða sem:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Tengipunktur:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Hætta við"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1220,49 +1227,49 @@ msgstr "Bý til disksneiðar á %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Forsníð %(partition)s sem %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Stilla vélarheiti"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Stilla staðfærslu"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Stilla vélarheiti"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Stilla valmöguleika lyklaborðsuppsetningar"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Fjarlægi prufudisksstillingar (hugbúnaðarpakkar)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Set upp ræsistjóra"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Stilli ræsistjóra"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1270,15 +1277,15 @@ msgstr ""
 "AÐVÖRUN: GRUB ræsistjórinn var ekki rétt uppsettur! Þú verður að stilla hann "
 "handvirkt."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Athugai ræsistjóra"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-is.po
+++ b/po/live-installer-is.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: live-installer_live-installer-is\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2020-02-25 13:31+0000\n"
 "Last-Translator: Sveinn í Felli <sv1@fellsnet.is>\n"
 "Language-Team: Icelandic <translation-team-is@lists.sourceforge.net>\n"
@@ -25,19 +25,19 @@ msgid "Welcome to the 17g Installer."
 msgstr "Velkomin í 17G uppsetningarforritið."
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr "Tegund lyklaborðs:"
 
@@ -47,10 +47,12 @@ msgid "Type here to test your keyboard"
 msgstr "Skrifaðu hér til að prófa lyklaborðsuppsetninguna"
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -59,13 +61,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Tímabelti"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr "Sjálfvirk uppsetning"
 
@@ -75,12 +77,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr "Hreinsa disk og setja 17G upp á honum."
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr "Diskur:"
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Breyta disksneið"
@@ -91,42 +93,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr "Nota LVM (umsýsla sýndardiska)"
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr "Dulrita stýrikerfið"
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr "Lykilsetning"
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr "Staðfestu lykilsetningu"
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr "Handvirk disksneiðing"
 
@@ -144,7 +146,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Fyrir sérfræðinga"
@@ -154,144 +156,150 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 #, fuzzy
 msgid "Minimal installation"
 msgstr "Sjálfvirk uppsetning"
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Endurlesa"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Forsníða sem"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr "Setja GRUB ræsivalmynd upp á:"
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Breyta disksneiðum"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr "Nafnið þitt:"
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr "Heiti tölvunnar þinnar:"
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr "Veldu þér notandanafn:"
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr "Nafnið sem hún notar þegar hún talar við aðrar tölvur."
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr "Veldu þér lykilorð:"
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Skrá inn sjálfkrafa"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr "Krefjast lykilorðs míns til að skrá inn"
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr "Dulrita heimamöppuna mína"
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr "Staðfestu lykilorðið þitt:"
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 #, fuzzy
 msgid "Automated installation enabled!"
 msgstr "Sjálfvirk uppsetning á %s"
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr "Velkomin"
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -322,6 +330,743 @@ msgstr ""
 #, fuzzy
 msgid "Welcome to 17g"
 msgstr "Velkomin"
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "Í lagi"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Nei"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Já"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Tímabelti"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, fuzzy, python-format
+msgid "Welcome to the %s Installer."
+msgstr "Velkomin í 17G uppsetningarforritið."
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr "Hvaða tungumál viltu nota?"
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Tungumál"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr "Hvar ertu?"
+
+#: live-installer/frontend/tui_interface.py:57
+#, fuzzy
+msgid "What keyboard would you like to use?"
+msgstr "Hvaða tungumál viltu nota?"
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Tegund lyklaborðs:"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Gerð uppsetningar"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Tegund"
+
+#: live-installer/frontend/tui_interface.py:80
+#, fuzzy
+msgid "Select a disk?"
+msgstr "Veldu disk."
+
+#: live-installer/frontend/tui_interface.py:84
+#, fuzzy
+msgid "Disk"
+msgstr "Diskur:"
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, fuzzy, python-format
+msgid "Welcome to %s"
+msgstr "Velkomin"
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Land"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Uppsetning"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Tilbrigði"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Reikna skráayfirlit ..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr "Uppsetningarforrit"
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Lyklaborðsútfærsla"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr "Hvaða lyklaborðsuppsetningu ertu með?"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr "Notandaaðgangur"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr "Hver ertu?"
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr "Gerð uppsetningar"
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Hvar viltu setja upp 17G?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Disksneiðing"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Yfirlit"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr "Uppsetning"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+#, fuzzy
+msgid "Automated Install"
+msgstr "Sjálfvirk uppsetning"
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Til baka"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr "Næsta"
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr "Skrifaðu hér til að prófa lyklaborðsuppsetninguna"
+
+#: live-installer/frontend/gtk_interface.py:546
+#, fuzzy
+msgid "Erase a disk and install system on it."
+msgstr "Hreinsa disk og setja 17G upp á honum."
+
+#: live-installer/frontend/gtk_interface.py:559
+#, fuzzy
+msgid "Manually create, resize or choose partitions for system."
+msgstr "Skilgreina, eyða og endurstilla disksneiðar fyrir 17G."
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Breyta disksneiðum"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Tæki"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Stýrikerfi"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Tengipunktur"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Forsníða sem"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Stærð"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Laust pláss"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr "Aðvörun"
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr "Þetta mun eyða öllum gögnum á %s. Ertu viss?"
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Setja upp"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Lykilorðin stemma ekki."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Hætta?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Ertu viss að þú viljir hætta í uppsetningarforritinu?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Veldu þér tungumál"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Veldu lykilorð fyrir notandaaðganginn þinn."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Settu inn fullt nafn."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Lykilorðin stemma ekki."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "EFI disksneiðin er of lítil. Hún þarf að vera a.m.k 35 MB."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Veldu einhverja disksneið sem grunndisksneið (/ - root)."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, fuzzy, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+"Nauðsynlegt er að ákveða grunndisksneið (rót) til að geta sett upp Linux "
+"Mint.\n"
+"\n"
+" - Tengipunktur: /\n"
+" - Kjörstærð: 30 GB\n"
+" - Skráakerfi sem mælt er með: ext4\n"
+"\n"
+"\n"
+"Athugaðu: Til að nota btrfs tímahliðrunaröryggisafritin (timeshift "
+"snapshots) þarf:\n"
+" - Tengipunkt undirsýndardisks /@\n"
+" - btrfs sem snið skráakerfis\n"
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+"EFI disksneiðin er ekki ræsanleg (bootable). Breyttu disksneiðaflöggunum."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "EFI disksneiðin er of lítil. Hún þarf að vera a.m.k 35 MB."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "EFI disksneiðin verður að vera forsniðin sem vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Veldu einhverja EFI disksneið."
+
+#: live-installer/frontend/gtk_interface.py:1301
+#, fuzzy
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+"EFI kerfisdisksneið er nauðsynleg, með eftirfarandi eiginleikum:\n"
+"\n"
+" - Tengipunktur: /boot/efi\n"
+" - Disksneiðaflagg: Bootable\n"
+" - Stærð: Stærri en 35MB (mælt er með 100MB eða meira)\n"
+" - Skráakerfi: vfat eða fat32\n"
+"\n"
+"Til að tryggja samhæfni við Windows mælum við með því að notuð sé fyrsta "
+"disksneið disksins undir EFI kerfisdisksneiðina.\n"
+" "
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr "Veldu disk."
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Settu inn notandanafn."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Staðfærsla"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Tungumál: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Tímabelti: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Uppsetning lyklaborðs: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Notandastillingar"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Fullt nafn: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Notandanafn: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Sjálfvirk innskráning: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "virkt"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "óvirkt"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Kerfisstillingar"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+#, fuzzy
+msgid "Install updates after installation"
+msgstr "Sjálfvirk uppsetning"
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Aðgerðir með skráakerfi"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Setja ræsistjóra upp á %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Ekki setja upp ræsistjóra"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Nota þegar tengt /target."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr "Sjálfvirk uppsetning á %s"
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Forsníða %(path)s sem %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Tengja %(path)s sem %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Tengja %(path)s sem %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr "LVM: "
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr "Dulritun disks: "
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Uppsetningu lokið"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Uppsetningu er lokið. Viltu endurræsa tölvuna svo að getir þú notað nýja "
+"stýrikerfið þitt?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Uppsetningarvilla"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Útskiptanlegt:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Breyta"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Úthluta sem /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Rökræn disksneið"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Útvíkkuð disksneið"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Óþekkt"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Breyta disksneið"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Breyta disksneið"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Tæki:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Forsníða sem:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Tengipunktur:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Hætta við"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
+msgstr ""
 
 #: live-installer/validate.py:12
 msgid "Please provide a username."
@@ -429,10 +1174,6 @@ msgstr "Lykilorðin stemma ekki."
 msgid "Please provide a password for your user account."
 msgstr "Veldu lykilorð fyrir notandaaðganginn þinn."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -459,7 +1200,7 @@ msgstr "Bæti nýjum notanda við á kerfið"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Skrifa tengiupplýsingar fyrir skráakerfi í /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Tengi %(partition)s sem %(mountpoint)s"
@@ -479,49 +1220,49 @@ msgstr "Bý til disksneiðar á %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Forsníð %(partition)s sem %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Stilla vélarheiti"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Stilla staðfærslu"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Stilla vélarheiti"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Stilla valmöguleika lyklaborðsuppsetningar"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Fjarlægi prufudisksstillingar (hugbúnaðarpakkar)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Set upp ræsistjóra"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Stilli ræsistjóra"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -529,672 +1270,17 @@ msgstr ""
 "AÐVÖRUN: GRUB ræsistjórinn var ekki rétt uppsettur! Þú verður að stilla hann "
 "handvirkt."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Uppsetningu lokið"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Athugai ræsistjóra"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Land"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Tungumál"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Uppsetning"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Tilbrigði"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Reikna skráayfirlit ..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr "Uppsetningarforrit"
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr "Hvaða tungumál viltu nota?"
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr "Hvar ertu?"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Lyklaborðsútfærsla"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr "Hvaða lyklaborðsuppsetningu ertu með?"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr "Notandaaðgangur"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr "Hver ertu?"
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr "Gerð uppsetningar"
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Hvar viltu setja upp 17G?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Disksneiðing"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Yfirlit"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr "Uppsetning"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-#, fuzzy
-msgid "Automated install"
-msgstr "Sjálfvirk uppsetning"
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Til baka"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr "Næsta"
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, fuzzy, python-format
-msgid "Welcome to the %s Installer."
-msgstr "Velkomin í 17G uppsetningarforritið."
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr "Skrifaðu hér til að prófa lyklaborðsuppsetninguna"
-
-#: live-installer/frontend/gtk_interface.py:542
-#, fuzzy
-msgid "Erase a disk and install system on it."
-msgstr "Hreinsa disk og setja 17G upp á honum."
-
-#: live-installer/frontend/gtk_interface.py:555
-#, fuzzy
-msgid "Manually create, resize or choose partitions for system."
-msgstr "Skilgreina, eyða og endurstilla disksneiðar fyrir 17G."
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Breyta disksneiðum"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Tæki"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Tegund"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Stýrikerfi"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Tengipunktur"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Forsníða sem"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Stærð"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Laust pláss"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Setja upp"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Lykilorðin stemma ekki."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Hætta?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Ertu viss að þú viljir hætta í uppsetningarforritinu?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Veldu þér tungumál"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Veldu lykilorð fyrir notandaaðganginn þinn."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Settu inn fullt nafn."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Lykilorðin stemma ekki."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "EFI disksneiðin er of lítil. Hún þarf að vera a.m.k 35 MB."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Veldu einhverja disksneið sem grunndisksneið (/ - root)."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, fuzzy, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-"Nauðsynlegt er að ákveða grunndisksneið (rót) til að geta sett upp Linux "
-"Mint.\n"
-"\n"
-" - Tengipunktur: /\n"
-" - Kjörstærð: 30 GB\n"
-" - Skráakerfi sem mælt er með: ext4\n"
-"\n"
-"\n"
-"Athugaðu: Til að nota btrfs tímahliðrunaröryggisafritin (timeshift "
-"snapshots) þarf:\n"
-" - Tengipunkt undirsýndardisks /@\n"
-" - btrfs sem snið skráakerfis\n"
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-"EFI disksneiðin er ekki ræsanleg (bootable). Breyttu disksneiðaflöggunum."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "EFI disksneiðin er of lítil. Hún þarf að vera a.m.k 35 MB."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "EFI disksneiðin verður að vera forsniðin sem vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Veldu einhverja EFI disksneið."
-
-#: live-installer/frontend/gtk_interface.py:1226
-#, fuzzy
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-"EFI kerfisdisksneið er nauðsynleg, með eftirfarandi eiginleikum:\n"
-"\n"
-" - Tengipunktur: /boot/efi\n"
-" - Disksneiðaflagg: Bootable\n"
-" - Stærð: Stærri en 35MB (mælt er með 100MB eða meira)\n"
-" - Skráakerfi: vfat eða fat32\n"
-"\n"
-"Til að tryggja samhæfni við Windows mælum við með því að notuð sé fyrsta "
-"disksneið disksins undir EFI kerfisdisksneiðina.\n"
-" "
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr "Veldu disk."
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr "Aðvörun"
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr "Þetta mun eyða öllum gögnum á %s. Ertu viss?"
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Settu inn notandanafn."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Staðfærsla"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Tungumál: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Tímabelti: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Uppsetning lyklaborðs: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Notandastillingar"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Fullt nafn: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Notandanafn: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Sjálfvirk innskráning: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "virkt"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "óvirkt"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Kerfisstillingar"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-#, fuzzy
-msgid "Install updates after installation"
-msgstr "Sjálfvirk uppsetning"
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Aðgerðir með skráakerfi"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Setja ræsistjóra upp á %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Ekki setja upp ræsistjóra"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Nota þegar tengt /target."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr "Sjálfvirk uppsetning á %s"
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Forsníða %(path)s sem %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Tengja %(path)s sem %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr "LVM: "
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr "Dulritun disks: "
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Uppsetningu er lokið. Viltu endurræsa tölvuna svo að getir þú notað nýja "
-"stýrikerfið þitt?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Uppsetningarvilla"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, fuzzy, python-format
-msgid "Welcome to %s"
-msgstr "Velkomin"
-
-#: live-installer/frontend/tui_interface.py:57
-#, fuzzy
-msgid "What keyboard would you like to use?"
-msgstr "Hvaða tungumál viltu nota?"
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Tegund lyklaborðs:"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Gerð uppsetningar"
-
-#: live-installer/frontend/tui_interface.py:80
-#, fuzzy
-msgid "Select a disk?"
-msgstr "Veldu disk."
-
-#: live-installer/frontend/tui_interface.py:84
-#, fuzzy
-msgid "Disk"
-msgstr "Diskur:"
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Tímabelti"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Útskiptanlegt:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Breyta"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Úthluta sem /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Rökræn disksneið"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Útvíkkuð disksneið"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Óþekkt"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Breyta disksneið"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Breyta disksneið"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Tæki:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Forsníða sem:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Tengipunktur:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Hætta við"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "Í lagi"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Nei"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Já"
 
 #~ msgid "Quit"
 #~ msgstr "Hætta"

--- a/po/live-installer-it.po
+++ b/po/live-installer-it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2020-03-11 17:22+0000\n"
 "Last-Translator: Dragone2 <Unknown>\n"
 "Language-Team: Italian <it@li.org>\n"
@@ -24,8 +24,8 @@ msgid "Welcome to the 17g Installer."
 msgstr "Benvenuto/a nell'installazione di 17G"
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 #, fuzzy
 msgid ""
 "This program will ask you some questions and set up system on your computer."
@@ -33,12 +33,12 @@ msgstr ""
 "Questo programma ti farà alcune domande e configurerà 17G sul tuo computer."
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr "Modello Tastiera:"
 
@@ -48,10 +48,12 @@ msgid "Type here to test your keyboard"
 msgstr "Digita qui per testare il layout della tua tastiera"
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -60,13 +62,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Fuso orario"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr "Installazione Automatica"
 
@@ -76,12 +78,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr "Cancella un disco e installa 17G su di esso."
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr "Disco:"
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Modifica partizione"
@@ -92,42 +94,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr "Usa LVM (Logical Volume Management)"
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr "Crittografa il sistema operativo"
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr "Frase di accesso"
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr "Conferma la frase di accesso"
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr "Questo garantisce una maggiore sicurezza, ma può richiedere ore."
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr "Riempi il disco con dati casuali"
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr "Partizionamento Manuale"
 
@@ -145,7 +147,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Modalità esperto"
@@ -155,144 +157,150 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 #, fuzzy
 msgid "Minimal installation"
 msgstr "Installazione Automatica"
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Aggiorna"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Formatta come"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr "Installa il menù di avvio GRUB su:"
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Modifica partizioni"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr "Il tuo nome:"
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr "Il nome del tuo computer:"
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr "Scegli un nome utente:"
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr "Il nome utilizzato per essere identificato da altri computer."
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr "Scegli una password:"
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Accesso automatico"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr "Richiedi la mia password all'accesso"
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr "Cifra la mia cartella personale"
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr "Conferma la tua password:"
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 #, fuzzy
 msgid "Automated installation enabled!"
 msgstr "Installazione automatizzata su %s"
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr "Benvenuto/a"
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -323,6 +331,745 @@ msgstr ""
 #, fuzzy
 msgid "Welcome to 17g"
 msgstr "Benvenuto/a"
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "OK"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "No"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Sì"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Fuso orario"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, fuzzy, python-format
+msgid "Welcome to the %s Installer."
+msgstr "Benvenuto/a nell'installazione di 17G"
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr "Quale lingua vorresti utilizzare?"
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Lingua"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr "Dove sei?"
+
+#: live-installer/frontend/tui_interface.py:57
+#, fuzzy
+msgid "What keyboard would you like to use?"
+msgstr "Quale lingua vorresti utilizzare?"
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Modello Tastiera:"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Tipologia di Installazione"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Tipo"
+
+#: live-installer/frontend/tui_interface.py:80
+#, fuzzy
+msgid "Select a disk?"
+msgstr "Seleziona un disco."
+
+#: live-installer/frontend/tui_interface.py:84
+#, fuzzy
+msgid "Disk"
+msgstr "Disco:"
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, fuzzy, python-format
+msgid "Welcome to %s"
+msgstr "Benvenuto/a"
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Paese"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "configurazione"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variante"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Calcolo indici dei file ..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr "Programma di Installazione"
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Disposizione della tastiera"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr "Qual è il layout della tua tastiera?"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr "Account utente"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr "Chi sei?"
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr "Tipologia di Installazione"
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Dove desideri installare 17G?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Partizionamento"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Riepilogo"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr "Installazione in corso"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+#, fuzzy
+msgid "Automated Install"
+msgstr "Installazione Automatica"
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Indietro"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr "Successivo"
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr "Digita qui per testare il layout della tua tastiera"
+
+#: live-installer/frontend/gtk_interface.py:546
+#, fuzzy
+msgid "Erase a disk and install system on it."
+msgstr "Cancella un disco e installa 17G su di esso."
+
+#: live-installer/frontend/gtk_interface.py:559
+#, fuzzy
+msgid "Manually create, resize or choose partitions for system."
+msgstr "Crea, ridimensiona o scegli manualmente le partizioni per 17G."
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Modifica partizioni"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Periferica"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Sistema operativo"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Punto di mount"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Formatta come"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Dimensione"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Spazio libero"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr "Attenzione"
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr "Questo eliminerà tutti i dati su %s. Vuoi proseguire?"
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Installa"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr "Fornisci una frase di accesso per la crittografia."
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Le tue password non coincidono."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Uscire?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Sei sicuro di voler uscire dall'installazione?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Scegli una lingua"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Inserisci un nome per il tuo computer."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Inserisci il tuo nome."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Le tue password non coincidono."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "La partizione EFI è troppo piccola. Deve essere di almeno 35MB."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Seleziona una partizione root (/)."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, fuzzy, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+"Per installare Linux Mint è necessaria una partizione di root.\n"
+"\n"
+"  - Punto di montaggio: /\n"
+"  - Dimensioni consigliate: 30 GB\n"
+"  - Formato file system consigliato: ext4\n"
+"\n"
+"Nota: la funzione snapshot btrfs di timeshift richiede l'uso di:\n"
+"  - Punto di montaggio del sottovolume /@\n"
+"  - btrfs come formato del filesystem\n"
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+"La partizione EFI non è avviabile, per favore modifica i flag della "
+"partizione."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "La partizione EFI è troppo piccola. Deve essere di almeno 35MB."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "La partizione EFI deve essere formattata in vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Per piacere selezionare una partizione EFI."
+
+#: live-installer/frontend/gtk_interface.py:1301
+#, fuzzy
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+"È necessaria una partizione di sistema EFI con i seguenti requisiti:\n"
+"\n"
+"  - Punto di montaggio: /boot/efi\n"
+"  - Flag di partizione: Avviabile\n"
+"  - Dimensioni: minimo 35 MB (almeno 100 MB consigliati)\n"
+"  - Formato: vfat o fat32\n"
+"\n"
+"Per garantire la compatibilità con Windows, si consiglia di utilizzare la "
+"prima partizione del disco come partizione di sistema EFI.\n"
+" "
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr "Seleziona un disco."
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Inserisci un nome utente."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Localizzazione"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Lingua: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Fuso orario: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Disposizione della tastiera: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Impostazioni utente"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Nome reale: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Nome utente: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Accesso automatico: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "attivato"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "disattivato"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Impostazioni di sistema"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr "Nome del computer: "
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+#, fuzzy
+msgid "Install updates after installation"
+msgstr "Installazione Automatica"
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Operazioni sul filesystem"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Installare bootloader in %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Non installare il bootloader"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Utilizzare il /target già montato."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr "Installazione automatizzata su %s"
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Formattare %(path)s come %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Montare %(path)s come %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Montare %(path)s come %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr "LVM: "
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr "Crittografia Disco: "
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Installazione completata"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"L' installazione è completata. Vuoi riavviare il computer per usare il nuovo "
+"sistema?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Errore di installazione"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "KB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Rimuovibile:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Modifica"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Assegnare a /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"Non è stato possibile scrivere la tabella delle partizioni per %s. Riavviare "
+"il computer e riprovare."
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"Non è stato possibile creare la partizione %s. L'installazione si fermerà. "
+"Riavviare il computer e riprovare."
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Partizione logica"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Partizione estesa"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Sconosciuta"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Modifica partizione"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Modifica partizione"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Dispositivo:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Formattare come:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Punto di montaggio:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Annulla"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
+msgstr ""
 
 #: live-installer/validate.py:12
 msgid "Please provide a username."
@@ -432,10 +1179,6 @@ msgstr "Le tue password non coincidono."
 msgid "Please provide a password for your user account."
 msgstr "Inserisci una password per il tuo account."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -462,7 +1205,7 @@ msgstr "Aggiunta nuovo utente al sistema"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Scrittura informazioni di montaggio del filesystem in /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Montaggio di %(partition)s in %(mountpoint)s"
@@ -484,49 +1227,49 @@ msgstr "Creazione delle partizioni su %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formattazione di %(partition)s come %(format)s"
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Impostazione dell'hostname"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Impostazione della localizzazione"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Impostazione dell'hostname"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Impostazione delle opzioni della tastiera"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Rimozione della configurazione live (pacchetti)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Installazione del bootloader"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Configurazione del bootloader"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -534,674 +1277,17 @@ msgstr ""
 "ATTENZIONE: Il bootloader grub non è stato configurato correttamente! È "
 "necessaria una configurazione manuale."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Installazione completata"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Controllo del bootloader"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Paese"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Lingua"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "configurazione"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Variante"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Calcolo indici dei file ..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr "Programma di Installazione"
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr "Quale lingua vorresti utilizzare?"
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr "Dove sei?"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Disposizione della tastiera"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr "Qual è il layout della tua tastiera?"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr "Account utente"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr "Chi sei?"
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr "Tipologia di Installazione"
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Dove desideri installare 17G?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Partizionamento"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Riepilogo"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr "Installazione in corso"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-#, fuzzy
-msgid "Automated install"
-msgstr "Installazione Automatica"
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Indietro"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr "Successivo"
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, fuzzy, python-format
-msgid "Welcome to the %s Installer."
-msgstr "Benvenuto/a nell'installazione di 17G"
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr "Digita qui per testare il layout della tua tastiera"
-
-#: live-installer/frontend/gtk_interface.py:542
-#, fuzzy
-msgid "Erase a disk and install system on it."
-msgstr "Cancella un disco e installa 17G su di esso."
-
-#: live-installer/frontend/gtk_interface.py:555
-#, fuzzy
-msgid "Manually create, resize or choose partitions for system."
-msgstr "Crea, ridimensiona o scegli manualmente le partizioni per 17G."
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Modifica partizioni"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Periferica"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Tipo"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Sistema operativo"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Punto di mount"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Formatta come"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Dimensione"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Spazio libero"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Installa"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr "Fornisci una frase di accesso per la crittografia."
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Le tue password non coincidono."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Uscire?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Sei sicuro di voler uscire dall'installazione?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Scegli una lingua"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Inserisci un nome per il tuo computer."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Inserisci il tuo nome."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Le tue password non coincidono."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "La partizione EFI è troppo piccola. Deve essere di almeno 35MB."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Seleziona una partizione root (/)."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, fuzzy, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-"Per installare Linux Mint è necessaria una partizione di root.\n"
-"\n"
-"  - Punto di montaggio: /\n"
-"  - Dimensioni consigliate: 30 GB\n"
-"  - Formato file system consigliato: ext4\n"
-"\n"
-"Nota: la funzione snapshot btrfs di timeshift richiede l'uso di:\n"
-"  - Punto di montaggio del sottovolume /@\n"
-"  - btrfs come formato del filesystem\n"
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-"La partizione EFI non è avviabile, per favore modifica i flag della "
-"partizione."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "La partizione EFI è troppo piccola. Deve essere di almeno 35MB."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "La partizione EFI deve essere formattata in vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Per piacere selezionare una partizione EFI."
-
-#: live-installer/frontend/gtk_interface.py:1226
-#, fuzzy
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-"È necessaria una partizione di sistema EFI con i seguenti requisiti:\n"
-"\n"
-"  - Punto di montaggio: /boot/efi\n"
-"  - Flag di partizione: Avviabile\n"
-"  - Dimensioni: minimo 35 MB (almeno 100 MB consigliati)\n"
-"  - Formato: vfat o fat32\n"
-"\n"
-"Per garantire la compatibilità con Windows, si consiglia di utilizzare la "
-"prima partizione del disco come partizione di sistema EFI.\n"
-" "
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr "Seleziona un disco."
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr "Attenzione"
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr "Questo eliminerà tutti i dati su %s. Vuoi proseguire?"
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Inserisci un nome utente."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Localizzazione"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Lingua: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Fuso orario: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Disposizione della tastiera: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Impostazioni utente"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Nome reale: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Nome utente: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Accesso automatico: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "attivato"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "disattivato"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Impostazioni di sistema"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr "Nome del computer: "
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-#, fuzzy
-msgid "Install updates after installation"
-msgstr "Installazione Automatica"
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Operazioni sul filesystem"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Installare bootloader in %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Non installare il bootloader"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Utilizzare il /target già montato."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr "Installazione automatizzata su %s"
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Formattare %(path)s come %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Montare %(path)s come %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr "LVM: "
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr "Crittografia Disco: "
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"L' installazione è completata. Vuoi riavviare il computer per usare il nuovo "
-"sistema?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Errore di installazione"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, fuzzy, python-format
-msgid "Welcome to %s"
-msgstr "Benvenuto/a"
-
-#: live-installer/frontend/tui_interface.py:57
-#, fuzzy
-msgid "What keyboard would you like to use?"
-msgstr "Quale lingua vorresti utilizzare?"
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Modello Tastiera:"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Tipologia di Installazione"
-
-#: live-installer/frontend/tui_interface.py:80
-#, fuzzy
-msgid "Select a disk?"
-msgstr "Seleziona un disco."
-
-#: live-installer/frontend/tui_interface.py:84
-#, fuzzy
-msgid "Disk"
-msgstr "Disco:"
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Fuso orario"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "KB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Rimuovibile:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Modifica"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Assegnare a /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"Non è stato possibile scrivere la tabella delle partizioni per %s. Riavviare "
-"il computer e riprovare."
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"Non è stato possibile creare la partizione %s. L'installazione si fermerà. "
-"Riavviare il computer e riprovare."
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Partizione logica"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Partizione estesa"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Sconosciuta"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Modifica partizione"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Modifica partizione"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Dispositivo:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Formattare come:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Punto di montaggio:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Annulla"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "OK"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "No"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Sì"
 
 #~ msgid "Quit"
 #~ msgstr "Esci"

--- a/po/live-installer-it.po
+++ b/po/live-installer-it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2020-03-11 17:22+0000\n"
 "Last-Translator: Dragone2 <Unknown>\n"
 "Language-Team: Italian <it@li.org>\n"
@@ -94,7 +94,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -196,9 +196,9 @@ msgid "Format"
 msgstr "Formatta come"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -303,6 +303,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Formatta come"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -334,8 +340,8 @@ msgstr "Benvenuto/a"
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "OK"
 
@@ -427,23 +433,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr "Benvenuto/a"
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Paese"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "configurazione"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "KB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Variante"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Calcolo indici dei file ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Rimuovibile:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Modifica"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Assegnare a /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -461,10 +538,108 @@ msgstr "Calcolo indici dei file ..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr "Programma di Installazione"
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Spazio libero"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"Non è stato possibile scrivere la tabella delle partizioni per %s. Riavviare "
+"il computer e riprovare."
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"Non è stato possibile creare la partizione %s. L'installazione si fermerà. "
+"Riavviare il computer e riprovare."
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Partizione logica"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Partizione estesa"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Sconosciuta"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Modifica partizione"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Modifica partizione"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Dispositivo:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Formattare come:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Punto di montaggio:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Annulla"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Paese"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "configurazione"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variante"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Calcolo indici dei file ..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -582,18 +757,6 @@ msgstr "Formatta come"
 msgid "Size"
 msgstr "Dimensione"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Spazio libero"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -626,25 +789,6 @@ msgstr "Uscire?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Sei sicuro di voler uscire dall'installazione?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -907,7 +1051,7 @@ msgid "Disk Encryption: "
 msgstr "Crittografia Disco: "
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Installazione completata"
 
@@ -928,143 +1072,6 @@ msgstr "Errore di installazione"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "KB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Rimuovibile:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Modifica"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Assegnare a /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"Non è stato possibile scrivere la tabella delle partizioni per %s. Riavviare "
-"il computer e riprovare."
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"Non è stato possibile creare la partizione %s. L'installazione si fermerà. "
-"Riavviare il computer e riprovare."
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Partizione logica"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Partizione estesa"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Sconosciuta"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Modifica partizione"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Modifica partizione"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Dispositivo:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Formattare come:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Punto di montaggio:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Annulla"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1227,49 +1234,49 @@ msgstr "Creazione delle partizioni su %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formattazione di %(partition)s come %(format)s"
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Impostazione dell'hostname"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Impostazione della localizzazione"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Impostazione dell'hostname"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Impostazione delle opzioni della tastiera"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Rimozione della configurazione live (pacchetti)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Installazione del bootloader"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Configurazione del bootloader"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1277,15 +1284,15 @@ msgstr ""
 "ATTENZIONE: Il bootloader grub non è stato configurato correttamente! È "
 "necessaria una configurazione manuale."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Controllo del bootloader"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-ja.po
+++ b/po/live-installer-ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2018-04-16 07:22+0000\n"
 "Last-Translator: Keith Shellingfield <Unknown>\n"
 "Language-Team: Japanese <https://launchpad.net/~linuxmint-translation-team-"
@@ -24,19 +24,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -45,10 +45,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -57,13 +59,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "タイムゾーン"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -72,12 +74,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "パーティションを編集"
@@ -88,42 +90,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -140,7 +142,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "上級者モード"
@@ -150,142 +152,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "更新"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "フォーマット:"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "パーティションの編集"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -314,6 +322,703 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "タイムゾーン"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "言語"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "キーボードのレイアウト"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "インストールエラー"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "種類"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "国名"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "レイアウト"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "スモールキャピタル"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "キーボードのレイアウト"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "概要"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "パーティションの編集"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "デバイス"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "オペレーティングシステム"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "マウントポイント"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "サイズ"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "空き容量"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "終了しますか？"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "ルート (/) パーティションを選択して下さい"
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "EFI パーティションを選択して下さい"
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "ローカライズ"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "言語: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "タイムゾーン: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "キーボードレイアウト: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "ユーザー設定"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "氏名: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "ユーザー名: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "自動ログイン: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "有効"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "無効"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "システム設定"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "ファイルシステムオペレーション"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "ブートローダーをインストールしない"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "%(partition)s を %(mountpoint)s にマウントしています"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "インストールエラー"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "KB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "削除:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "編集"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "/ にアサイン"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "論理パーティション"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "拡張パーティション"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "不明"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "パーティションを編集"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "パーティションを編集"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "デバイス:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "フォーマット:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "マウントポイント:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -409,10 +1114,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -439,7 +1140,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "ファイルシステムのマウント情報を /etc/fstab に書き込んでいます"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "%(partition)s を %(mountpoint)s にマウントしています"
@@ -459,679 +1160,64 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "ホスト名を設定しています"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "ロケールを設定しています"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "ホスト名を設定しています"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "キーボードオプションを設定しています"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "ライブ設定 (パッケージ) を削除しています"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "ブートローダーをインストールしています"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "ブートローダーを設定しています"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr ""
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "ブートローダーを確認しています"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "国名"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "言語"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "レイアウト"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "スモールキャピタル"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "キーボードのレイアウト"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "概要"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "パーティションの編集"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "デバイス"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "種類"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "オペレーティングシステム"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "マウントポイント"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "サイズ"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "空き容量"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "終了しますか？"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "ルート (/) パーティションを選択して下さい"
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "EFI パーティションを選択して下さい"
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "ローカライズ"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "言語: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "タイムゾーン: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "キーボードレイアウト: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "ユーザー設定"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "氏名: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "ユーザー名: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "自動ログイン: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "有効"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "無効"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "システム設定"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "ファイルシステムオペレーション"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "ブートローダーをインストールしない"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "インストールエラー"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "キーボードのレイアウト"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "インストールエラー"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "タイムゾーン"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "KB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "削除:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "編集"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "/ にアサイン"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "論理パーティション"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "拡張パーティション"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "不明"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "パーティションを編集"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "パーティションを編集"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "デバイス:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "フォーマット:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "マウントポイント:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-ja.po
+++ b/po/live-installer-ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2018-04-16 07:22+0000\n"
 "Last-Translator: Keith Shellingfield <Unknown>\n"
 "Language-Team: Japanese <https://launchpad.net/~linuxmint-translation-team-"
@@ -90,7 +90,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -190,9 +190,9 @@ msgid "Format"
 msgstr "フォーマット:"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -296,6 +296,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "フォーマット:"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -326,8 +332,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -416,23 +422,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "国名"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "レイアウト"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "KB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "スモールキャピタル"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "削除:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "編集"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "/ にアサイン"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -450,9 +527,103 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "空き容量"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "論理パーティション"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "拡張パーティション"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "不明"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "パーティションを編集"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "パーティションを編集"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "デバイス:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "フォーマット:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "マウントポイント:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "国名"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "レイアウト"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "スモールキャピタル"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -567,18 +738,6 @@ msgstr ""
 msgid "Size"
 msgstr "サイズ"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "空き容量"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -610,25 +769,6 @@ msgstr "終了しますか？"
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -863,7 +1003,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr ""
 
@@ -882,139 +1022,6 @@ msgstr "インストールエラー"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "KB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "削除:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "編集"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "/ にアサイン"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "論理パーティション"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "拡張パーティション"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "不明"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "パーティションを編集"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "パーティションを編集"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "デバイス:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "フォーマット:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "マウントポイント:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1160,63 +1167,63 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "ホスト名を設定しています"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "ロケールを設定しています"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "ホスト名を設定しています"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "キーボードオプションを設定しています"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "ライブ設定 (パッケージ) を削除しています"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "ブートローダーをインストールしています"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "ブートローダーを設定しています"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "ブートローダーを確認しています"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-jv.po
+++ b/po/live-installer-jv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2016-02-19 01:32+0000\n"
 "Last-Translator: muiz kenjeran <muizkenjeran@gmail.com>\n"
 "Language-Team: Javanese <jv@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,141 +149,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "setelan sistim"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -310,6 +318,702 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Boso"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "totoruang papanketik "
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Pemasangane bubrah"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Jenisipun"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Notoruang"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Aneka Ragam"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Piranti"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Sistem Operasine"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Titik Rangkul"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Ukurane"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Ruang Bebas"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "pelokal'an"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "boso "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "wektu wilayah "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "totoruang papanketik "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "setelan pengguno"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "jeneng asli "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "jeneng pengguno "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "setelan sistim"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "kerjaan'e sistim file"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "ojo masang bootloader"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "nGerangkul %(partition)s nok %(mountpoint)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Masangine wis rampung"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Pemasangane bubrah"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "setelan sistim"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -405,10 +1109,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -435,7 +1135,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "nGerangkul %(partition)s nok %(mountpoint)s"
@@ -455,49 +1155,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Penyetelan nami-host"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Penyetelan lokal"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Penyetelan nami-host"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Penyetelan pilihane papan ketik"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "ngGuwak konfigurasi sing aktif (paketan)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Masangi bootloader"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "nGonfigurasi bootloader"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -505,630 +1205,16 @@ msgstr ""
 "NGILINGNO: Grub bootloader yo ora dikonfigurasi sakmestine! Kowe mbutuhno "
 "kanggo ngonfigurasi iku secoro manual."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Masangine wis rampung"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Ngecek bootloader"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Boso"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Notoruang"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Aneka Ragam"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Piranti"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Jenisipun"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Sistem Operasine"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Titik Rangkul"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Ukurane"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Ruang Bebas"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "pelokal'an"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "boso "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "wektu wilayah "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "totoruang papanketik "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "setelan pengguno"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "jeneng asli "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "jeneng pengguno "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "setelan sistim"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "kerjaan'e sistim file"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "ojo masang bootloader"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Pemasangane bubrah"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "totoruang papanketik "
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Pemasangane bubrah"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "setelan sistim"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-jv.po
+++ b/po/live-installer-jv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2016-02-19 01:32+0000\n"
 "Last-Translator: muiz kenjeran <muizkenjeran@gmail.com>\n"
 "Language-Team: Javanese <jv@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -292,6 +292,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -322,8 +327,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -411,23 +416,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Notoruang"
-
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Aneka Ragam"
-
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -445,9 +521,103 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Ruang Bebas"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "setelan sistim"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Notoruang"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Aneka Ragam"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -562,18 +732,6 @@ msgstr ""
 msgid "Size"
 msgstr "Ukurane"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Ruang Bebas"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -605,25 +763,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -858,7 +997,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Masangine wis rampung"
 
@@ -877,139 +1016,6 @@ msgstr "Pemasangane bubrah"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "setelan sistim"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1155,49 +1161,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Penyetelan nami-host"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Penyetelan lokal"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Penyetelan nami-host"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Penyetelan pilihane papan ketik"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "ngGuwak konfigurasi sing aktif (paketan)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Masangi bootloader"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "nGonfigurasi bootloader"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1205,15 +1211,15 @@ msgstr ""
 "NGILINGNO: Grub bootloader yo ora dikonfigurasi sakmestine! Kowe mbutuhno "
 "kanggo ngonfigurasi iku secoro manual."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Ngecek bootloader"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-ka.po
+++ b/po/live-installer-ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2014-10-16 18:58+0000\n"
 "Last-Translator: Tornike Batavani <Unknown>\n"
 "Language-Team: Georgian <ka@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -291,6 +291,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -320,8 +325,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -408,23 +413,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -442,9 +518,102 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -559,18 +728,6 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -602,25 +759,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -855,7 +993,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr ""
 
@@ -874,138 +1012,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1151,60 +1157,60 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 msgid "Removing extra packages"
 msgstr ""
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""

--- a/po/live-installer-ka.po
+++ b/po/live-installer-ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2014-10-16 18:58+0000\n"
 "Last-Translator: Tornike Batavani <Unknown>\n"
 "Language-Team: Georgian <ka@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "დროის სარტყელი"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,140 +149,146 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 msgid "Edit Partitions"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -308,6 +316,700 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "დროის სარტყელი"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "ენა"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+msgid "Keyboard Model"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:73
+msgid "Installation type?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "ტიპი"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "ოპერაციული სისტემა"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -403,10 +1105,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -433,7 +1131,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr ""
@@ -453,672 +1151,60 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 msgid "Removing extra packages"
 msgstr ""
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr ""
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "ენა"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "ტიპი"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "ოპერაციული სისტემა"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-msgid "Keyboard Model"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:73
-msgid "Installation type?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "დროის სარტყელი"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""

--- a/po/live-installer-kab.po
+++ b/po/live-installer-kab.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2020-02-29 12:22+0000\n"
 "Last-Translator: Yacine Bouklif <yacinebouklif@gmail.com>\n"
 "Language-Team: Kabyle <kab@li.org>\n"
@@ -94,7 +94,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GAṬ"
 
@@ -196,9 +196,9 @@ msgid "Format"
 msgstr "Msel s:"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -303,6 +303,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Msel s:"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -334,8 +340,8 @@ msgstr "Anṣuf"
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "IH"
 
@@ -427,23 +433,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr "Anṣuf"
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Tamurt"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "AṬ"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Taneɣruft"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "KAṬ"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Tantala"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MAṬ"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Asmiter n ifuyla ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TAṬ"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Aziraz:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Ẓreg"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Sddukel ɣer /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -461,10 +538,104 @@ msgstr "Asmiter n ifuyla ..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr "Amsbedday"
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Tallunt tilellit"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Aḥric ameẓẓul"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Aḥric yettwaẓẓel"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Arussin"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Ẓreg aḥric"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Ẓreg aḥric"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Ibenk:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Msel s:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Tanqiḍt n userkeb:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Sesfex"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Tamurt"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Taneɣruft"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Tantala"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Asmiter n ifuyla ..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -582,18 +753,6 @@ msgstr "Msel s:"
 msgid "Size"
 msgstr "Tiddi"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Tallunt tilellit"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -626,25 +785,6 @@ msgstr "Ad teffɣeḍ?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "D tidet tebɣiḍ ad teffɣeḍ seg usbedday?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -885,7 +1025,7 @@ msgid "Disk Encryption: "
 msgstr "Awgelhen n uḍebsi: "
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Asebded yemmed"
 
@@ -906,139 +1046,6 @@ msgstr "Tuccḍa deg usbeddi"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "AṬ"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "KAṬ"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MAṬ"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TAṬ"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Aziraz:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Ẓreg"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Sddukel ɣer /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Aḥric ameẓẓul"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Aḥric yettwaẓẓel"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Arussin"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Ẓreg aḥric"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Ẓreg aḥric"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Ibenk:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Msel s:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Tanqiḍt n userkeb:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Sesfex"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1199,49 +1206,49 @@ msgstr "Asnulfu n yeḥricen ɣef %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Amsal n %(partition)s am %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Asbadu n usenneftaɣ"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Asbadu n tutlayt"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Asbadu n usenneftaɣ"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Asbadu n iqewwaṛen n unasiw"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Tukksa n twila s srid (ikemmusen)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Asbeddi n uɛebbay n usekker"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Tawila n uɛebbay n usekker"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1249,15 +1256,15 @@ msgstr ""
 "ƔUR-K : aɛebbay n usekker GRUB ur yettuseɣwer ara akken iwata! Isefk ad t-"
 "tesɣewreḍ s ufus."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Asenqed n uɛebbay n usekker"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-kab.po
+++ b/po/live-installer-kab.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2020-02-29 12:22+0000\n"
 "Last-Translator: Yacine Bouklif <yacinebouklif@gmail.com>\n"
 "Language-Team: Kabyle <kab@li.org>\n"
@@ -24,8 +24,8 @@ msgid "Welcome to the 17g Installer."
 msgstr "Anṣuf ɣer umsbedday 17G."
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 #, fuzzy
 msgid ""
 "This program will ask you some questions and set up system on your computer."
@@ -33,12 +33,12 @@ msgstr ""
 "Ahil-agi ad k-d-yefk kra n isteqsiyen yerna ad isbedd 17G ɣef uselkim-inek."
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr "Tamudemt n unasiw:"
 
@@ -48,10 +48,12 @@ msgid "Type here to test your keyboard"
 msgstr "Aru dagi iwakken ad teskeydeḍ taneɣruft n unasiw-inek"
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -60,13 +62,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Izḍi usrig"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr "Asbeddi awurman"
 
@@ -76,12 +78,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr "Sfeḍ aḍebsi u sbedd degs 17G."
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr "Aḍebsi:"
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Ẓreg aḥric"
@@ -92,42 +94,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GAṬ"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr "Seqdec  LVM (Logical Volume Management)"
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr "Wgelhen anagraw n wammud"
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr "Tafyirt tuffirt"
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr "Sentem tafyirt tuffirt"
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr "Beḍḍu n uḍebsi s ufus"
 
@@ -145,7 +147,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Askar ussnaw"
@@ -155,144 +157,150 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 #, fuzzy
 msgid "Minimal installation"
 msgstr "Asbeddi awurman"
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Smiren"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Msel s:"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr "Sbedd umuɣ n GRUB:"
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Ẓreg iḥricen"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr "Isem-ik:"
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr "Isem n uselkim inek:"
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr "Fren isem n useqdac:"
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr "Isem ara yeseqdec mi ara yemmelay akke iselkimen-nniḍen."
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr "Fren awal n uɛeddi:"
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Qqen s wudem awurman"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr "Yesra awal-inu n uɛeddi iwakken ad yeqqen"
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr "Wgelhen akaram-inu agejdan"
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr "Sentem awal-inek n uɛeddi:"
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 #, fuzzy
 msgid "Automated installation enabled!"
 msgstr "Asbeddi awurman di %s"
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr "Anṣuf"
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -323,6 +331,719 @@ msgstr ""
 #, fuzzy
 msgid "Welcome to 17g"
 msgstr "Anṣuf"
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "IH"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Ala"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Ih"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Izḍi usrig"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, fuzzy, python-format
+msgid "Welcome to the %s Installer."
+msgstr "Anṣuf ɣer umsbedday 17G."
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr "Anta tutlayt i tebɣiḍ ad tesqedeḍ ?"
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Tutlayt"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr "Anida telliḍ?"
+
+#: live-installer/frontend/tui_interface.py:57
+#, fuzzy
+msgid "What keyboard would you like to use?"
+msgstr "Anta tutlayt i tebɣiḍ ad tesqedeḍ ?"
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Tamudemt n unasiw:"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Anaw n usbeddi"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Taggayt"
+
+#: live-installer/frontend/tui_interface.py:80
+#, fuzzy
+msgid "Select a disk?"
+msgstr "Ttxil-k fren aḍebsi."
+
+#: live-installer/frontend/tui_interface.py:84
+#, fuzzy
+msgid "Disk"
+msgstr "Aḍebsi:"
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, fuzzy, python-format
+msgid "Welcome to %s"
+msgstr "Anṣuf"
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Tamurt"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Taneɣruft"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Tantala"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Asmiter n ifuyla ..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr "Amsbedday"
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Taneɣruft n unasiw"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr "Anta i d taneɣruft n unasiw-inek ?"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr "Amiḍan n useqdac"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr "Anwa i d kečč?"
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr "Anaw n usbeddi"
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Anida tebɣiḍ ad tesbeddeḍ 17G ?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Beṭṭu n udebṣi"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Agzul"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr "Asebded"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+#, fuzzy
+msgid "Automated Install"
+msgstr "Asbeddi awurman"
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Ɣer deffir"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr "Ɣer sdat"
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr "Aru dagi iwakken ad teskeydeḍ taneɣruft n unasiw-inek"
+
+#: live-installer/frontend/gtk_interface.py:546
+#, fuzzy
+msgid "Erase a disk and install system on it."
+msgstr "Sfeḍ aḍebsi u sbedd degs 17G."
+
+#: live-installer/frontend/gtk_interface.py:559
+#, fuzzy
+msgid "Manually create, resize or choose partitions for system."
+msgstr "Snulfu-d, beddel tiddi neɣ fren iḥricen i 17G s ufus."
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Ẓreg iḥricen"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Ibenk"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Anagraw n wammud"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Tanqiḍt n userkeb:"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Msel s:"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Tiddi"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Tallunt tilellit"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr "Ɣur-k"
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr "Ayagi ad yekkes akk isefka di %s. Tettḥeqqeḍ ?"
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Sebded"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr "Ttxil-k fk-d tafyirt tuffirt i uwgelhen."
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Awalen n uɛeddi mgaraden."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Ad teffɣeḍ?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "D tidet tebɣiḍ ad teffɣeḍ seg usbedday?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Ttxil-k fren tutlayt"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Ttxil-k efk-d isem i uselkim-inek."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Ttxil-k sekcem isem-ik ummid."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Awalen n uɛeddi mgaraden."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "Aḥric EFI meẓẓi aṭas. isefk ad yili ma drus 35MB."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Ttxil-k fren aḥric aẓar (/)."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "Aḥric EFI ur yesɛi ara asekker. Ttxil-k ẓreg iraten n uḥric."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "Aḥric EFI meẓẓi aṭas. isefk ad yili ma drus 35MB."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "Aḥric EFI isefk ad yettwamsel s vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Ttxil-k fren aḥric EFI."
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr "Ttxil-k fren aḍebsi."
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Ttxil-k sekcem isem n useqdac."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Asideg"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Tutlayt: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Tamnaḍt tasragant: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Tarusi n unasiw: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Iɣewwaren n useqdac"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Isem ummid: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Isem n useqdac: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Tuqqna tawurmant: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "yermed"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "ittwasens"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Iɣewwaren n unagraw"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr "Isem n uselkim: "
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+#, fuzzy
+msgid "Install updates after installation"
+msgstr "Asbeddi awurman"
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Timehlin n unagraw n ifuyla"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Asbeddi n uɛebbay n usekker di %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Ur sbedday ara aɛebbay n usekker"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Aseqdec n uḥric /target yettwaserkeb yakan."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr "Asbeddi awurman di %s"
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Amsal n %(path)s s %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Aserkeb n %(path)s di %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Aserkeb n %(path)s di %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr "LVM: "
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr "Awgelhen n uḍebsi: "
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Asebded yemmed"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Asbeddi ifuk. Tebɣiḍ ad alseḍ asbekker n uselkim iwakken ad tesqedceḍ "
+"anagraw amaynut?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Tuccḍa deg usbeddi"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "AṬ"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "KAṬ"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MAṬ"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TAṬ"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Aziraz:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Ẓreg"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Sddukel ɣer /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Aḥric ameẓẓul"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Aḥric yettwaẓẓel"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Arussin"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Ẓreg aḥric"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Ẓreg aḥric"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Ibenk:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Msel s:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Tanqiḍt n userkeb:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Sesfex"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
+msgstr ""
 
 #: live-installer/validate.py:12
 msgid "Please provide a username."
@@ -432,10 +1153,6 @@ msgstr "Awalen n uɛeddi mgaraden."
 msgid "Please provide a password for your user account."
 msgstr "Ttxil-k sekcem awal n uɛeddi i umiḍan-inek."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -462,7 +1179,7 @@ msgstr "Timerna n useqdac amaynut ar unagraw"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Tira n isalan n userkeb di /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Aserkeb n %(partition)s ɣef %(mountpoint)s"
@@ -482,49 +1199,49 @@ msgstr "Asnulfu n yeḥricen ɣef %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Amsal n %(partition)s am %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Asbadu n usenneftaɣ"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Asbadu n tutlayt"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Asbadu n usenneftaɣ"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Asbadu n iqewwaṛen n unasiw"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Tukksa n twila s srid (ikemmusen)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Asbeddi n uɛebbay n usekker"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Tawila n uɛebbay n usekker"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -532,648 +1249,17 @@ msgstr ""
 "ƔUR-K : aɛebbay n usekker GRUB ur yettuseɣwer ara akken iwata! Isefk ad t-"
 "tesɣewreḍ s ufus."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Asebded yemmed"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Asenqed n uɛebbay n usekker"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Tamurt"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Tutlayt"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Taneɣruft"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Tantala"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Asmiter n ifuyla ..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr "Amsbedday"
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr "Anta tutlayt i tebɣiḍ ad tesqedeḍ ?"
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr "Anida telliḍ?"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Taneɣruft n unasiw"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr "Anta i d taneɣruft n unasiw-inek ?"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr "Amiḍan n useqdac"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr "Anwa i d kečč?"
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr "Anaw n usbeddi"
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Anida tebɣiḍ ad tesbeddeḍ 17G ?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Beṭṭu n udebṣi"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Agzul"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr "Asebded"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-#, fuzzy
-msgid "Automated install"
-msgstr "Asbeddi awurman"
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Ɣer deffir"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr "Ɣer sdat"
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, fuzzy, python-format
-msgid "Welcome to the %s Installer."
-msgstr "Anṣuf ɣer umsbedday 17G."
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr "Aru dagi iwakken ad teskeydeḍ taneɣruft n unasiw-inek"
-
-#: live-installer/frontend/gtk_interface.py:542
-#, fuzzy
-msgid "Erase a disk and install system on it."
-msgstr "Sfeḍ aḍebsi u sbedd degs 17G."
-
-#: live-installer/frontend/gtk_interface.py:555
-#, fuzzy
-msgid "Manually create, resize or choose partitions for system."
-msgstr "Snulfu-d, beddel tiddi neɣ fren iḥricen i 17G s ufus."
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Ẓreg iḥricen"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Ibenk"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Taggayt"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Anagraw n wammud"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Tanqiḍt n userkeb:"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Msel s:"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Tiddi"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Tallunt tilellit"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Sebded"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr "Ttxil-k fk-d tafyirt tuffirt i uwgelhen."
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Awalen n uɛeddi mgaraden."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Ad teffɣeḍ?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "D tidet tebɣiḍ ad teffɣeḍ seg usbedday?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Ttxil-k fren tutlayt"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Ttxil-k efk-d isem i uselkim-inek."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Ttxil-k sekcem isem-ik ummid."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Awalen n uɛeddi mgaraden."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "Aḥric EFI meẓẓi aṭas. isefk ad yili ma drus 35MB."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Ttxil-k fren aḥric aẓar (/)."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "Aḥric EFI ur yesɛi ara asekker. Ttxil-k ẓreg iraten n uḥric."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "Aḥric EFI meẓẓi aṭas. isefk ad yili ma drus 35MB."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "Aḥric EFI isefk ad yettwamsel s vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Ttxil-k fren aḥric EFI."
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr "Ttxil-k fren aḍebsi."
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr "Ɣur-k"
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr "Ayagi ad yekkes akk isefka di %s. Tettḥeqqeḍ ?"
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Ttxil-k sekcem isem n useqdac."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Asideg"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Tutlayt: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Tamnaḍt tasragant: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Tarusi n unasiw: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Iɣewwaren n useqdac"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Isem ummid: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Isem n useqdac: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Tuqqna tawurmant: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "yermed"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "ittwasens"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Iɣewwaren n unagraw"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr "Isem n uselkim: "
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-#, fuzzy
-msgid "Install updates after installation"
-msgstr "Asbeddi awurman"
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Timehlin n unagraw n ifuyla"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Asbeddi n uɛebbay n usekker di %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Ur sbedday ara aɛebbay n usekker"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Aseqdec n uḥric /target yettwaserkeb yakan."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr "Asbeddi awurman di %s"
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Amsal n %(path)s s %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Aserkeb n %(path)s di %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr "LVM: "
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr "Awgelhen n uḍebsi: "
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Asbeddi ifuk. Tebɣiḍ ad alseḍ asbekker n uselkim iwakken ad tesqedceḍ "
-"anagraw amaynut?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Tuccḍa deg usbeddi"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, fuzzy, python-format
-msgid "Welcome to %s"
-msgstr "Anṣuf"
-
-#: live-installer/frontend/tui_interface.py:57
-#, fuzzy
-msgid "What keyboard would you like to use?"
-msgstr "Anta tutlayt i tebɣiḍ ad tesqedeḍ ?"
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Tamudemt n unasiw:"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Anaw n usbeddi"
-
-#: live-installer/frontend/tui_interface.py:80
-#, fuzzy
-msgid "Select a disk?"
-msgstr "Ttxil-k fren aḍebsi."
-
-#: live-installer/frontend/tui_interface.py:84
-#, fuzzy
-msgid "Disk"
-msgstr "Aḍebsi:"
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Izḍi usrig"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "AṬ"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "KAṬ"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MAṬ"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TAṬ"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Aziraz:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Ẓreg"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Sddukel ɣer /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Aḥric ameẓẓul"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Aḥric yettwaẓẓel"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Arussin"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Ẓreg aḥric"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Ẓreg aḥric"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Ibenk:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Msel s:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Tanqiḍt n userkeb:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Sesfex"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "IH"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Ala"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Ih"
 
 #~ msgid "Quit"
 #~ msgstr "Ffeɣ"

--- a/po/live-installer-kk.po
+++ b/po/live-installer-kk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2016-05-29 18:23+0000\n"
 "Last-Translator: Murat Käribay <d2vsd1@mail.ru>\n"
 "Language-Team: Kazakh <kk@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Уақыт белдеуі"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,142 +149,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Жаңарту"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Сияқты сақтау:"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Жүйелік баптаулар"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Автоматты түрде кіру"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -311,6 +319,703 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Уақыт белдеуі"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Тіл"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Пернетақтаның пернелері"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Орнату қатесі"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Түрі"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Ел"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Жайма"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Нұсқасы"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Пернетақтаның пернелері"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Бөлімдеу"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Қорытынды"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Құрылғы"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Операциялық жүйесі"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Тіркелу нүктесі"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Өлшемі"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Бос орын"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Аудармалар"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Тіл: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Уақыт белдеуі: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Пернетақта жаймасы: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Пайдаланушы баптаулары"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Шын аты: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Пайдаланушы аты: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Жүйелік баптаулар"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Файлдық жүйе әрекеттері"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Жүктеушіні орнатпау"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "%(partition)s диск бөлімін %(mountpoint)s жеріне тіркеу"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Орнату аяқталды"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Орнату қатесі"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Жүйелік баптаулар"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Сияқты сақтау:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Тіркеу нүктесі:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -406,10 +1111,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -436,7 +1137,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "%(partition)s диск бөлімін %(mountpoint)s жеріне тіркеу"
@@ -456,49 +1157,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "%(partition)s бөлімін %(format)s форматтау..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Хост атын орнату"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Локальді орнату"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Хост атын орнату"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Пернетақта баптауларын орнату"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Тірі жүйенің баптауларын (бағдарламалар) өшіру"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Жүктеуші орнатылуда"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Жүктеушіні баптау"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -506,631 +1207,16 @@ msgstr ""
 "НАЗАР АУДАРЫҢЫЗ: grub жүктеушісі дұрыс бапталмады! Сізге оны қолмен баптау "
 "керек."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Орнату аяқталды"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Жүктеушіні тексеру"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Ел"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Тіл"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Жайма"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Нұсқасы"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Пернетақтаның пернелері"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Бөлімдеу"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Қорытынды"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Құрылғы"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Түрі"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Операциялық жүйесі"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Тіркелу нүктесі"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Өлшемі"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Бос орын"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Аудармалар"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Тіл: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Уақыт белдеуі: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Пернетақта жаймасы: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Пайдаланушы баптаулары"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Шын аты: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Пайдаланушы аты: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Жүйелік баптаулар"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Файлдық жүйе әрекеттері"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Жүктеушіні орнатпау"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Орнату қатесі"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Пернетақтаның пернелері"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Орнату қатесі"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Уақыт белдеуі"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Жүйелік баптаулар"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Сияқты сақтау:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Тіркеу нүктесі:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-kk.po
+++ b/po/live-installer-kk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2016-05-29 18:23+0000\n"
 "Last-Translator: Murat Käribay <d2vsd1@mail.ru>\n"
 "Language-Team: Kazakh <kk@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgid "Format"
 msgstr "Сияқты сақтау:"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -293,6 +293,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Сияқты сақтау:"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -323,8 +329,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -413,23 +419,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Ел"
-
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Жайма"
-
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Нұсқасы"
-
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -447,9 +524,103 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Бос орын"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Жүйелік баптаулар"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Сияқты сақтау:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Тіркеу нүктесі:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Ел"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Жайма"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Нұсқасы"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -564,18 +735,6 @@ msgstr ""
 msgid "Size"
 msgstr "Өлшемі"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Бос орын"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -607,25 +766,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -860,7 +1000,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Орнату аяқталды"
 
@@ -879,139 +1019,6 @@ msgstr "Орнату қатесі"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Жүйелік баптаулар"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Сияқты сақтау:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Тіркеу нүктесі:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1157,49 +1164,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "%(partition)s бөлімін %(format)s форматтау..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Хост атын орнату"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Локальді орнату"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Хост атын орнату"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Пернетақта баптауларын орнату"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Тірі жүйенің баптауларын (бағдарламалар) өшіру"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Жүктеуші орнатылуда"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Жүктеушіні баптау"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1207,15 +1214,15 @@ msgstr ""
 "НАЗАР АУДАРЫҢЫЗ: grub жүктеушісі дұрыс бапталмады! Сізге оны қолмен баптау "
 "керек."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Жүктеушіні тексеру"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-km.po
+++ b/po/live-installer-km.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2018-07-25 09:27+0000\n"
 "Last-Translator: Rockworld <sumoisrock@gmail.com>\n"
 "Language-Team: Khmer <km@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "តំបន់​ពេលវេលា"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "កែ​សម្រួល​ភាគ​ថាស"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -148,141 +150,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "កែ​សម្រួល​ភាគ​ថាស"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -311,6 +319,703 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "តំបន់​ពេលវេលា"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "ភាសា"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "ប្លង់​ក្ដារចុច"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "កំហុស​ការ​ដំឡើង"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "ប្រភេទ"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "ប្រទេស"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "ប្លង់"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "វ៉ារ្យង់"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "ប្លង់​ក្ដារចុច"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "ការ​ចែក​ភាគ​ថាស"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "សេចក្ដី​សង្ខេប"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "ឧបករណ៍"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "ប្រព័ន្ធ​ប្រតិបត្តិការ"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "ចំណុច​ម៉ោន"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "ទំហំ"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "ទំហំ​ទំនេរ"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "មូលដ្ឋានីយកម្ម"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "ភាសា៖ "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "តំបន់​ពេលវេលា៖ "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "ប្លង់​ក្ដារចុច៖ "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "ការកំណត់​អ្នកប្រើ"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "ឈ្មោះ​ពិត៖ "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "ឈ្មោះ​អ្នក​ប្រើ​ ៖ "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "ការ​កំណត់​ប្រព័ន្ធ"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "ប្រតិបត្តិការ​ប្រព័ន្ធ​ឯកសារ"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "កុំ​ដំឡើង​កម្មវិធី​ចាប់ផ្ដើម"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "កំពុង​ម៉ោន %(partition)s លើ %(mountpoint)s..."
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "បាន​បញ្ចប់​ការ​ដំឡើង"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "កំហុស​ការ​ដំឡើង"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "មិនស្គាល់"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "កែ​សម្រួល​ភាគ​ថាស"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "កែ​សម្រួល​ភាគ​ថាស"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "ឧបករណ៍៖"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "ចំណុច​ម៉ោន៖"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -406,10 +1111,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -436,7 +1137,7 @@ msgstr "កំពុងបន្ថែមអ្នកប្រើថ្មីទ
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "កំពុង​ម៉ោន %(partition)s លើ %(mountpoint)s..."
@@ -456,49 +1157,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "កំពុងធ្វើការ format %(partition)s ជា %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "កំពុង​កំណត់​ឈ្មោះ​ម៉ាស៊ីន"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "កំពុង​កំណត់​មូលដ្ឋាន"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "កំពុង​កំណត់​ឈ្មោះ​ម៉ាស៊ីន"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "កំពុង​កំណត់​ជម្រើស​ក្ដារចុច"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "កំពុង​យកការ​កំណត់​រចនាសម្ព័ន្ធបន្តផ្ទាល់​ចេញ (កញ្ចប់)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "កំពុង​ដំឡើង​កម្មវិធី​ចាប់ផ្ដើម"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "កំពុង​កំណត់​រចនាសម្ព័ន្ធ​កម្មវិធី​ចាប់ផ្ដើម"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -506,631 +1207,16 @@ msgstr ""
 "សូមព្រមាន៖ កម្មវិធីចាប់ផ្ដើមប្រព័ន្ធ grub មិនត្រូវបានកំណត់យ៉ាងត្រឹមត្រូវទេ! "
 "អ្នកត្រូវកំណត់រចនាសម្ព័ន្ធវាដោយដៃ។"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "បាន​បញ្ចប់​ការ​ដំឡើង"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "កំពុង​ពិនិត្យមើល​កម្មវិធី​ចាប់ផ្ដើម"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "ប្រទេស"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "ភាសា"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "ប្លង់"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "វ៉ារ្យង់"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "ប្លង់​ក្ដារចុច"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "ការ​ចែក​ភាគ​ថាស"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "សេចក្ដី​សង្ខេប"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "ឧបករណ៍"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "ប្រភេទ"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "ប្រព័ន្ធ​ប្រតិបត្តិការ"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "ចំណុច​ម៉ោន"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "ទំហំ"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "ទំហំ​ទំនេរ"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "មូលដ្ឋានីយកម្ម"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "ភាសា៖ "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "តំបន់​ពេលវេលា៖ "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "ប្លង់​ក្ដារចុច៖ "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "ការកំណត់​អ្នកប្រើ"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "ឈ្មោះ​ពិត៖ "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "ឈ្មោះ​អ្នក​ប្រើ​ ៖ "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "ការ​កំណត់​ប្រព័ន្ធ"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "ប្រតិបត្តិការ​ប្រព័ន្ធ​ឯកសារ"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "កុំ​ដំឡើង​កម្មវិធី​ចាប់ផ្ដើម"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "កំហុស​ការ​ដំឡើង"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "ប្លង់​ក្ដារចុច"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "កំហុស​ការ​ដំឡើង"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "តំបន់​ពេលវេលា"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "មិនស្គាល់"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "កែ​សម្រួល​ភាគ​ថាស"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "កែ​សម្រួល​ភាគ​ថាស"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "ឧបករណ៍៖"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "ចំណុច​ម៉ោន៖"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-km.po
+++ b/po/live-installer-km.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2018-07-25 09:27+0000\n"
 "Last-Translator: Rockworld <sumoisrock@gmail.com>\n"
 "Language-Team: Khmer <km@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -187,9 +187,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -293,6 +293,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -323,8 +328,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -413,23 +418,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "ប្រទេស"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "ប្លង់"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "វ៉ារ្យង់"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -447,9 +523,103 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "ទំហំ​ទំនេរ"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "មិនស្គាល់"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "កែ​សម្រួល​ភាគ​ថាស"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "កែ​សម្រួល​ភាគ​ថាស"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "ឧបករណ៍៖"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "ចំណុច​ម៉ោន៖"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "ប្រទេស"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "ប្លង់"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "វ៉ារ្យង់"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -564,18 +734,6 @@ msgstr ""
 msgid "Size"
 msgstr "ទំហំ"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "ទំហំ​ទំនេរ"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -607,25 +765,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -860,7 +999,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "បាន​បញ្ចប់​ការ​ដំឡើង"
 
@@ -879,139 +1018,6 @@ msgstr "កំហុស​ការ​ដំឡើង"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "មិនស្គាល់"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "កែ​សម្រួល​ភាគ​ថាស"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "កែ​សម្រួល​ភាគ​ថាស"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "ឧបករណ៍៖"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "ចំណុច​ម៉ោន៖"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1157,49 +1163,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "កំពុងធ្វើការ format %(partition)s ជា %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "កំពុង​កំណត់​ឈ្មោះ​ម៉ាស៊ីន"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "កំពុង​កំណត់​មូលដ្ឋាន"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "កំពុង​កំណត់​ឈ្មោះ​ម៉ាស៊ីន"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "កំពុង​កំណត់​ជម្រើស​ក្ដារចុច"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "កំពុង​យកការ​កំណត់​រចនាសម្ព័ន្ធបន្តផ្ទាល់​ចេញ (កញ្ចប់)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "កំពុង​ដំឡើង​កម្មវិធី​ចាប់ផ្ដើម"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "កំពុង​កំណត់​រចនាសម្ព័ន្ធ​កម្មវិធី​ចាប់ផ្ដើម"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1207,15 +1213,15 @@ msgstr ""
 "សូមព្រមាន៖ កម្មវិធីចាប់ផ្ដើមប្រព័ន្ធ grub មិនត្រូវបានកំណត់យ៉ាងត្រឹមត្រូវទេ! "
 "អ្នកត្រូវកំណត់រចនាសម្ព័ន្ធវាដោយដៃ។"
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "កំពុង​ពិនិត្យមើល​កម្មវិធី​ចាប់ផ្ដើម"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-kn.po
+++ b/po/live-installer-kn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2012-06-03 19:42+0000\n"
 "Last-Translator: Hoysala T'swamy <jrandomnerd@gmail.com>\n"
 "Language-Team: Kannada <kn@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -292,6 +292,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -322,8 +327,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -411,23 +416,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "ವಿನ್ಯಾಸ"
-
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "ಭಿನ್ನಾಂಶ"
-
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -445,9 +521,103 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "ಖಾಲಿ ಸ್ಥಳ"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "ವ್ಯವಸ್ಥೆ ಸಂಯೋಜನೆಗಳು"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "ವಿನ್ಯಾಸ"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "ಭಿನ್ನಾಂಶ"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -562,18 +732,6 @@ msgstr ""
 msgid "Size"
 msgstr "ಗಾತ್ರ"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "ಖಾಲಿ ಸ್ಥಳ"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -605,25 +763,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -858,7 +997,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "ಸಂಸ್ಥಾಪನೆ ಪೂರ್ಣವಾಗಿದೆ"
 
@@ -877,139 +1016,6 @@ msgstr "ಸಂಸ್ಥಾಪನೆ ದೋಷ"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "ವ್ಯವಸ್ಥೆ ಸಂಯೋಜನೆಗಳು"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1155,49 +1161,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "ಆತಿಥೇಯ ಹೆಸರು ನಿಗದಿಪಡಿಸುತ್ತಿದೆ"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "ಸ್ಥಳೀಯತೆ ನಿಗದಿಪಡಿಸುತ್ತಿದೆ"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "ಆತಿಥೇಯ ಹೆಸರು ನಿಗದಿಪಡಿಸುತ್ತಿದೆ"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "ಕೀಲಿಮಣೆ ಆಯ್ಕೆಗಳನ್ನು ನಿಗದಿಮಾಡುತ್ತಿದೆ"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "ಲೈವ್ ಸಂಯೋಜನೆ (ತಂತ್ರಾಂಶ ಪೊಟ್ಟಣಗಳು) ತೆಗೆದುಹಾಕುತ್ತಿದೆ"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "ಬೂಟ್ ಲೋಡರ್ ಸಂಸ್ಥಾಪಿಸುತ್ತಿದೆ"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "ಬೂಟ್ ಲೋಡರ್ ಸಂಯೋಜಿಸುತ್ತಿದೆ"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1205,15 +1211,15 @@ msgstr ""
 "ಎಚ್ಚರಿಕೆ: ಗ್ರಬ್ ಬೂಟ್ ಲೋಡರ್ ಸಮರ್ಪಕವಾಗಿ ಸಂಯೋಜಿತವಾಗಿಲ್ಲ! ನೀವು ಇದನ್ನು ಪ್ರತ್ಯೇಕವಾಗಿ ಸಂಯೋಜನೆ "
 "ಮಾಡಬೇಕಿದೆ"
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "ಬೂಟ್ ಲೋಡರ್ ಪರೀಕ್ಷಿಸುತ್ತಿದೆ"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-kn.po
+++ b/po/live-installer-kn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2012-06-03 19:42+0000\n"
 "Last-Translator: Hoysala T'swamy <jrandomnerd@gmail.com>\n"
 "Language-Team: Kannada <kn@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,141 +149,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "ವ್ಯವಸ್ಥೆ ಸಂಯೋಜನೆಗಳು"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -310,6 +318,702 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "ಕೀಲಿಮಣೆ ವಿನ್ಯಾಸ: "
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "ಸಂಸ್ಥಾಪನೆ ದೋಷ"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "ವಿಧ"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "ವಿನ್ಯಾಸ"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "ಭಿನ್ನಾಂಶ"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "ಸಾಧನ"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "ಕಾರ್ಯನಿರ್ವಹಣಾ ವ್ಯವಸ್ಥೆ"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "ಆರೋಹಣ ಬಿಂದು"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "ಗಾತ್ರ"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "ಖಾಲಿ ಸ್ಥಳ"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "ಸ್ಥಳೀಕರಣ"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "ಭಾಷೆ: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "ಕಾಲವಲಯ: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "ಕೀಲಿಮಣೆ ವಿನ್ಯಾಸ: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "ಬಳಕೆದಾರರ ಸಂಯೋಜನೆಗಳು"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "ನೈಜ ಹೆಸರು: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "ಬಳಕೆ ಹೆಸರು: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "ವ್ಯವಸ್ಥೆ ಸಂಯೋಜನೆಗಳು"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "ಕಡತವ್ಯವಸ್ಥೆ ಕಾರ್ಯಗಳು"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "ಬೂಟ್ ಲೋಡರ್ ಸಂಸ್ಥಾಪಿಸುವುದು ಬೇಡ"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "%(partition)s ನ್ನು %(mountpoint)s ನಲ್ಲಿ ಆರೋಹಣ ಮಾಡುತ್ತಿದೆ"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "ಸಂಸ್ಥಾಪನೆ ಪೂರ್ಣವಾಗಿದೆ"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "ಸಂಸ್ಥಾಪನೆ ದೋಷ"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "ವ್ಯವಸ್ಥೆ ಸಂಯೋಜನೆಗಳು"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -405,10 +1109,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -435,7 +1135,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "%(partition)s ನ್ನು %(mountpoint)s ನಲ್ಲಿ ಆರೋಹಣ ಮಾಡುತ್ತಿದೆ"
@@ -455,49 +1155,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "ಆತಿಥೇಯ ಹೆಸರು ನಿಗದಿಪಡಿಸುತ್ತಿದೆ"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "ಸ್ಥಳೀಯತೆ ನಿಗದಿಪಡಿಸುತ್ತಿದೆ"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "ಆತಿಥೇಯ ಹೆಸರು ನಿಗದಿಪಡಿಸುತ್ತಿದೆ"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "ಕೀಲಿಮಣೆ ಆಯ್ಕೆಗಳನ್ನು ನಿಗದಿಮಾಡುತ್ತಿದೆ"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "ಲೈವ್ ಸಂಯೋಜನೆ (ತಂತ್ರಾಂಶ ಪೊಟ್ಟಣಗಳು) ತೆಗೆದುಹಾಕುತ್ತಿದೆ"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "ಬೂಟ್ ಲೋಡರ್ ಸಂಸ್ಥಾಪಿಸುತ್ತಿದೆ"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "ಬೂಟ್ ಲೋಡರ್ ಸಂಯೋಜಿಸುತ್ತಿದೆ"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -505,630 +1205,16 @@ msgstr ""
 "ಎಚ್ಚರಿಕೆ: ಗ್ರಬ್ ಬೂಟ್ ಲೋಡರ್ ಸಮರ್ಪಕವಾಗಿ ಸಂಯೋಜಿತವಾಗಿಲ್ಲ! ನೀವು ಇದನ್ನು ಪ್ರತ್ಯೇಕವಾಗಿ ಸಂಯೋಜನೆ "
 "ಮಾಡಬೇಕಿದೆ"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "ಸಂಸ್ಥಾಪನೆ ಪೂರ್ಣವಾಗಿದೆ"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "ಬೂಟ್ ಲೋಡರ್ ಪರೀಕ್ಷಿಸುತ್ತಿದೆ"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "ವಿನ್ಯಾಸ"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "ಭಿನ್ನಾಂಶ"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "ಸಾಧನ"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "ವಿಧ"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "ಕಾರ್ಯನಿರ್ವಹಣಾ ವ್ಯವಸ್ಥೆ"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "ಆರೋಹಣ ಬಿಂದು"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "ಗಾತ್ರ"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "ಖಾಲಿ ಸ್ಥಳ"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "ಸ್ಥಳೀಕರಣ"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "ಭಾಷೆ: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "ಕಾಲವಲಯ: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "ಕೀಲಿಮಣೆ ವಿನ್ಯಾಸ: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "ಬಳಕೆದಾರರ ಸಂಯೋಜನೆಗಳು"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "ನೈಜ ಹೆಸರು: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "ಬಳಕೆ ಹೆಸರು: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "ವ್ಯವಸ್ಥೆ ಸಂಯೋಜನೆಗಳು"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "ಕಡತವ್ಯವಸ್ಥೆ ಕಾರ್ಯಗಳು"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "ಬೂಟ್ ಲೋಡರ್ ಸಂಸ್ಥಾಪಿಸುವುದು ಬೇಡ"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "ಸಂಸ್ಥಾಪನೆ ದೋಷ"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "ಕೀಲಿಮಣೆ ವಿನ್ಯಾಸ: "
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "ಸಂಸ್ಥಾಪನೆ ದೋಷ"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "ವ್ಯವಸ್ಥೆ ಸಂಯೋಜನೆಗಳು"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-ko.po
+++ b/po/live-installer-ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2020-02-15 20:21+0000\n"
 "Last-Translator: Litty <Unknown>\n"
 "Language-Team: Korean <ko@li.org>\n"
@@ -92,7 +92,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -193,9 +193,9 @@ msgid "Format"
 msgstr "포맷하기"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -300,6 +300,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "포맷하기"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -331,8 +337,8 @@ msgstr "환영합니다"
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "OK"
 
@@ -423,23 +429,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr "환영합니다"
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "국가"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "배치"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "변형"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "파일 색인을 계산하는 중입니다 ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "이동식 매체:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "편집하기"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "/로 할당합니다"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -457,10 +534,104 @@ msgstr "파일 색인을 계산하는 중입니다 ..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "남은 공간"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "논리 파티션"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "확장 파티션"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "알 수 없음"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "파티션 편집하기"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "파티션 편집하기"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "장치:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "포맷하기:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "장착 지점:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "취소"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "국가"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "배치"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "변형"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "파일 색인을 계산하는 중입니다 ..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -576,18 +747,6 @@ msgstr "포맷하기"
 msgid "Size"
 msgstr "크기"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "남은 공간"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -620,25 +779,6 @@ msgstr "종료하시겠습니까?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "정말 설치 프로그램을 종료하시겠습니까?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -881,7 +1021,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "설치가 완료되었습니다"
 
@@ -902,139 +1042,6 @@ msgstr "설치 오류가 발생했습니다"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "이동식 매체:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "편집하기"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "/로 할당합니다"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "논리 파티션"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "확장 파티션"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "알 수 없음"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "파티션 편집하기"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "파티션 편집하기"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "장치:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "포맷하기:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "장착 지점:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "취소"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1193,49 +1200,49 @@ msgstr "%s에 파티션 만드는 중"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "%(partition)s를 %(format)s로 포맷하는 중입니다 ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "호스트 이름을 설정하는 중입니다"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "로케일을 설정하는 중입니다"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "호스트 이름을 설정하는 중입니다"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "키보드 선택 사항을 설정하는 중입니다"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "라이브 환경 설정을 제거하는 중입니다(패키지)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "부트로더를 설치하는 중입니다"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "부트로더를 설정하는 중입니다"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1243,15 +1250,15 @@ msgstr ""
 "주의: grub 부트로더가 올바르게 설정되지 않았습니다! 수동으로 설정하셔야 합니"
 "다."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "부트로더를 확인하는 중입니다"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-ko.po
+++ b/po/live-installer-ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2020-02-15 20:21+0000\n"
 "Last-Translator: Litty <Unknown>\n"
 "Language-Team: Korean <ko@li.org>\n"
@@ -24,20 +24,20 @@ msgid "Welcome to the 17g Installer."
 msgstr "17G 설치관리자에 오신 걸 환영합니다."
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 #, fuzzy
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr "이 프로그램은 몇 가지 질문을 하고 17G를 컴퓨터에 설치할 것입니다."
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr "키보드 모델:"
 
@@ -47,10 +47,12 @@ msgid "Type here to test your keyboard"
 msgstr "자판 배열이 어떻게 되나요?"
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -59,13 +61,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "시간대"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr "자동 설치"
 
@@ -74,12 +76,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr "디스크:"
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "파티션 편집하기"
@@ -90,42 +92,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr "운영체제 암호화"
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr "수동 파티션 작업"
 
@@ -142,7 +144,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "전문가 모드"
@@ -152,144 +154,150 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 #, fuzzy
 msgid "Minimal installation"
 msgstr "자동 설치"
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "새로 고침"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "포맷하기"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "파티션 편집하기"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr "이름:"
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr "컴퓨터 이름:"
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr "사용자 이름 선택:"
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr "다른 컴퓨터에서 보여지는 이름"
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr "암호 선택:"
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "자동으로 로그인합니다"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr "로그인할 때 암호 입력"
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr "홈 폴더 암호화"
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr "암호 확인:"
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 #, fuzzy
 msgid "Automated installation enabled!"
 msgstr "자동 설치"
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr "환영합니다"
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -320,6 +328,718 @@ msgstr ""
 #, fuzzy
 msgid "Welcome to 17g"
 msgstr "환영합니다"
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "OK"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "아니요"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "예"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "시간대"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, fuzzy, python-format
+msgid "Welcome to the %s Installer."
+msgstr "17G 설치관리자에 오신 걸 환영합니다."
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "언어"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+#, fuzzy
+msgid "What keyboard would you like to use?"
+msgstr "자판 배열이 어떻게 되나요?"
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "키보드 모델:"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "설치 형태"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "유형"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+#, fuzzy
+msgid "Disk"
+msgstr "디스크:"
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, fuzzy, python-format
+msgid "Welcome to %s"
+msgstr "환영합니다"
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "국가"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "배치"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "변형"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "파일 색인을 계산하는 중입니다 ..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "키보드 배치"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr "자판 배열이 어떻게 되나요?"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr "사용자 계정"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr "당신은 누구십니까?"
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr "설치 형태"
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "17G를 설치하고자 하는 장소가 어떻게 되나요?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "파티션 만들기"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "개요"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr "설치 중"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+#, fuzzy
+msgid "Automated Install"
+msgstr "자동 설치"
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "뒤로"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr "다음"
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "파티션 편집하기"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "장치"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "운영체제"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "장착 지점"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "포맷하기"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "크기"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "남은 공간"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "설치하기"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "비밀번호가 일치하지 않습니다."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "종료하시겠습니까?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "정말 설치 프로그램을 종료하시겠습니까?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "언어를 선택해주십시오"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "사용자 계정에 대한 비밀번호를 입력해주십시오."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "사용자의 실명을 입력해주십시오."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "비밀번호가 일치하지 않습니다."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+"EFI 파티션이 부팅 불가능으로 되어있습니다. 파티션 플래그를 편집해주십시오."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "루트(/) 파티션을 선택해주십시오."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+"EFI 파티션이 부팅 불가능으로 되어있습니다. 파티션 플래그를 편집해주십시오."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "EFI 파티션은 vfat 형식으로 포맷되어야 합니다."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "EFI 파티션은 vfat 형식으로 포맷되어야 합니다."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "EFI 파티션을 선택해주십시오."
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "사용자 이름을 입력해주십시오."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "지역화"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "언어: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "시간대: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "키보드 배치: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "사용자 설정"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "실명: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "사용자 이름: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "자동 로그인: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "활성화됨"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "비활성화됨"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "시스템 설정"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+#, fuzzy
+msgid "Install updates after installation"
+msgstr "자동 설치"
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "파일시스템 작업"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "%s에 부트로더를 설치합니다"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "부트로더를 설치하지 않습니다"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "이미-장착된 /target을 사용합니다."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "%(path)s를 %(filesystem)s로 포맷합니다"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "%(path)s를 %(mount)s로 장착합니다"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "%(path)s를 %(mount)s로 장착합니다"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "설치가 완료되었습니다"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"지금 설치가 완료되었습니다. 사용자의 컴퓨터를 다시 시작하셔서 새로운 시스템"
+"을 사용하시겠습니까?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "설치 오류가 발생했습니다"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "이동식 매체:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "편집하기"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "/로 할당합니다"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "논리 파티션"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "확장 파티션"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "알 수 없음"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "파티션 편집하기"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "파티션 편집하기"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "장치:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "포맷하기:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "장착 지점:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "취소"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
+msgstr ""
 
 #: live-installer/validate.py:12
 msgid "Please provide a username."
@@ -427,10 +1147,6 @@ msgstr "비밀번호가 일치하지 않습니다."
 msgid "Please provide a password for your user account."
 msgstr "사용자 계정에 대한 비밀번호를 입력해주십시오."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -457,7 +1173,7 @@ msgstr "시스템에 새로운 사용자를 추가하는 중입니다"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "/etc/fstab에 파일시스템 장착 정보를 쓰는 중입니다"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "%(partition)s를 %(mountpoint)s에 장착하는 중입니다"
@@ -477,49 +1193,49 @@ msgstr "%s에 파티션 만드는 중"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "%(partition)s를 %(format)s로 포맷하는 중입니다 ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "호스트 이름을 설정하는 중입니다"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "로케일을 설정하는 중입니다"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "호스트 이름을 설정하는 중입니다"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "키보드 선택 사항을 설정하는 중입니다"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "라이브 환경 설정을 제거하는 중입니다(패키지)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "부트로더를 설치하는 중입니다"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "부트로더를 설정하는 중입니다"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -527,647 +1243,17 @@ msgstr ""
 "주의: grub 부트로더가 올바르게 설정되지 않았습니다! 수동으로 설정하셔야 합니"
 "다."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "설치가 완료되었습니다"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "부트로더를 확인하는 중입니다"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "국가"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "언어"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "배치"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "변형"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "파일 색인을 계산하는 중입니다 ..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "키보드 배치"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr "자판 배열이 어떻게 되나요?"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr "사용자 계정"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr "당신은 누구십니까?"
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr "설치 형태"
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "17G를 설치하고자 하는 장소가 어떻게 되나요?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "파티션 만들기"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "개요"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr "설치 중"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-#, fuzzy
-msgid "Automated install"
-msgstr "자동 설치"
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "뒤로"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr "다음"
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, fuzzy, python-format
-msgid "Welcome to the %s Installer."
-msgstr "17G 설치관리자에 오신 걸 환영합니다."
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "파티션 편집하기"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "장치"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "유형"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "운영체제"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "장착 지점"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "포맷하기"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "크기"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "남은 공간"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "설치하기"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "비밀번호가 일치하지 않습니다."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "종료하시겠습니까?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "정말 설치 프로그램을 종료하시겠습니까?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "언어를 선택해주십시오"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "사용자 계정에 대한 비밀번호를 입력해주십시오."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "사용자의 실명을 입력해주십시오."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "비밀번호가 일치하지 않습니다."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-"EFI 파티션이 부팅 불가능으로 되어있습니다. 파티션 플래그를 편집해주십시오."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "루트(/) 파티션을 선택해주십시오."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-"EFI 파티션이 부팅 불가능으로 되어있습니다. 파티션 플래그를 편집해주십시오."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "EFI 파티션은 vfat 형식으로 포맷되어야 합니다."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "EFI 파티션은 vfat 형식으로 포맷되어야 합니다."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "EFI 파티션을 선택해주십시오."
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "사용자 이름을 입력해주십시오."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "지역화"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "언어: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "시간대: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "키보드 배치: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "사용자 설정"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "실명: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "사용자 이름: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "자동 로그인: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "활성화됨"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "비활성화됨"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "시스템 설정"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-#, fuzzy
-msgid "Install updates after installation"
-msgstr "자동 설치"
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "파일시스템 작업"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "%s에 부트로더를 설치합니다"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "부트로더를 설치하지 않습니다"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "이미-장착된 /target을 사용합니다."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "%(path)s를 %(filesystem)s로 포맷합니다"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "%(path)s를 %(mount)s로 장착합니다"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"지금 설치가 완료되었습니다. 사용자의 컴퓨터를 다시 시작하셔서 새로운 시스템"
-"을 사용하시겠습니까?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "설치 오류가 발생했습니다"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, fuzzy, python-format
-msgid "Welcome to %s"
-msgstr "환영합니다"
-
-#: live-installer/frontend/tui_interface.py:57
-#, fuzzy
-msgid "What keyboard would you like to use?"
-msgstr "자판 배열이 어떻게 되나요?"
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "키보드 모델:"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "설치 형태"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-#, fuzzy
-msgid "Disk"
-msgstr "디스크:"
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "시간대"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "이동식 매체:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "편집하기"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "/로 할당합니다"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "논리 파티션"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "확장 파티션"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "알 수 없음"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "파티션 편집하기"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "파티션 편집하기"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "장치:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "포맷하기:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "장착 지점:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "취소"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "OK"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "아니요"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "예"
 
 #~ msgid "Quit"
 #~ msgstr "끝내기"

--- a/po/live-installer-ku.po
+++ b/po/live-installer-ku.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2017-01-19 00:27+0000\n"
 "Last-Translator: Rokar ✌ <Unknown>\n"
 "Language-Team: Kurdish <ku@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Demê herêmê"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Beşan sererast bike"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Moda şareza"
@@ -149,142 +151,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Nûbike"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Şêwebike weke"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Beşan sererast bike"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Bixwe tê kevê"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -313,6 +321,704 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Demê herêmê"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Ziman"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Rengê klavyeyê"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Alavên Sazkirinê"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Cure"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Welat"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Rengê klavyeyê"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Tu ji xwe bawerî ji sazkerê derbikevî?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Tê beşkirin"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Kurte"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Beşan sererast bike"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Amûr"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Pergêla karanînê"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Xala girêdanê"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Şêwebike weke"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Mezinahî"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Herêma vale"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Derdikevî?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Tu ji xwe bawerî ji sazkerê derbikevî?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Sazkirin bidawî bû"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Beşan sererast bike"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -408,10 +1114,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -438,7 +1140,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr ""
@@ -458,49 +1160,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Navêpergêlê mîheng bike"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Herêm mîheng bike"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Navêpergêlê mîheng bike"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Bijartekên klavyê mîheng bike"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Bestekên herêm kirinê"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Bootloader ava dibe"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Bootloader tê çêkirin"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -508,632 +1210,16 @@ msgstr ""
 "ŞIYARBE:  grup bootloader bi şêweyek guncaw ne hat çêkirin! Divê tu wê bi "
 "dest çê bikî."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Sazkirin bidawî bû"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Bootloader dager bike"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Welat"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Ziman"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Rengê klavyeyê"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Tu ji xwe bawerî ji sazkerê derbikevî?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Tê beşkirin"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Kurte"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Beşan sererast bike"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Amûr"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Cure"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Pergêla karanînê"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Xala girêdanê"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Şêwebike weke"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Mezinahî"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Herêma vale"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Derdikevî?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Tu ji xwe bawerî ji sazkerê derbikevî?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Rengê klavyeyê"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Alavên Sazkirinê"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Demê herêmê"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Beşan sererast bike"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #, fuzzy

--- a/po/live-installer-ku.po
+++ b/po/live-installer-ku.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2017-01-19 00:27+0000\n"
 "Last-Translator: Rokar ✌ <Unknown>\n"
 "Language-Team: Kurdish <ku@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -189,9 +189,9 @@ msgid "Format"
 msgstr "Şêwebike weke"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -295,6 +295,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Şêwebike weke"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -325,8 +331,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -415,23 +421,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Welat"
-
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -449,9 +526,103 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Herêma vale"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Beşan sererast bike"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Welat"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -567,18 +738,6 @@ msgstr "Şêwebike weke"
 msgid "Size"
 msgstr "Mezinahî"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Herêma vale"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -611,25 +770,6 @@ msgstr "Derdikevî?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Tu ji xwe bawerî ji sazkerê derbikevî?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -863,7 +1003,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Sazkirin bidawî bû"
 
@@ -882,139 +1022,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Beşan sererast bike"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1160,49 +1167,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Navêpergêlê mîheng bike"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Herêm mîheng bike"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Navêpergêlê mîheng bike"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Bijartekên klavyê mîheng bike"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Bestekên herêm kirinê"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Bootloader ava dibe"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Bootloader tê çêkirin"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1210,15 +1217,15 @@ msgstr ""
 "ŞIYARBE:  grup bootloader bi şêweyek guncaw ne hat çêkirin! Divê tu wê bi "
 "dest çê bikî."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Bootloader dager bike"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-ky.po
+++ b/po/live-installer-ky.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2013-05-06 10:57+0000\n"
 "Last-Translator: SimpleLeon <Unknown>\n"
 "Language-Team: Kirghiz <ky@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,140 +149,146 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 msgid "Edit Partitions"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -309,6 +317,700 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+msgid "Keyboard Model"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Орнотуу аякталды"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Түрү"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Жабдыгы"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Операциялык система"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Монтирлөө чекити"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Өлчөмү"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Бош оруну"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Орнотуу аякталды"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -404,10 +1106,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -434,7 +1132,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr ""
@@ -454,675 +1152,63 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Түйүн аты орнотулууда"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Локаль орнотулууда"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Түйүн аты орнотулууда"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 msgid "Removing extra packages"
 msgstr ""
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Жүктөгүч орнотулууда"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Жүктөгүч ырасталууда"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Орнотуу аякталды"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Жүктөгүч текшерилүүдө"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Жабдыгы"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Түрү"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Операциялык система"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Монтирлөө чекити"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Өлчөмү"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Бош оруну"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-msgid "Keyboard Model"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Орнотуу аякталды"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Cleaning APT"

--- a/po/live-installer-ky.po
+++ b/po/live-installer-ky.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2013-05-06 10:57+0000\n"
 "Last-Translator: SimpleLeon <Unknown>\n"
 "Language-Team: Kirghiz <ky@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -291,6 +291,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -321,8 +326,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -409,23 +414,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -443,9 +519,102 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Бош оруну"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -560,18 +729,6 @@ msgstr ""
 msgid "Size"
 msgstr "Өлчөмү"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Бош оруну"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -603,25 +760,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -856,7 +994,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Орнотуу аякталды"
 
@@ -875,138 +1013,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1152,62 +1158,62 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Түйүн аты орнотулууда"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Локаль орнотулууда"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Түйүн аты орнотулууда"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 msgid "Removing extra packages"
 msgstr ""
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Жүктөгүч орнотулууда"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Жүктөгүч ырасталууда"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Жүктөгүч текшерилүүдө"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-la.po
+++ b/po/live-installer-la.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2011-08-24 12:44+0000\n"
 "Last-Translator: Alex Eponym <Unknown>\n"
 "Language-Team: Latin <la@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -291,6 +291,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -320,8 +325,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -407,23 +412,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -441,9 +517,102 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -558,18 +727,6 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -601,25 +758,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -854,7 +992,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr ""
 
@@ -873,138 +1011,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1150,60 +1156,60 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 msgid "Removing extra packages"
 msgstr ""
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""

--- a/po/live-installer-la.po
+++ b/po/live-installer-la.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2011-08-24 12:44+0000\n"
 "Last-Translator: Alex Eponym <Unknown>\n"
 "Language-Team: Latin <la@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,140 +149,146 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 msgid "Edit Partitions"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -308,6 +316,699 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+msgid "Keyboard Model"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:73
+msgid "Installation type?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -403,10 +1104,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -433,7 +1130,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr ""
@@ -453,671 +1150,60 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 msgid "Removing extra packages"
 msgstr ""
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr ""
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-msgid "Keyboard Model"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:73
-msgid "Installation type?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""

--- a/po/live-installer-lb.po
+++ b/po/live-installer-lb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2012-04-07 18:50+0000\n"
 "Last-Translator: Blackwolf <Unknown>\n"
 "Language-Team: Luxembourgish <lb@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,141 +149,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Systemastellungen"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -310,6 +318,702 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Tastatur layout: "
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Installatiounsfehler"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Typ"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Layout"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Gerät"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Betriebssystem"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Anhänkpunkt"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Gréisst"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Freit Speicherplatz"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Lokalisatioun"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Sprooch: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Zeitzone: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Tastatur layout: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Userastellung"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Richtegennumm: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Usernumm: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Systemastellungen"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Dateisystem operatiounen"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Bootloader net installeieren"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Mounten vun %(partition)s  op %(mountpoint)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Installatioun as ferdeg"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Installatiounsfehler"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Systemastellungen"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -405,10 +1109,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -435,7 +1135,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Mounten vun %(partition)s  op %(mountpoint)s"
@@ -455,49 +1155,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Astellung vum Hostnum"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Astellung vum locale"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Astellung vum Hostnum"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Astellung vun den Tastaturoptiounen"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Life-Konfiguratioun (packages) entfernen"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Bootloader get installeiert"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Konfigureieren vum Bootloader"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -505,630 +1205,16 @@ msgstr ""
 "OPGEPASST : Den Grub bootloader as net ordentlech konfigureiert gin! Dir "
 "musst en selwer astellen."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Installatioun as ferdeg"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Iwerpreifen vum Bootloader"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Layout"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Variant"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Gerät"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Typ"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Betriebssystem"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Anhänkpunkt"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Gréisst"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Freit Speicherplatz"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Lokalisatioun"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Sprooch: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Zeitzone: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Tastatur layout: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Userastellung"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Richtegennumm: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Usernumm: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Systemastellungen"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Dateisystem operatiounen"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Bootloader net installeieren"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Installatiounsfehler"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Tastatur layout: "
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Installatiounsfehler"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Systemastellungen"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-lb.po
+++ b/po/live-installer-lb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2012-04-07 18:50+0000\n"
 "Last-Translator: Blackwolf <Unknown>\n"
 "Language-Team: Luxembourgish <lb@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -292,6 +292,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -322,8 +327,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -411,23 +416,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Layout"
-
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Variant"
-
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -445,9 +521,103 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Freit Speicherplatz"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Systemastellungen"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Layout"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -562,18 +732,6 @@ msgstr ""
 msgid "Size"
 msgstr "Gréisst"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Freit Speicherplatz"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -605,25 +763,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -858,7 +997,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Installatioun as ferdeg"
 
@@ -877,139 +1016,6 @@ msgstr "Installatiounsfehler"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Systemastellungen"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1155,49 +1161,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Astellung vum Hostnum"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Astellung vum locale"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Astellung vum Hostnum"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Astellung vun den Tastaturoptiounen"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Life-Konfiguratioun (packages) entfernen"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Bootloader get installeiert"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Konfigureieren vum Bootloader"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1205,15 +1211,15 @@ msgstr ""
 "OPGEPASST : Den Grub bootloader as net ordentlech konfigureiert gin! Dir "
 "musst en selwer astellen."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Iwerpreifen vum Bootloader"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-lo.po
+++ b/po/live-installer-lo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2015-06-22 12:36+0000\n"
 "Last-Translator: Rockworld <sumoisrock@gmail.com>\n"
 "Language-Team: Lao <lo@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "ເຂດເວລາ"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,141 +149,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "ການແບ່ງ partition"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -310,6 +318,702 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "ເຂດເວລາ"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "ພາສາ"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "ແບບແປ້ນພິມ"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "ການຕິດຕັ້ງສຳເລັດແລ້ວ"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "ປະເພດ"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "ປະເທດ"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "ການຈັດແບ່ງ"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "ແບບແປ້ນພິມ"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "ການແບ່ງ partition"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "ສະຫຼຸບ"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "ອຸປະກອນ"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "ລະບົບປະຕິບັດການ"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "ຕຳແຫນ່ງ Mount"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "ຂະຫນາດ"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "ເນື້ອທີ່ວ່າງ"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "ກຳລັງ mount %(partition)s ເທິງ %(mountpoint)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "ການຕິດຕັ້ງສຳເລັດແລ້ວ"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -405,10 +1109,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -435,7 +1135,7 @@ msgstr "ກຳລັງເພີ່ມຜູ້ໃຊ້ໃໝ່ໄປຍັງ
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "ກຳລັງຂຽນຂໍ້ມູນການເມົາລະບົບໄຟລ໌ໄປທີ່ /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "ກຳລັງ mount %(partition)s ເທິງ %(mountpoint)s"
@@ -455,678 +1155,64 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "ກຳລັງຟໍແມດ %(partition)s ເປັນ %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "ກຳລັງຕັ້ງ ໂຮສຕ໌ເນມ"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "ກຳລັງຕັ້ງ ຄວາມເປັນທ້ອງຖິ່ນ"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "ກຳລັງຕັ້ງ ໂຮສຕ໌ເນມ"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "ກຳລັງຕັ້ງ ຕົວເລືອກແປ້ນພິມ"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "ກຳລັງລຶບ live configuration (packages)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "ກຳລັງຕິດຕັ້ງ ໂຕເອີ້ນລະບົບ"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "ກຳລັງກຳໜົດຄ່າ ໂຕເອີ້ນລະບົບ"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr "ເຕືອນ: ໂຕເອີ້ນລະບົບ grub ບໍ່ໄດ້ກຳໜົດ ຢ່າງຖືກຕ້ອງ! ເຈົ້າຕ້ອງກຳໜົດມັນ ດ້ວຍໂຕເອງ."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "ການຕິດຕັ້ງສຳເລັດແລ້ວ"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "ກຳລັງກວດສອບ ໂຕເອີ້ນລະບົບ"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "ປະເທດ"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "ພາສາ"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "ການຈັດແບ່ງ"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Variant"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "ແບບແປ້ນພິມ"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "ການແບ່ງ partition"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "ສະຫຼຸບ"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "ອຸປະກອນ"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "ປະເພດ"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "ລະບົບປະຕິບັດການ"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "ຕຳແຫນ່ງ Mount"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "ຂະຫນາດ"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "ເນື້ອທີ່ວ່າງ"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "ແບບແປ້ນພິມ"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "ການຕິດຕັ້ງສຳເລັດແລ້ວ"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "ເຂດເວລາ"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #, fuzzy

--- a/po/live-installer-lo.po
+++ b/po/live-installer-lo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2015-06-22 12:36+0000\n"
 "Last-Translator: Rockworld <sumoisrock@gmail.com>\n"
 "Language-Team: Lao <lo@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -292,6 +292,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -322,8 +327,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -412,23 +417,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "ປະເທດ"
-
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "ການຈັດແບ່ງ"
-
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Variant"
-
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -446,9 +522,102 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "ເນື້ອທີ່ວ່າງ"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "ປະເທດ"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "ການຈັດແບ່ງ"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -563,18 +732,6 @@ msgstr ""
 msgid "Size"
 msgstr "ຂະຫນາດ"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "ເນື້ອທີ່ວ່າງ"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -606,25 +763,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -859,7 +997,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "ການຕິດຕັ້ງສຳເລັດແລ້ວ"
 
@@ -878,138 +1016,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1155,63 +1161,63 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "ກຳລັງຟໍແມດ %(partition)s ເປັນ %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "ກຳລັງຕັ້ງ ໂຮສຕ໌ເນມ"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "ກຳລັງຕັ້ງ ຄວາມເປັນທ້ອງຖິ່ນ"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "ກຳລັງຕັ້ງ ໂຮສຕ໌ເນມ"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "ກຳລັງຕັ້ງ ຕົວເລືອກແປ້ນພິມ"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "ກຳລັງລຶບ live configuration (packages)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "ກຳລັງຕິດຕັ້ງ ໂຕເອີ້ນລະບົບ"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "ກຳລັງກຳໜົດຄ່າ ໂຕເອີ້ນລະບົບ"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr "ເຕືອນ: ໂຕເອີ້ນລະບົບ grub ບໍ່ໄດ້ກຳໜົດ ຢ່າງຖືກຕ້ອງ! ເຈົ້າຕ້ອງກຳໜົດມັນ ດ້ວຍໂຕເອງ."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "ກຳລັງກວດສອບ ໂຕເອີ້ນລະບົບ"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-lt.po
+++ b/po/live-installer-lt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2020-03-07 19:23+0000\n"
 "Last-Translator: Moo <hazap@hotmail.com>\n"
 "Language-Team: Lithuanian <lt@li.org>\n"
@@ -24,8 +24,8 @@ msgid "Welcome to the 17g Installer."
 msgstr "Sveiki atvykę į 17G diegimo programą."
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 #, fuzzy
 msgid ""
 "This program will ask you some questions and set up system on your computer."
@@ -34,12 +34,12 @@ msgstr ""
 "17G."
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr "Klaviatūros modelis:"
 
@@ -49,10 +49,12 @@ msgid "Type here to test your keyboard"
 msgstr "Rašykite čia norėdami išbandyti klaviatūros išdėstymą"
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -61,13 +63,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Laiko juosta"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr "Automatizuotas diegimas"
 
@@ -77,12 +79,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr "Ištrinti diską ir įdiegti jame 17G."
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr "Diskas:"
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Taisyti skaidinį"
@@ -93,42 +95,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr "Naudoti LVM (Loginių tomų tvarkymą)"
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr "Šifruoti operacinę sistemą"
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr "Slaptafrazė"
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr "Patvirtinkite slaptafrazę"
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr "Rankinis skaidymas"
 
@@ -145,7 +147,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Eksperto veiksena"
@@ -155,144 +157,150 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 #, fuzzy
 msgid "Minimal installation"
 msgstr "Automatizuotas diegimas"
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Atnaujinti"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Formatuoti kaip"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr "Įdiegti GRUB paleidimo meniu ties:"
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Tvarkyti skaidinius"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr "Jūsų vardas:"
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr "Jūsų kompiuterio vardas:"
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr "Pasirinkite naudotojo vardą:"
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr "Šis vardas naudojamas bendraujant su kitais kompiuteriais tinkle."
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr "Pasirinkite slaptažodį:"
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Automatiškai prisijungti (slaptažodis nereikalaujamas)"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr "Norint prisijungti, reikalauti slaptažodžio"
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr "Šifruoti mano namų aplanką"
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr "Patvirtinkite slaptažodį:"
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 #, fuzzy
 msgid "Automated installation enabled!"
 msgstr "Automatizuotas diegimas ties %s"
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr "Sveiki"
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -323,6 +331,739 @@ msgstr ""
 #, fuzzy
 msgid "Welcome to 17g"
 msgstr "Sveiki"
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "Gerai"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Ne"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Taip"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Laiko juosta"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, fuzzy, python-format
+msgid "Welcome to the %s Installer."
+msgstr "Sveiki atvykę į 17G diegimo programą."
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr "Kurią kalbą norėtumėte naudoti?"
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Kalba"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr "Kur esate?"
+
+#: live-installer/frontend/tui_interface.py:57
+#, fuzzy
+msgid "What keyboard would you like to use?"
+msgstr "Kurią kalbą norėtumėte naudoti?"
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Klaviatūros modelis:"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Diegimo tipas"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Tipas"
+
+#: live-installer/frontend/tui_interface.py:80
+#, fuzzy
+msgid "Select a disk?"
+msgstr "Pasirinkite diską."
+
+#: live-installer/frontend/tui_interface.py:84
+#, fuzzy
+msgid "Disk"
+msgstr "Diskas:"
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, fuzzy, python-format
+msgid "Welcome to %s"
+msgstr "Sveiki"
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Šalis"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Išdėstymas"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variantas"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Skaičiuojami failų indeksai ..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr "Diegimo programa"
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Klaviatūros išdėstymas"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr "Koks yra jūsų klaviatūros išdėstymas?"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr "Naudotojo paskyra"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr "Kas jūs esate?"
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr "Diegimo tipas"
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Kur norite įdiegti 17G?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Skaidymas"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Suvestinė"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr "Diegiama"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+#, fuzzy
+msgid "Automated Install"
+msgstr "Automatizuotas diegimas"
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Atgal"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr "Kitas"
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr "Rašykite čia norėdami išbandyti klaviatūros išdėstymą"
+
+#: live-installer/frontend/gtk_interface.py:546
+#, fuzzy
+msgid "Erase a disk and install system on it."
+msgstr "Ištrinti diską ir įdiegti jame 17G."
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Tvarkyti skaidinius"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Įrenginys"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Operacinė sistema"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Prijungimo vieta"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Formatuoti kaip"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Dydis"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Laisva vieta"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr "Įspėjimas"
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr "Tai ištrins visus, %s esančius, duomenis. Ar esate tikri?"
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Įdiegti"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr "Pateikite šifravimo slaptafrazę."
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Jūsų slaptažodžiai nesutampa."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Išeiti?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Ar tikrai norite baigti diegimo programos darbą?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Prašome pasirinkti kalbą"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Pateikite savo kompiuterio vardą."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Prašome pateikti savo vardą."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Jūsų slaptažodžiai nesutampa."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "EFI skaidinys yra per mažas. Jis privalo būti bent 35MB dydžio."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Prašome pasirinkti šaknies (/) skaidinį."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, fuzzy, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+"Reikalingas šaknies skaidinys, kuriame bus įdiegta Linux Mint.\n"
+"\n"
+" - Prijungimo taškas: /\n"
+" - Rekomenduojamas dydis: 30GB\n"
+" - Rekomenduojamas failų sistemos formatas: ext4\n"
+"\n"
+"Pastaba: Timeshift btrfs momentinių kopijų ypatybė reikalauja naudoti:\n"
+" - subvolume prijungimo tašką /@\n"
+" - btrfs kaip failų sistemos formatą\n"
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+"EFI skaidinys nėra nustatytas įkėlimui. Patikrinkite skaidinio vėliavėles."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "EFI skaidinys yra per mažas. Jis privalo būti bent 35MB dydžio."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "EFI skaidinys turi būti suformatuotas kaip vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Prašome pasirinkti EFI skaidinį."
+
+#: live-installer/frontend/gtk_interface.py:1301
+#, fuzzy
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+"Reikalingas EFI sistemos skaidinys, atitinkantis šiuos reikalavimus:\n"
+"\n"
+" - Prijungimo taškas: /boot/efi\n"
+" - Skaidinio vėliavėlės: Paleidžiamas\n"
+" - Dydis: bent 35MB (rekomenduojama 100MB ar daugiau)\n"
+" - Formatas: vfat arba fat32\n"
+"\n"
+"Siekiant užtikrinti suderinamumą su Windows, rekomenduojame jums pirmą disko "
+"skaidinį naudoti kaip EFI sistemos skaidinį.\n"
+" "
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr "Pasirinkite diską."
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Prašome pateikti naudotojo vardą."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Lokalizavimas"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Kalba: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Laiko juosta: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Klaviatūros išdėstymas: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Naudotojo nustatymai"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Tikrasis vardas: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Naudotojo vardas: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Automatinis prisijungimas: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "įjungta"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "išjungta"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Sistemos nustatymai"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr "Kompiuterio vardas: "
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+#, fuzzy
+msgid "Install updates after installation"
+msgstr "Automatizuotas diegimas"
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Failų sistemos veiksmai"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Įdiegti paleidyklę ties %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Nediegti paleidyklės"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Naudoti jau prijungtą /target."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr "Automatizuotas diegimas ties %s"
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Formatuoti %(path)s kaip %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Prijungti %(path)s kaip %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Prijungti %(path)s kaip %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr "LVM: "
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr "Disko šifravimas: "
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Diegimas baigtas"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Įdiegimas yra užbaigtas. Ar norite iš naujo paleisti kompiuterį ir pradėti "
+"naudotis savo naująja sistema?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Įdiegimo klaida"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Keičiamasis:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Taisyti"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Priskirti prie /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Loginis skaidinys"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Išplėstasis skaidinys"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Nežinoma"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Taisyti skaidinį"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Taisyti skaidinį"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Įrenginys:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Formatuoti kaip:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Prijungimo vieta:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Atsisakyti"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
+msgstr ""
 
 #: live-installer/validate.py:12
 msgid "Please provide a username."
@@ -432,10 +1173,6 @@ msgstr "Jūsų slaptažodžiai nesutampa."
 msgid "Please provide a password for your user account."
 msgstr "Prašome pateikti jūsų naudotojui skirtą slaptažodį."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -462,7 +1199,7 @@ msgstr "Į sistemą pridedamas naujas naudotojas"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Į /etc/fstab failą įrašoma failų sistemos prijungimo informacija"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Prijungiamas %(partition)s skaidinys prie %(mountpoint)s vietos"
@@ -482,49 +1219,49 @@ msgstr "Kuriami skaidiniai ties %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formatuojama %(partition)s kaip %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Nustatomas kompiuterio vardas"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Nustatoma lokalizacija"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Nustatomas kompiuterio vardas"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Nustatomi klaviatūros parametrai"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Šalinama bandomoji konfigūracija (paketai)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Įdiegiama paleidyklė"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Konfigūruojama paleidyklė"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -532,668 +1269,17 @@ msgstr ""
 "DĖMESIO! Grub paleidyklė nebuvo tinkamai sukonfigūruota! Būtina ją "
 "sukonfigūruoti rankiniu būdu."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Diegimas baigtas"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Tikrinama paleidyklė"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Šalis"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Kalba"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Išdėstymas"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Variantas"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Skaičiuojami failų indeksai ..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr "Diegimo programa"
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr "Kurią kalbą norėtumėte naudoti?"
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr "Kur esate?"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Klaviatūros išdėstymas"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr "Koks yra jūsų klaviatūros išdėstymas?"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr "Naudotojo paskyra"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr "Kas jūs esate?"
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr "Diegimo tipas"
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Kur norite įdiegti 17G?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Skaidymas"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Suvestinė"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr "Diegiama"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-#, fuzzy
-msgid "Automated install"
-msgstr "Automatizuotas diegimas"
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Atgal"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr "Kitas"
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, fuzzy, python-format
-msgid "Welcome to the %s Installer."
-msgstr "Sveiki atvykę į 17G diegimo programą."
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr "Rašykite čia norėdami išbandyti klaviatūros išdėstymą"
-
-#: live-installer/frontend/gtk_interface.py:542
-#, fuzzy
-msgid "Erase a disk and install system on it."
-msgstr "Ištrinti diską ir įdiegti jame 17G."
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Tvarkyti skaidinius"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Įrenginys"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Tipas"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Operacinė sistema"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Prijungimo vieta"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Formatuoti kaip"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Dydis"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Laisva vieta"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Įdiegti"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr "Pateikite šifravimo slaptafrazę."
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Jūsų slaptažodžiai nesutampa."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Išeiti?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Ar tikrai norite baigti diegimo programos darbą?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Prašome pasirinkti kalbą"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Pateikite savo kompiuterio vardą."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Prašome pateikti savo vardą."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Jūsų slaptažodžiai nesutampa."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "EFI skaidinys yra per mažas. Jis privalo būti bent 35MB dydžio."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Prašome pasirinkti šaknies (/) skaidinį."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, fuzzy, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-"Reikalingas šaknies skaidinys, kuriame bus įdiegta Linux Mint.\n"
-"\n"
-" - Prijungimo taškas: /\n"
-" - Rekomenduojamas dydis: 30GB\n"
-" - Rekomenduojamas failų sistemos formatas: ext4\n"
-"\n"
-"Pastaba: Timeshift btrfs momentinių kopijų ypatybė reikalauja naudoti:\n"
-" - subvolume prijungimo tašką /@\n"
-" - btrfs kaip failų sistemos formatą\n"
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-"EFI skaidinys nėra nustatytas įkėlimui. Patikrinkite skaidinio vėliavėles."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "EFI skaidinys yra per mažas. Jis privalo būti bent 35MB dydžio."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "EFI skaidinys turi būti suformatuotas kaip vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Prašome pasirinkti EFI skaidinį."
-
-#: live-installer/frontend/gtk_interface.py:1226
-#, fuzzy
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-"Reikalingas EFI sistemos skaidinys, atitinkantis šiuos reikalavimus:\n"
-"\n"
-" - Prijungimo taškas: /boot/efi\n"
-" - Skaidinio vėliavėlės: Paleidžiamas\n"
-" - Dydis: bent 35MB (rekomenduojama 100MB ar daugiau)\n"
-" - Formatas: vfat arba fat32\n"
-"\n"
-"Siekiant užtikrinti suderinamumą su Windows, rekomenduojame jums pirmą disko "
-"skaidinį naudoti kaip EFI sistemos skaidinį.\n"
-" "
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr "Pasirinkite diską."
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr "Įspėjimas"
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr "Tai ištrins visus, %s esančius, duomenis. Ar esate tikri?"
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Prašome pateikti naudotojo vardą."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Lokalizavimas"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Kalba: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Laiko juosta: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Klaviatūros išdėstymas: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Naudotojo nustatymai"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Tikrasis vardas: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Naudotojo vardas: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Automatinis prisijungimas: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "įjungta"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "išjungta"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Sistemos nustatymai"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr "Kompiuterio vardas: "
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-#, fuzzy
-msgid "Install updates after installation"
-msgstr "Automatizuotas diegimas"
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Failų sistemos veiksmai"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Įdiegti paleidyklę ties %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Nediegti paleidyklės"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Naudoti jau prijungtą /target."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr "Automatizuotas diegimas ties %s"
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Formatuoti %(path)s kaip %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Prijungti %(path)s kaip %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr "LVM: "
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr "Disko šifravimas: "
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Įdiegimas yra užbaigtas. Ar norite iš naujo paleisti kompiuterį ir pradėti "
-"naudotis savo naująja sistema?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Įdiegimo klaida"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, fuzzy, python-format
-msgid "Welcome to %s"
-msgstr "Sveiki"
-
-#: live-installer/frontend/tui_interface.py:57
-#, fuzzy
-msgid "What keyboard would you like to use?"
-msgstr "Kurią kalbą norėtumėte naudoti?"
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Klaviatūros modelis:"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Diegimo tipas"
-
-#: live-installer/frontend/tui_interface.py:80
-#, fuzzy
-msgid "Select a disk?"
-msgstr "Pasirinkite diską."
-
-#: live-installer/frontend/tui_interface.py:84
-#, fuzzy
-msgid "Disk"
-msgstr "Diskas:"
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Laiko juosta"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Keičiamasis:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Taisyti"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Priskirti prie /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Loginis skaidinys"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Išplėstasis skaidinys"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Nežinoma"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Taisyti skaidinį"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Taisyti skaidinį"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Įrenginys:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Formatuoti kaip:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Prijungimo vieta:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Atsisakyti"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "Gerai"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Ne"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Taip"
 
 #~ msgid "Quit"
 #~ msgstr "Išeiti"

--- a/po/live-installer-lt.po
+++ b/po/live-installer-lt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2020-03-07 19:23+0000\n"
 "Last-Translator: Moo <hazap@hotmail.com>\n"
 "Language-Team: Lithuanian <lt@li.org>\n"
@@ -95,7 +95,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -196,9 +196,9 @@ msgid "Format"
 msgstr "Formatuoti kaip"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -303,6 +303,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Formatuoti kaip"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -334,8 +340,8 @@ msgstr "Sveiki"
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "Gerai"
 
@@ -427,23 +433,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr "Sveiki"
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Šalis"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Išdėstymas"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Variantas"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Skaičiuojami failų indeksai ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Keičiamasis:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Taisyti"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Priskirti prie /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -461,10 +538,104 @@ msgstr "Skaičiuojami failų indeksai ..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr "Diegimo programa"
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Laisva vieta"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Loginis skaidinys"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Išplėstasis skaidinys"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Nežinoma"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Taisyti skaidinį"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Taisyti skaidinį"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Įrenginys:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Formatuoti kaip:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Prijungimo vieta:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Atsisakyti"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Šalis"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Išdėstymas"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variantas"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Skaičiuojami failų indeksai ..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -581,18 +752,6 @@ msgstr "Formatuoti kaip"
 msgid "Size"
 msgstr "Dydis"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Laisva vieta"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -625,25 +784,6 @@ msgstr "Išeiti?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Ar tikrai norite baigti diegimo programos darbą?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -905,7 +1045,7 @@ msgid "Disk Encryption: "
 msgstr "Disko šifravimas: "
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Diegimas baigtas"
 
@@ -926,139 +1066,6 @@ msgstr "Įdiegimo klaida"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Keičiamasis:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Taisyti"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Priskirti prie /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Loginis skaidinys"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Išplėstasis skaidinys"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Nežinoma"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Taisyti skaidinį"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Taisyti skaidinį"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Įrenginys:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Formatuoti kaip:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Prijungimo vieta:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Atsisakyti"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1219,49 +1226,49 @@ msgstr "Kuriami skaidiniai ties %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formatuojama %(partition)s kaip %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Nustatomas kompiuterio vardas"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Nustatoma lokalizacija"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Nustatomas kompiuterio vardas"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Nustatomi klaviatūros parametrai"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Šalinama bandomoji konfigūracija (paketai)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Įdiegiama paleidyklė"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Konfigūruojama paleidyklė"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1269,15 +1276,15 @@ msgstr ""
 "DĖMESIO! Grub paleidyklė nebuvo tinkamai sukonfigūruota! Būtina ją "
 "sukonfigūruoti rankiniu būdu."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Tikrinama paleidyklė"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-lv.po
+++ b/po/live-installer-lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2014-06-22 18:10+0000\n"
 "Last-Translator: Juris Daikteris <juris.daikteris@gmail.com>\n"
 "Language-Team: Latvian <lv@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Laika josla"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,141 +149,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Sistēmas iestatījumi"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -310,6 +318,703 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Laika josla"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Valoda"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Tastatūras izkārtojums"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Uzstādīšanas kļūda"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Veids"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Izkārtojums"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variants"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Tastatūras izkārtojums"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Nodalīšana"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Kopsavilkums"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Ierīce"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Operētājsistēma"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Montēšanas punkts"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Izmērs"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Brīva vieta"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Lokalizācija"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Valoda: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Laika josla "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Tastatūras izkārtojums "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Lietotāja uzstādījumi"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Īstais vārds "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Lietotājvārds: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Sistēmas iestatījumi"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Failu sistēmas darbības"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Neuzstādīt sāknēšanaās failu"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Piemontē %(partition)s pie %(mountpoint)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Instalācija pabeigta"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Uzstādīšanas kļūda"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Sistēmas iestatījumi"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -405,10 +1110,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -435,7 +1136,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Piemontē %(partition)s pie %(mountpoint)s"
@@ -455,49 +1156,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Iestata saimniekdatora nosaukumu"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Iestata atrašanās vietu"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Iestata saimniekdatora nosaukumu"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Iestata klaviatūras opcijas"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Noņem Live konfigurāciju (pakotnes)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Uzstāda sāknēšanās failu"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Konfigurē bootloaderi"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -505,631 +1206,16 @@ msgstr ""
 "Brīdinājums: Grub bootloaderis nav konfigurēts pareizi! Jums tas ir "
 "janokonfigurē manuāli."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Instalācija pabeigta"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Pārbauda sistēmas palaidēju"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Valoda"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Izkārtojums"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Variants"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Tastatūras izkārtojums"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Nodalīšana"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Kopsavilkums"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Ierīce"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Veids"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Operētājsistēma"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Montēšanas punkts"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Izmērs"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Brīva vieta"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Lokalizācija"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Valoda: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Laika josla "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Tastatūras izkārtojums "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Lietotāja uzstādījumi"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Īstais vārds "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Lietotājvārds: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Sistēmas iestatījumi"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Failu sistēmas darbības"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Neuzstādīt sāknēšanaās failu"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Uzstādīšanas kļūda"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Tastatūras izkārtojums"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Uzstādīšanas kļūda"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Laika josla"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Sistēmas iestatījumi"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-lv.po
+++ b/po/live-installer-lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2014-06-22 18:10+0000\n"
 "Last-Translator: Juris Daikteris <juris.daikteris@gmail.com>\n"
 "Language-Team: Latvian <lv@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -292,6 +292,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -322,8 +327,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -412,23 +417,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Izkārtojums"
-
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Variants"
-
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -446,9 +522,103 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Brīva vieta"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Sistēmas iestatījumi"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Izkārtojums"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variants"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -563,18 +733,6 @@ msgstr ""
 msgid "Size"
 msgstr "Izmērs"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Brīva vieta"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -606,25 +764,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -859,7 +998,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Instalācija pabeigta"
 
@@ -878,139 +1017,6 @@ msgstr "Uzstādīšanas kļūda"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Sistēmas iestatījumi"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1156,49 +1162,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Iestata saimniekdatora nosaukumu"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Iestata atrašanās vietu"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Iestata saimniekdatora nosaukumu"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Iestata klaviatūras opcijas"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Noņem Live konfigurāciju (pakotnes)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Uzstāda sāknēšanās failu"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Konfigurē bootloaderi"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1206,15 +1212,15 @@ msgstr ""
 "Brīdinājums: Grub bootloaderis nav konfigurēts pareizi! Jums tas ir "
 "janokonfigurē manuāli."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Pārbauda sistēmas palaidēju"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-mai.po
+++ b/po/live-installer-mai.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2019-07-27 07:17+0000\n"
 "Last-Translator: Abhinav Jha <Unknown>\n"
 "Language-Team: Maithili <mai@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "समय क्षेत्र"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "विभाजन संपादित करू"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "विशेषज्ञ मोड"
@@ -149,141 +151,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "ताजा करू"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "विभाजन संपादित करू"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "स्वत: लॉगिन"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -312,6 +320,703 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "बेस"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "समय क्षेत्र"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "भाषा"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "कुंजीपटल अभिन्यास"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "इंस्टॉल समाप्त"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "देश"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "खाका"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "प्रकार"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "फाइलक अनुक्रमण के गणना कयल जा रहल अछि"
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "कुंजीपटल अभिन्यास"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "डिस्क विभाजन भ' रहल अछि"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "सार"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "पाछु जाउ"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "विभाजन संपादित करू"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "%(partition)s के %(mountpoint)s पर माउंट कयल जा रहल अछि"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "इंस्टॉल समाप्त"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "विभाजन संपादित करू"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "रद्द करू"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -407,10 +1112,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -437,7 +1138,7 @@ msgstr "नया उपयोक्ताके सिस्टममे जो
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "फाइल सिस्टम माउंट के जानकारी /etc/fstab पर लिखल जा रहल अछि"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "%(partition)s के %(mountpoint)s पर माउंट कयल जा रहल अछि"
@@ -457,49 +1158,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "%(partition)s के फॉर्मेट कयल जा रहल अछि %(format)s रूप मे ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "होस्टनेम सेट भ रहल अछि"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "स्थानिकी सेट भ' रहल अछि"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "होस्टनेम सेट भ रहल अछि"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "कुंजीपटल विकल्प सेट कयल जा रहल अछि"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "लाइव पैकेज हटाओल जा रहल अछि"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "बूट लोडर इंस्टॉल कयल जा रहल अछि"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "बूट लोडर विन्यस्त कयल जा रहल अछि"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -507,631 +1208,16 @@ msgstr ""
 "चेतावनी: grub बूट लोडर ठीक स' विन्यस्त नहि भेल अछि। आहाँके एकरा मैनुअल रूप स' अपने करय "
 "पड़त।"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "इंस्टॉल समाप्त"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "बूट लोडर जाँच कयल जा रहल अछि"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "देश"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "भाषा"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "खाका"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "प्रकार"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "फाइलक अनुक्रमण के गणना कयल जा रहल अछि"
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "कुंजीपटल अभिन्यास"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "डिस्क विभाजन भ' रहल अछि"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "सार"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "पाछु जाउ"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "विभाजन संपादित करू"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "कुंजीपटल अभिन्यास"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "इंस्टॉल समाप्त"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "समय क्षेत्र"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "विभाजन संपादित करू"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "रद्द करू"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "बेस"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Quit"

--- a/po/live-installer-mai.po
+++ b/po/live-installer-mai.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2019-07-27 07:17+0000\n"
 "Last-Translator: Abhinav Jha <Unknown>\n"
 "Language-Team: Maithili <mai@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -188,9 +188,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -294,6 +294,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -324,8 +329,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "बेस"
 
@@ -414,23 +419,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "देश"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "खाका"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "प्रकार"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "फाइलक अनुक्रमण के गणना कयल जा रहल अछि"
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -448,10 +524,104 @@ msgstr "फाइलक अनुक्रमण के गणना कयल �
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "विभाजन संपादित करू"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "रद्द करू"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "देश"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "खाका"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "प्रकार"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "फाइलक अनुक्रमण के गणना कयल जा रहल अछि"
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -565,18 +735,6 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -608,25 +766,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -861,7 +1000,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "इंस्टॉल समाप्त"
 
@@ -880,139 +1019,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "विभाजन संपादित करू"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "रद्द करू"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1158,49 +1164,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "%(partition)s के फॉर्मेट कयल जा रहल अछि %(format)s रूप मे ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "होस्टनेम सेट भ रहल अछि"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "स्थानिकी सेट भ' रहल अछि"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "होस्टनेम सेट भ रहल अछि"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "कुंजीपटल विकल्प सेट कयल जा रहल अछि"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "लाइव पैकेज हटाओल जा रहल अछि"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "बूट लोडर इंस्टॉल कयल जा रहल अछि"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "बूट लोडर विन्यस्त कयल जा रहल अछि"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1208,15 +1214,15 @@ msgstr ""
 "चेतावनी: grub बूट लोडर ठीक स' विन्यस्त नहि भेल अछि। आहाँके एकरा मैनुअल रूप स' अपने करय "
 "पड़त।"
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "बूट लोडर जाँच कयल जा रहल अछि"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-mhr.po
+++ b/po/live-installer-mhr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2011-10-08 16:06+0000\n"
 "Last-Translator: Max Romanov <Unknown>\n"
 "Language-Team: Meadow Mari <mhr@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,140 +149,146 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 msgid "Edit Partitions"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -308,6 +316,699 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+msgid "Keyboard Model"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:73
+msgid "Installation type?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -403,10 +1104,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -433,7 +1130,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr ""
@@ -453,671 +1150,60 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 msgid "Removing extra packages"
 msgstr ""
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr ""
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-msgid "Keyboard Model"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:73
-msgid "Installation type?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""

--- a/po/live-installer-mhr.po
+++ b/po/live-installer-mhr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2011-10-08 16:06+0000\n"
 "Last-Translator: Max Romanov <Unknown>\n"
 "Language-Team: Meadow Mari <mhr@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -291,6 +291,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -320,8 +325,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -407,23 +412,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -441,9 +517,102 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -558,18 +727,6 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -601,25 +758,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -854,7 +992,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr ""
 
@@ -873,138 +1011,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1150,60 +1156,60 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 msgid "Removing extra packages"
 msgstr ""
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""

--- a/po/live-installer-mk.po
+++ b/po/live-installer-mk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2010-10-09 21:38+0000\n"
 "Last-Translator: Dejan Noveski <Unknown>\n"
 "Language-Team: Macedonian <mk@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,140 +149,146 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 msgid "Edit Partitions"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -308,6 +316,699 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+msgid "Keyboard Model"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:73
+msgid "Installation type?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -403,10 +1104,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -433,7 +1130,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr ""
@@ -453,671 +1150,60 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 msgid "Removing extra packages"
 msgstr ""
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr ""
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-msgid "Keyboard Model"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:73
-msgid "Installation type?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""

--- a/po/live-installer-mk.po
+++ b/po/live-installer-mk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2010-10-09 21:38+0000\n"
 "Last-Translator: Dejan Noveski <Unknown>\n"
 "Language-Team: Macedonian <mk@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -291,6 +291,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -320,8 +325,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -407,23 +412,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -441,9 +517,102 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -558,18 +727,6 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -601,25 +758,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -854,7 +992,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr ""
 
@@ -873,138 +1011,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1150,60 +1156,60 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 msgid "Removing extra packages"
 msgstr ""
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""

--- a/po/live-installer-ml.po
+++ b/po/live-installer-ml.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2015-11-19 10:58+0000\n"
 "Last-Translator: Jude <judeosby@gmail.com>\n"
 "Language-Team: Malayalam <ml@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,141 +149,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "സിസ്റ്റം സജ്ജീകരണങ്ങൾ"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -310,6 +318,702 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "കീബോർഡ് രൂപരേഖ: "
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "ഇൻസ്റ്റലേഷൻ പിഴവ്"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "തരം"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "രൂപരേഖ"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "രൂപാന്തരം"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "ഉപകരണം"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "ഓപ്പറേറ്റിങ് സിസ്റ്റം"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "മൗണ്ട് പോയിന്റ്"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "വലിപ്പം"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "ശൂന്യമായ ഇട"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "പ്രാദേശീകരണം"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "ഭാഷ: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "സമയമേഖല: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "കീബോർഡ് രൂപരേഖ: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "ഉപയോക്തൃ സജ്ജീകരണങ്ങൾ"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "യഥാർത്ഥ പേര്: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "ഉപയോക്തൃനാമം: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "സിസ്റ്റം സജ്ജീകരണങ്ങൾ"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "ഫയൽസിസ്റ്റം പ്രവർത്തനങ്ങൾ"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "ബൂട്ട്ലോഡർ ഇൻസ്റ്റോൾ ചെയ്യേണ്ടതില്ല"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "%(partition)s  %(mountpoint)s-ൽ മൗണ്ട് ചെയ്യുന്നു"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "ഇൻസ്റ്റലേഷൻ പുർണ്ണമായി"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "ഇൻസ്റ്റലേഷൻ പിഴവ്"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "സിസ്റ്റം സജ്ജീകരണങ്ങൾ"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -405,10 +1109,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -435,7 +1135,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "%(partition)s  %(mountpoint)s-ൽ മൗണ്ട് ചെയ്യുന്നു"
@@ -455,49 +1155,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "ഹോസ്റ്റ്പേര് സജ്ജീകരിക്കുന്നു"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "പ്രാദേശികവിവരങ്ങൾ സജ്ജീകരിക്കുന്നു"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "ഹോസ്റ്റ്പേര് സജ്ജീകരിക്കുന്നു"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "കീബോഡ് ഐച്ഛികങ്ങൾ സജ്ജീകരിക്കുന്നു"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "തത്സമയ ക്രമീകരണങ്ങൾ ഒഴിവാക്കുന്നു (പാക്കേജുകൾ)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "ബൂട്ട്ലോഡര്‍ ഇന്‍സ്റ്റോള്‍ ചെയ്യുന്നു"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "ബൂട്ട്ലോഡർ ക്രമീകരിക്കുന്നു"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -505,630 +1205,16 @@ msgstr ""
 "മുന്നറിയിപ്പ്: ഗ്രബ് ബൂട്ട്ലോഡർ ശരിയായ വിധത്തിലല്ല ക്രമീകരിച്ചിരിക്കുന്നത്! താങ്കളത് സ്വയം "
 "ക്രമീകരിക്കേണ്ടതുണ്ട്."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "ഇൻസ്റ്റലേഷൻ പുർണ്ണമായി"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "ബൂട്ട്ലോഡർ പരിശോധിക്കുന്നു"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "രൂപരേഖ"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "രൂപാന്തരം"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "ഉപകരണം"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "തരം"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "ഓപ്പറേറ്റിങ് സിസ്റ്റം"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "മൗണ്ട് പോയിന്റ്"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "വലിപ്പം"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "ശൂന്യമായ ഇട"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "പ്രാദേശീകരണം"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "ഭാഷ: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "സമയമേഖല: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "കീബോർഡ് രൂപരേഖ: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "ഉപയോക്തൃ സജ്ജീകരണങ്ങൾ"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "യഥാർത്ഥ പേര്: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "ഉപയോക്തൃനാമം: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "സിസ്റ്റം സജ്ജീകരണങ്ങൾ"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "ഫയൽസിസ്റ്റം പ്രവർത്തനങ്ങൾ"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "ബൂട്ട്ലോഡർ ഇൻസ്റ്റോൾ ചെയ്യേണ്ടതില്ല"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "ഇൻസ്റ്റലേഷൻ പിഴവ്"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "കീബോർഡ് രൂപരേഖ: "
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "ഇൻസ്റ്റലേഷൻ പിഴവ്"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "സിസ്റ്റം സജ്ജീകരണങ്ങൾ"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-ml.po
+++ b/po/live-installer-ml.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2015-11-19 10:58+0000\n"
 "Last-Translator: Jude <judeosby@gmail.com>\n"
 "Language-Team: Malayalam <ml@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -292,6 +292,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -322,8 +327,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -411,23 +416,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "രൂപരേഖ"
-
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "രൂപാന്തരം"
-
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -445,9 +521,103 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "ശൂന്യമായ ഇട"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "സിസ്റ്റം സജ്ജീകരണങ്ങൾ"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "രൂപരേഖ"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "രൂപാന്തരം"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -562,18 +732,6 @@ msgstr ""
 msgid "Size"
 msgstr "വലിപ്പം"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "ശൂന്യമായ ഇട"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -605,25 +763,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -858,7 +997,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "ഇൻസ്റ്റലേഷൻ പുർണ്ണമായി"
 
@@ -877,139 +1016,6 @@ msgstr "ഇൻസ്റ്റലേഷൻ പിഴവ്"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "സിസ്റ്റം സജ്ജീകരണങ്ങൾ"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1155,49 +1161,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "ഹോസ്റ്റ്പേര് സജ്ജീകരിക്കുന്നു"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "പ്രാദേശികവിവരങ്ങൾ സജ്ജീകരിക്കുന്നു"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "ഹോസ്റ്റ്പേര് സജ്ജീകരിക്കുന്നു"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "കീബോഡ് ഐച്ഛികങ്ങൾ സജ്ജീകരിക്കുന്നു"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "തത്സമയ ക്രമീകരണങ്ങൾ ഒഴിവാക്കുന്നു (പാക്കേജുകൾ)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "ബൂട്ട്ലോഡര്‍ ഇന്‍സ്റ്റോള്‍ ചെയ്യുന്നു"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "ബൂട്ട്ലോഡർ ക്രമീകരിക്കുന്നു"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1205,15 +1211,15 @@ msgstr ""
 "മുന്നറിയിപ്പ്: ഗ്രബ് ബൂട്ട്ലോഡർ ശരിയായ വിധത്തിലല്ല ക്രമീകരിച്ചിരിക്കുന്നത്! താങ്കളത് സ്വയം "
 "ക്രമീകരിക്കേണ്ടതുണ്ട്."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "ബൂട്ട്ലോഡർ പരിശോധിക്കുന്നു"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-mr.po
+++ b/po/live-installer-mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2016-01-03 14:39+0000\n"
 "Last-Translator: Vikram Kulkarni <kul.vikram@gmail.com>\n"
 "Language-Team: Marathi <mr@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "वेळक्षेत्र"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "विभाजने संपादित करा"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "विशेषज्ञ पद्धत"
@@ -149,141 +151,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "रीफ्रेश करा"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "विभाजने संपादित करा"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "स्वयंचलितरित्या प्रवेश करा"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -312,6 +320,703 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "वेळक्षेत्र"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "भाषा"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "कळफलक मांडणी"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "प्रस्थापानेतील अडचणी/त्रुटी"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "प्रकार"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "देश"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "आराखडा"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "एक प्रकार"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "फाइल निर्देशांक मोजत आहे ..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "कळफलक मांडणी"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "विभाजन"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "सारांश"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "विभाजने संपादित करा"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "उपकरण"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "ऑपरेटिंग सिस्टीम"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "माउन्ट पॉइन्ट"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "आकार"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "मुक्त जागा"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "स्थानिकीकरण"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "भाषा: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "कालविभाग: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "कळफलकाचा आराखडा "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "वापरकर्त्याचे सेटिंग्ज"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "खरे नाव: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "युजरनेम: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "सिस्टम सेटिंग्ज"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "फाइल प्रणाली कार्य"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "बूटलोडर प्रस्थापित करू नका"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "%(partition)s हे विभाजन %(mountpoint)s  इथे माउंट (mount) करत आहे"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "प्रस्थापन पूर्ण झाली"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "प्रस्थापानेतील अडचणी/त्रुटी"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "विभाजने संपादित करा"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -407,10 +1112,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -437,7 +1138,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "%(partition)s हे विभाजन %(mountpoint)s  इथे माउंट (mount) करत आहे"
@@ -457,49 +1158,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "होस्टनेम सेट करत आहे"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "स्थानिक माहिती बसवत आहे"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "होस्टनेम सेट करत आहे"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "कळफलकाचे पर्याय सेट करत आहे"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "लाइव्ह योजनेची माहिती काढत आहे ()"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "बूटलोडर प्रस्थापित करत आहे"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "बूटलोडर अनुकुलीत करत आहे"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -507,631 +1208,16 @@ msgstr ""
 "सूचना: GRUB (संगणक सुरु करण्यास लागणारी प्रणाली) व्यवस्थित मांडली गेले नाही. तुम्हाला "
 "स्वताहून ती मांडायला (configure) लागेल."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "प्रस्थापन पूर्ण झाली"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "बूटलोडरची तपासणी करत आहे"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "देश"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "भाषा"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "आराखडा"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "एक प्रकार"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "फाइल निर्देशांक मोजत आहे ..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "कळफलक मांडणी"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "विभाजन"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "सारांश"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "विभाजने संपादित करा"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "उपकरण"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "प्रकार"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "ऑपरेटिंग सिस्टीम"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "माउन्ट पॉइन्ट"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "आकार"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "मुक्त जागा"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "स्थानिकीकरण"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "भाषा: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "कालविभाग: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "कळफलकाचा आराखडा "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "वापरकर्त्याचे सेटिंग्ज"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "खरे नाव: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "युजरनेम: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "सिस्टम सेटिंग्ज"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "फाइल प्रणाली कार्य"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "बूटलोडर प्रस्थापित करू नका"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "प्रस्थापानेतील अडचणी/त्रुटी"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "कळफलक मांडणी"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "प्रस्थापानेतील अडचणी/त्रुटी"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "वेळक्षेत्र"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "विभाजने संपादित करा"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-mr.po
+++ b/po/live-installer-mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2016-01-03 14:39+0000\n"
 "Last-Translator: Vikram Kulkarni <kul.vikram@gmail.com>\n"
 "Language-Team: Marathi <mr@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -188,9 +188,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -294,6 +294,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -324,8 +329,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -414,23 +419,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "देश"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "आराखडा"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "एक प्रकार"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "फाइल निर्देशांक मोजत आहे ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -448,10 +524,104 @@ msgstr "फाइल निर्देशांक मोजत आहे ..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "मुक्त जागा"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "विभाजने संपादित करा"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "देश"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "आराखडा"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "एक प्रकार"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "फाइल निर्देशांक मोजत आहे ..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -565,18 +735,6 @@ msgstr ""
 msgid "Size"
 msgstr "आकार"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "मुक्त जागा"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -608,25 +766,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -861,7 +1000,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "प्रस्थापन पूर्ण झाली"
 
@@ -880,139 +1019,6 @@ msgstr "प्रस्थापानेतील अडचणी/त्रु�
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "विभाजने संपादित करा"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1158,49 +1164,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "होस्टनेम सेट करत आहे"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "स्थानिक माहिती बसवत आहे"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "होस्टनेम सेट करत आहे"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "कळफलकाचे पर्याय सेट करत आहे"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "लाइव्ह योजनेची माहिती काढत आहे ()"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "बूटलोडर प्रस्थापित करत आहे"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "बूटलोडर अनुकुलीत करत आहे"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1208,15 +1214,15 @@ msgstr ""
 "सूचना: GRUB (संगणक सुरु करण्यास लागणारी प्रणाली) व्यवस्थित मांडली गेले नाही. तुम्हाला "
 "स्वताहून ती मांडायला (configure) लागेल."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "बूटलोडरची तपासणी करत आहे"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-ms.po
+++ b/po/live-installer-ms.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2019-09-30 03:00+0000\n"
 "Last-Translator: abuyop <Unknown>\n"
 "Language-Team: Malay <ms@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -189,9 +189,9 @@ msgid "Format"
 msgstr "Format sebagai"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -295,6 +295,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Format sebagai"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -325,8 +331,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "OK"
 
@@ -415,23 +421,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Negara"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Bentangan"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Varian"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Mengira index-index fail"
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Boleh tanggal:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Sunting"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Menetapkan ke /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -449,10 +526,104 @@ msgstr "Mengira index-index fail"
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Membebaskan ruang"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Partisi logikal"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Partisi lanjutan"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Tidak diketahui"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Ubahsuai partisi"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Ubahsuai partisi"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Peranti:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Format sebagai:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Tempat mount:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Batal"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Negara"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Bentangan"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Varian"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Mengira index-index fail"
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -567,18 +738,6 @@ msgstr "Format sebagai"
 msgid "Size"
 msgstr "Saiz"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Membebaskan ruang"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -611,25 +770,6 @@ msgstr "Keluar?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Adakah anda pasti anda mahu keluar dari pemasangan?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -869,7 +1009,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Pemasangan selesai"
 
@@ -890,139 +1030,6 @@ msgstr "Ralat pemasangan"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Boleh tanggal:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Sunting"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Menetapkan ke /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Partisi logikal"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Partisi lanjutan"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Tidak diketahui"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Ubahsuai partisi"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Ubahsuai partisi"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Peranti:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Format sebagai:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Tempat mount:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Batal"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1181,49 +1188,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Memformat %(partition)s sebagai %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Tetapan nama hos"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Menetapkan penempatan"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Tetapan nama hos"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Menetapkan pilihan papan kekunci"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Membuang konfigurasi langsung (pakej)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Memasang pemuat but"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Menkonfigur pemuat but"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1231,15 +1238,15 @@ msgstr ""
 "AMARAN: Pemuat but Grub tidak dikonfigur dengan betul! Anda perlu konfigur "
 "ia secara manual."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Memeriksa pemuat but"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-ms.po
+++ b/po/live-installer-ms.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2019-09-30 03:00+0000\n"
 "Last-Translator: abuyop <Unknown>\n"
 "Language-Team: Malay <ms@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Zon waktu"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Ubahsuai partisi"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Mod pakar"
@@ -149,142 +151,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Refresh"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Format sebagai"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Ubah partisi-partisi"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Log masuk secara automatik"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -313,6 +321,712 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "OK"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Tidak"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Ya"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Zon waktu"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Bahasa"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Bentangan papan kekunci"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Pemasangan dihentikan seketika"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Jenis"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Negara"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Bentangan"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Varian"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Mengira index-index fail"
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Bentangan papan kekunci"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Adakah anda pasti anda mahu keluar dari pemasangan?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Menyekatkan"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Ringkasan"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Undur"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Ubah partisi-partisi"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Peranti"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Sistem operasi"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Titik lekap"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Format sebagai"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Saiz"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Membebaskan ruang"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Pasang"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Kata laluan anda tidak padan."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Keluar?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Adakah anda pasti anda mahu keluar dari pemasangan?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Sila pilih bahasa"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Sila berikan kata laluan untuk akaun pengguna anda"
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Sila berikan nama penuh anda"
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Kata laluan anda tidak padan."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "Sekatan EFI tidak boleh dibut. Sila sunting bendera sekatan."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Sila pilih partisi root (/)."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "Sekatan EFI tidak boleh dibut. Sila sunting bendera sekatan."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "Sekatan EFI mesti diformat sebagai vfat."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "Sekatan EFI mesti diformat sebagai vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Sila pilih partisi EFI."
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Sila berikan nama pengguna"
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Penyetempatan"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Bahasa: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Zon masa: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Bentangan papan kekunci: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Tetapan pengguna"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Nama sebenar: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Nama pengguna: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Log masuk automatik: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "dibenarkan"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "dilumpuhkan"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Tetapan sistem"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Operasi sistem fail"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Pasang bootloader ke %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Jangan pasang pemuat but"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Guna /target yang telah mount."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Format %(path)s sebagai %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Mount %(path)s sebagai %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Mount %(path)s sebagai %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Pemasangan selesai"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Pemasangan sudah siap. Adakah anda mahu restart komputer anda untuk "
+"menggunakan sistem baru?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Ralat pemasangan"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Boleh tanggal:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Sunting"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Menetapkan ke /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Partisi logikal"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Partisi lanjutan"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Tidak diketahui"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Ubahsuai partisi"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Ubahsuai partisi"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Peranti:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Format sebagai:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Tempat mount:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Batal"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -421,10 +1135,6 @@ msgstr "Kata laluan anda tidak padan."
 msgid "Please provide a password for your user account."
 msgstr "Sila berikan kata laluan untuk akaun pengguna anda"
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -451,7 +1161,7 @@ msgstr "Memasukkan pengguna baru ke dalam sistem"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Menulis informasi mount sistem fail  ke /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Melekap %(partition)s pada %(mountpoint)s"
@@ -471,49 +1181,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Memformat %(partition)s sebagai %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Tetapan nama hos"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Menetapkan penempatan"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Tetapan nama hos"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Menetapkan pilihan papan kekunci"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Membuang konfigurasi langsung (pakej)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Memasang pemuat but"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Menkonfigur pemuat but"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -521,641 +1231,17 @@ msgstr ""
 "AMARAN: Pemuat but Grub tidak dikonfigur dengan betul! Anda perlu konfigur "
 "ia secara manual."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Pemasangan selesai"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Memeriksa pemuat but"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Negara"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Bahasa"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Bentangan"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Varian"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Mengira index-index fail"
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Bentangan papan kekunci"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Adakah anda pasti anda mahu keluar dari pemasangan?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Menyekatkan"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Ringkasan"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Undur"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Ubah partisi-partisi"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Peranti"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Jenis"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Sistem operasi"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Titik lekap"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Format sebagai"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Saiz"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Membebaskan ruang"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Pasang"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Kata laluan anda tidak padan."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Keluar?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Adakah anda pasti anda mahu keluar dari pemasangan?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Sila pilih bahasa"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Sila berikan kata laluan untuk akaun pengguna anda"
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Sila berikan nama penuh anda"
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Kata laluan anda tidak padan."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "Sekatan EFI tidak boleh dibut. Sila sunting bendera sekatan."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Sila pilih partisi root (/)."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "Sekatan EFI tidak boleh dibut. Sila sunting bendera sekatan."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "Sekatan EFI mesti diformat sebagai vfat."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "Sekatan EFI mesti diformat sebagai vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Sila pilih partisi EFI."
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Sila berikan nama pengguna"
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Penyetempatan"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Bahasa: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Zon masa: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Bentangan papan kekunci: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Tetapan pengguna"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Nama sebenar: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Nama pengguna: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Log masuk automatik: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "dibenarkan"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "dilumpuhkan"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Tetapan sistem"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Operasi sistem fail"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Pasang bootloader ke %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Jangan pasang pemuat but"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Guna /target yang telah mount."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Format %(path)s sebagai %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Mount %(path)s sebagai %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Pemasangan sudah siap. Adakah anda mahu restart komputer anda untuk "
-"menggunakan sistem baru?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Ralat pemasangan"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Bentangan papan kekunci"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Pemasangan dihentikan seketika"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Zon waktu"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Boleh tanggal:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Sunting"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Menetapkan ke /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Partisi logikal"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Partisi lanjutan"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Tidak diketahui"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Ubahsuai partisi"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Ubahsuai partisi"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Peranti:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Format sebagai:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Tempat mount:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Batal"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "OK"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Tidak"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Ya"
 
 #~ msgid "Quit"
 #~ msgstr "Keluar"

--- a/po/live-installer-my.po
+++ b/po/live-installer-my.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2015-06-27 06:29+0000\n"
 "Last-Translator: Lu Bu <lubu.3kingdoms.mdy@gmail.com>\n"
 "Language-Team: Burmese <my@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,140 +149,146 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 msgid "Edit Partitions"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -308,6 +316,699 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+msgid "Keyboard Model"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:73
+msgid "Installation type?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -403,10 +1104,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -433,7 +1130,7 @@ msgstr "စနစ်အတွင်းသို့  အသုံးပြုသ�
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr ""
@@ -453,671 +1150,60 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 msgid "Removing extra packages"
 msgstr ""
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr ""
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-msgid "Keyboard Model"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:73
-msgid "Installation type?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""

--- a/po/live-installer-my.po
+++ b/po/live-installer-my.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2015-06-27 06:29+0000\n"
 "Last-Translator: Lu Bu <lubu.3kingdoms.mdy@gmail.com>\n"
 "Language-Team: Burmese <my@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -291,6 +291,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -320,8 +325,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -407,23 +412,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -441,9 +517,102 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -558,18 +727,6 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -601,25 +758,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -854,7 +992,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr ""
 
@@ -873,138 +1011,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1150,60 +1156,60 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 msgid "Removing extra packages"
 msgstr ""
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""

--- a/po/live-installer-nb.po
+++ b/po/live-installer-nb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2018-08-26 23:12+0000\n"
 "Last-Translator: Thomas Olsen <Unknown>\n"
 "Language-Team: Norwegian Bokmal <nb@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -189,9 +189,9 @@ msgid "Format"
 msgstr "Formater som"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -295,6 +295,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Formater som"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -325,8 +331,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "Ok"
 
@@ -415,23 +421,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Land"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Utforming"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Variant"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Kalkulerer filindekser ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Flyttbar:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Endre"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Tildel til /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -449,10 +526,104 @@ msgstr "Kalkulerer filindekser ..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Tilgjengelig plass"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Logisk partisjon"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Utvidet partisjon"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Ukjent"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Endre partisjon"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Endre partisjon"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Enhet:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Formater som:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Monteringspunkt:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Land"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Utforming"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Kalkulerer filindekser ..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -567,18 +738,6 @@ msgstr "Formater som"
 msgid "Size"
 msgstr "Størrelse"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Tilgjengelig plass"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -611,25 +770,6 @@ msgstr "Avslutt?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Er du sikker på at du vil avslutte installasjonsprogrammet?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -871,7 +1011,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Installasjonen er fullført"
 
@@ -892,139 +1032,6 @@ msgstr "Installasjonsfeil"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Flyttbar:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Endre"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Tildel til /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Logisk partisjon"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Utvidet partisjon"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Ukjent"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Endre partisjon"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Endre partisjon"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Enhet:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Formater som:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Monteringspunkt:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Avbryt"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1183,49 +1190,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formaterer %(partition)s som %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Setter vertsnavn"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Setter opp område-opplysninger"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Setter vertsnavn"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Setter opp tastaturinnstillinger"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Fjerner midlertidige innstillinger (pakker)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Installerer oppstartslasteren"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Konfigurerer oppstartslasteren"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1233,15 +1240,15 @@ msgstr ""
 "ADVARSEL: Oppstartslasteren (grub) ble ikke ordentlig konfigurert. Du må "
 "konfigurere den manuelt."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Sjekker oppstartslasteren"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-nb.po
+++ b/po/live-installer-nb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2018-08-26 23:12+0000\n"
 "Last-Translator: Thomas Olsen <Unknown>\n"
 "Language-Team: Norwegian Bokmal <nb@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Tidssone"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Endre partisjon"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Ekspertmodus"
@@ -149,142 +151,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Oppdater"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Formater som"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Endre på partisjoner"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Logg inn automatisk"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -313,6 +321,714 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "Ok"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Nei"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Ja"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Tidssone"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Språk"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Tastaturoppsett"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Installasjon midlertidig stoppet"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Skriv"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Land"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Utforming"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Kalkulerer filindekser ..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Tastaturoppsett"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Er du sikker på at du vil avslutte installasjonsprogrammet?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Partisjonering"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Oppsummering."
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Tilbake"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Endre på partisjoner"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Enhet"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Operativsystem"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Monteringspunkt"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Formater som"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Størrelse"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Tilgjengelig plass"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Installer"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Passordene du oppga stemmer ikke overens."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Avslutt?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Er du sikker på at du vil avslutte installasjonsprogrammet?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Vennligst velg et språk"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Vennligst oppgi et passord for din brukerkonto."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Vennligst oppgi ditt fulle navn."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Passordene du oppga stemmer ikke overens."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+"EFI partisjonen er ikke oppstartsbar. Vennligst rediger partisjonsflaggene."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Vennligst velg en rotpartisjon(/)."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+"EFI partisjonen er ikke oppstartsbar. Vennligst rediger partisjonsflaggene."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "EFI partisjonen må formateres som vfat."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "EFI partisjonen må formateres som vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Vennligst velg en EFI-partisjon."
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Vennligst oppgi et brukernavn."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Plassering"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Språk: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Tidssone: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Tastaturutforming: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Brukerinnstillinger"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Virkelig navn: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Brukernavn: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Automatisk innlogging: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "aktivert"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "deaktivert"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Systeminnstillinger"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Filsystemhandlinger"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Installer oppstartslaster på %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Ikke installer oppstartslasteren"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Bruk den allerede monterte /target."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Formater %(path)s som %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Monter %(path)s som %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Monter %(path)s som %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Installasjonen er fullført"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Installasjonen er nå fullført. Vil du starte datamaskinen på nytt for å ta i "
+"bruk det nye systemet?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Installasjonsfeil"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Flyttbar:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Endre"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Tildel til /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Logisk partisjon"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Utvidet partisjon"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Ukjent"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Endre partisjon"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Endre partisjon"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Enhet:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Formater som:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Monteringspunkt:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -421,10 +1137,6 @@ msgstr "Passordene du oppga stemmer ikke overens."
 msgid "Please provide a password for your user account."
 msgstr "Vennligst oppgi et passord for din brukerkonto."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -451,7 +1163,7 @@ msgstr "Legger til ny bruker til systemet"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Skriver filsystemets monteringsinformasjon til /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Monterer %(partition)s i %(mountpoint)s"
@@ -471,49 +1183,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formaterer %(partition)s som %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Setter vertsnavn"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Setter opp område-opplysninger"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Setter vertsnavn"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Setter opp tastaturinnstillinger"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Fjerner midlertidige innstillinger (pakker)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Installerer oppstartslasteren"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Konfigurerer oppstartslasteren"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -521,643 +1233,17 @@ msgstr ""
 "ADVARSEL: Oppstartslasteren (grub) ble ikke ordentlig konfigurert. Du må "
 "konfigurere den manuelt."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Installasjonen er fullført"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Sjekker oppstartslasteren"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Land"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Språk"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Utforming"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Variant"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Kalkulerer filindekser ..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Tastaturoppsett"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Er du sikker på at du vil avslutte installasjonsprogrammet?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Partisjonering"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Oppsummering."
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Tilbake"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Endre på partisjoner"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Enhet"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Skriv"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Operativsystem"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Monteringspunkt"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Formater som"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Størrelse"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Tilgjengelig plass"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Installer"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Passordene du oppga stemmer ikke overens."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Avslutt?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Er du sikker på at du vil avslutte installasjonsprogrammet?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Vennligst velg et språk"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Vennligst oppgi et passord for din brukerkonto."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Vennligst oppgi ditt fulle navn."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Passordene du oppga stemmer ikke overens."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-"EFI partisjonen er ikke oppstartsbar. Vennligst rediger partisjonsflaggene."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Vennligst velg en rotpartisjon(/)."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-"EFI partisjonen er ikke oppstartsbar. Vennligst rediger partisjonsflaggene."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "EFI partisjonen må formateres som vfat."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "EFI partisjonen må formateres som vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Vennligst velg en EFI-partisjon."
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Vennligst oppgi et brukernavn."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Plassering"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Språk: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Tidssone: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Tastaturutforming: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Brukerinnstillinger"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Virkelig navn: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Brukernavn: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Automatisk innlogging: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "aktivert"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "deaktivert"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Systeminnstillinger"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Filsystemhandlinger"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Installer oppstartslaster på %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Ikke installer oppstartslasteren"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Bruk den allerede monterte /target."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Formater %(path)s som %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Monter %(path)s som %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Installasjonen er nå fullført. Vil du starte datamaskinen på nytt for å ta i "
-"bruk det nye systemet?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Installasjonsfeil"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Tastaturoppsett"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Installasjon midlertidig stoppet"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Tidssone"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Flyttbar:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Endre"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Tildel til /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Logisk partisjon"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Utvidet partisjon"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Ukjent"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Endre partisjon"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Endre partisjon"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Enhet:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Formater som:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Monteringspunkt:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Avbryt"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "Ok"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Nei"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Ja"
 
 #~ msgid "Quit"
 #~ msgstr "Avslutt"

--- a/po/live-installer-nds.po
+++ b/po/live-installer-nds.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2015-05-13 02:24+0000\n"
 "Last-Translator: Cedrik Heckenbach <cedrik.heckenbach@gmail.com>\n"
 "Language-Team: Low German <nds@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -189,9 +189,9 @@ msgid "Format"
 msgstr "Formatieren als"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -295,6 +295,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Formatieren als"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -325,8 +331,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -415,23 +421,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Land"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Layout"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Variante"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Berechne Datei-Indizes..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Entfernbar:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Bearbeiten"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Zuordnen zu /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -449,10 +526,104 @@ msgstr "Berechne Datei-Indizes..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Freier Speicherplatz"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Logische Partition"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Erweiterte Partition"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Unbekannt"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Partition bearbeiten"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Partition bearbeiten"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Gerät:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Formatieren als:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Einhängepunkt:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Land"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Layout"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variante"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Berechne Datei-Indizes..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -567,18 +738,6 @@ msgstr "Formatieren als"
 msgid "Size"
 msgstr "Größe"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Freier Speicherplatz"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -611,25 +770,6 @@ msgstr "Beenden?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Sind Sie sicher, dass Sie das Installationsprogramm beenden möchten?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -873,7 +1013,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Installation fertig"
 
@@ -894,139 +1034,6 @@ msgstr "Fehler bei der Installation"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Entfernbar:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Bearbeiten"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Zuordnen zu /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Logische Partition"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Erweiterte Partition"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Unbekannt"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Partition bearbeiten"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Partition bearbeiten"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Gerät:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Formatieren als:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Einhängepunkt:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1185,49 +1192,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formatiere %(partition)s als %(format)s"
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Setze den Hostnamen"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Setze lokale Einstellungen (locale)"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Setze den Hostnamen"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Stelle die Tastatur ein"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Lösche Live Konfiguration (Installationspakete)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Installiere Bootloader"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Richte Bootloader ein"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1235,15 +1242,15 @@ msgstr ""
 "WARNUNG! Der Grub Bootloader wurde nicht ordnungsgemäß eingerichtet! Sie "
 "müssen den Bootloader manuell einrichten."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Prüfe Bootloader"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-nds.po
+++ b/po/live-installer-nds.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2015-05-13 02:24+0000\n"
 "Last-Translator: Cedrik Heckenbach <cedrik.heckenbach@gmail.com>\n"
 "Language-Team: Low German <nds@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Zeitzone"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Partition bearbeiten"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Expertenmodus"
@@ -149,142 +151,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Aktualisieren"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Formatieren als"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Partitionen bearbeiten"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Automatisch einloggen"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -313,6 +321,716 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Zeitzone"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Sprache"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Tastaturbelegung"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Installation pausiert"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Typ"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Land"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Layout"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variante"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Berechne Datei-Indizes..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Tastaturbelegung"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Sind Sie sicher, dass Sie das Installationsprogramm beenden möchten?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Partitionierung"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Zusammenfassung"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Partitionen bearbeiten"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Gerät"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Betriebssystem"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Einhängepunkt"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Formatieren als"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Größe"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Freier Speicherplatz"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Ihre Passwörter stimmen nicht überein."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Beenden?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Sind Sie sicher, dass Sie das Installationsprogramm beenden möchten?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Bitte wählen Sie eine Sprache"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Bitte geben Sie ein Kennwort für Ihr Benutzerkonto ein."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Bitte geben Sie Ihren vollständigen Namen an."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Ihre Passwörter stimmen nicht überein."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+"Die EFI-Partition ist nicht bootfähig. Bitte bearbeiten Sie die Partitions-"
+"Flags."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Bitte wählen Sie eine Root (/) Partition."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+"Die EFI-Partition ist nicht bootfähig. Bitte bearbeiten Sie die Partitions-"
+"Flags."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "Die EFI-Partition muss als vfat formatiert sein."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "Die EFI-Partition muss als vfat formatiert sein."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Bitte wählen Sie eine EFI-Partition."
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Bitte geben Sie Ihren Benutzernamen an"
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Lokalisierung"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Sprache: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Zeitzone: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Tastaturbelegung: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Benutzereinstellungen"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Ihr echter Name "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Benutzername: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Automatische Anmeldung: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "aktiviert"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "deaktiviert"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Systemeinstellungen"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Dateisystem-Funktionen"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Installiere Bootloader auf %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Keinen Bootloader installieren"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Verwende bereits eingehängte /target"
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Formatiere %(path)s als %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Binde %(path)s als %(mount)s ein"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Binde %(path)s als %(mount)s ein"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Installation fertig"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Die Installation ist nun abgeschlossen. Möchten Sie Ihren Computer für die "
+"Verwendung des neuen Systems neu starten?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Fehler bei der Installation"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Entfernbar:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Bearbeiten"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Zuordnen zu /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Logische Partition"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Erweiterte Partition"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Unbekannt"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Partition bearbeiten"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Partition bearbeiten"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Gerät:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Formatieren als:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Einhängepunkt:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -421,10 +1139,6 @@ msgstr "Ihre Passwörter stimmen nicht überein."
 msgid "Please provide a password for your user account."
 msgstr "Bitte geben Sie ein Kennwort für Ihr Benutzerkonto ein."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -451,7 +1165,7 @@ msgstr "Neuen Benutzer zum System hinzufügen"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Schreiben von Dateisystem-Einhängeinformationen in /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Hänge %(partition)s in %(mountpoint)s ein"
@@ -471,49 +1185,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formatiere %(partition)s als %(format)s"
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Setze den Hostnamen"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Setze lokale Einstellungen (locale)"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Setze den Hostnamen"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Stelle die Tastatur ein"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Lösche Live Konfiguration (Installationspakete)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Installiere Bootloader"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Richte Bootloader ein"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -521,644 +1235,16 @@ msgstr ""
 "WARNUNG! Der Grub Bootloader wurde nicht ordnungsgemäß eingerichtet! Sie "
 "müssen den Bootloader manuell einrichten."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Installation fertig"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Prüfe Bootloader"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Land"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Sprache"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Layout"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Variante"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Berechne Datei-Indizes..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Tastaturbelegung"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Sind Sie sicher, dass Sie das Installationsprogramm beenden möchten?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Partitionierung"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Zusammenfassung"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Partitionen bearbeiten"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Gerät"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Typ"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Betriebssystem"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Einhängepunkt"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Formatieren als"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Größe"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Freier Speicherplatz"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Ihre Passwörter stimmen nicht überein."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Beenden?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Sind Sie sicher, dass Sie das Installationsprogramm beenden möchten?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Bitte wählen Sie eine Sprache"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Bitte geben Sie ein Kennwort für Ihr Benutzerkonto ein."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Bitte geben Sie Ihren vollständigen Namen an."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Ihre Passwörter stimmen nicht überein."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-"Die EFI-Partition ist nicht bootfähig. Bitte bearbeiten Sie die Partitions-"
-"Flags."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Bitte wählen Sie eine Root (/) Partition."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-"Die EFI-Partition ist nicht bootfähig. Bitte bearbeiten Sie die Partitions-"
-"Flags."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "Die EFI-Partition muss als vfat formatiert sein."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "Die EFI-Partition muss als vfat formatiert sein."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Bitte wählen Sie eine EFI-Partition."
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Bitte geben Sie Ihren Benutzernamen an"
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Lokalisierung"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Sprache: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Zeitzone: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Tastaturbelegung: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Benutzereinstellungen"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Ihr echter Name "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Benutzername: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Automatische Anmeldung: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "aktiviert"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "deaktiviert"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Systemeinstellungen"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Dateisystem-Funktionen"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Installiere Bootloader auf %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Keinen Bootloader installieren"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Verwende bereits eingehängte /target"
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Formatiere %(path)s als %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Binde %(path)s als %(mount)s ein"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Die Installation ist nun abgeschlossen. Möchten Sie Ihren Computer für die "
-"Verwendung des neuen Systems neu starten?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Fehler bei der Installation"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Tastaturbelegung"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Installation pausiert"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Zeitzone"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Entfernbar:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Bearbeiten"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Zuordnen zu /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Logische Partition"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Erweiterte Partition"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Unbekannt"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Partition bearbeiten"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Partition bearbeiten"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Gerät:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Formatieren als:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Einhängepunkt:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-ne.po
+++ b/po/live-installer-ne.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2014-03-10 08:30+0000\n"
 "Last-Translator: Bista Nirooj <nirooj56@gmail.com>\n"
 "Language-Team: Nepali <ne@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "समय क्षेत्र"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,141 +149,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "सिस्टम सेत्तिन्ग्स"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -310,6 +318,703 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "समय क्षेत्र"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "भाषा"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "किबोर्द लेआउट: "
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "स्थापना त्रुटि देखियो"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "टाइप"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "ढाँचा"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "प्रकार"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "उपकरण"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "अपरेटिंग सिस्टम"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "माउन्ट बिन्दु"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "साइज"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "खाली ठाउँ"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "स्थानीयकरण"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "भाषा: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "समयक्षेत्र "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "किबोर्द लेआउट: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "तपाइको सेटिंगहरु"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "असली नाम "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "प्रयोगकर्ता नाम: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "सिस्टम सेत्तिन्ग्स"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "फाइल सिस्टम कृयाहरू"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "bootloader स्थापन नगर्नु |"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "%(partition)sलाई %(mountpoint)s मा माउन्ट गरिदै ।"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "स्थापना सकियो"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "स्थापना त्रुटि देखियो"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "सिस्टम सेत्तिन्ग्स"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -405,10 +1110,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -435,7 +1136,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "%(partition)sलाई %(mountpoint)s मा माउन्ट गरिदै ।"
@@ -455,680 +1156,65 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "hostname स्थापना गरिदै"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "स्थान स्थापना गरिदै"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "hostname स्थापना गरिदै"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "किबोर्द अप्संस मिलायिदै"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "लाईभका कनफिगरासनहरु निकलिदै छ (पाकेजहरु)।"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "bootloader स्थापना गरिदै"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "bootloader कन्फ़िगर गरिदै"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 "चेतावनी: grub bootloader ठीक संग कन्फ़िगर गरिएको छैन, कृपया आफै कॉन्फ़िगर मिलाउनु होला"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "स्थापना सकियो"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "bootloader जाँचिदै"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "भाषा"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "ढाँचा"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "प्रकार"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "उपकरण"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "टाइप"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "अपरेटिंग सिस्टम"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "माउन्ट बिन्दु"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "साइज"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "खाली ठाउँ"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "स्थानीयकरण"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "भाषा: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "समयक्षेत्र "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "किबोर्द लेआउट: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "तपाइको सेटिंगहरु"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "असली नाम "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "प्रयोगकर्ता नाम: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "सिस्टम सेत्तिन्ग्स"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "फाइल सिस्टम कृयाहरू"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "bootloader स्थापन नगर्नु |"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "स्थापना त्रुटि देखियो"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "किबोर्द लेआउट: "
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "स्थापना त्रुटि देखियो"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "समय क्षेत्र"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "सिस्टम सेत्तिन्ग्स"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-ne.po
+++ b/po/live-installer-ne.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2014-03-10 08:30+0000\n"
 "Last-Translator: Bista Nirooj <nirooj56@gmail.com>\n"
 "Language-Team: Nepali <ne@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -292,6 +292,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -322,8 +327,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -412,23 +417,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "ढाँचा"
-
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "प्रकार"
-
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -446,9 +522,103 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "खाली ठाउँ"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "सिस्टम सेत्तिन्ग्स"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "ढाँचा"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "प्रकार"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -563,18 +733,6 @@ msgstr ""
 msgid "Size"
 msgstr "साइज"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "खाली ठाउँ"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -606,25 +764,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -859,7 +998,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "स्थापना सकियो"
 
@@ -878,139 +1017,6 @@ msgstr "स्थापना त्रुटि देखियो"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "सिस्टम सेत्तिन्ग्स"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1156,64 +1162,64 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "hostname स्थापना गरिदै"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "स्थान स्थापना गरिदै"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "hostname स्थापना गरिदै"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "किबोर्द अप्संस मिलायिदै"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "लाईभका कनफिगरासनहरु निकलिदै छ (पाकेजहरु)।"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "bootloader स्थापना गरिदै"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "bootloader कन्फ़िगर गरिदै"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 "चेतावनी: grub bootloader ठीक संग कन्फ़िगर गरिएको छैन, कृपया आफै कॉन्फ़िगर मिलाउनु होला"
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "bootloader जाँचिदै"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-nl.po
+++ b/po/live-installer-nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2020-03-09 22:55+0000\n"
 "Last-Translator: Pjotr12345 <Unknown>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -94,7 +94,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -197,9 +197,9 @@ msgid "Format"
 msgstr "Formatteren als"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -306,6 +306,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Formatteren als"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -337,8 +343,8 @@ msgstr "Welkom"
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "Oké"
 
@@ -430,23 +436,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr "Welkom"
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Land"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Indeling"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Variant"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Bestandindices aan het berekenen...."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Verwijderbaar:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Bewerken"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Toewijzen aan /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -464,10 +541,108 @@ msgstr "Bestandindices aan het berekenen...."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr "Installatieprogramma"
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Vrije ruimte"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"De partitietabel voor %s kon niet worden geschreven. Herstart de computer en "
+"probeer het opnieuw."
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"De partitie %s kon niet worden aangemaakt. De installatie wordt gestaakt. "
+"Herstart de computer en probeer het opnieuw."
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Logische partitie"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Uitgebreide partitie"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Onbekend"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Partitie bewerken"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Partitie bewerken"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Apparaat:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Formatteren als:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Koppelpunt:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Afbreken"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Land"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Indeling"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Bestandindices aan het berekenen...."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -585,18 +760,6 @@ msgstr "Formatteren als"
 msgid "Size"
 msgstr "Grootte"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Vrije ruimte"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -629,25 +792,6 @@ msgstr "Afbreken?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Weet u zeker dat u de installatie wil afbreken?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -909,7 +1053,7 @@ msgid "Disk Encryption: "
 msgstr "Schijfversleuteling: "
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Installatie voltooid"
 
@@ -930,143 +1074,6 @@ msgstr "Installatiefout"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Verwijderbaar:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Bewerken"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Toewijzen aan /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"De partitietabel voor %s kon niet worden geschreven. Herstart de computer en "
-"probeer het opnieuw."
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"De partitie %s kon niet worden aangemaakt. De installatie wordt gestaakt. "
-"Herstart de computer en probeer het opnieuw."
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Logische partitie"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Uitgebreide partitie"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Onbekend"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Partitie bewerken"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Partitie bewerken"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Apparaat:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Formatteren als:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Koppelpunt:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Afbreken"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1231,49 +1238,49 @@ msgstr "Partities aanmaken op %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Bezig met formatteren van %(partition)s als %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Computernaam instellen"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Taal en land instellen"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Computernaam instellen"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Toetsenbordopties instellen"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Live-configuratie (pakketten) aan het verwijderen"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Opstartlader installeren"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Opstartlader instellen"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1281,15 +1288,15 @@ msgstr ""
 "WAARSCHUWING: opstartlader Grub werd niet juist ingesteld! U dient deze "
 "handmatig in te stellen."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Opstartlader controleren"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-nl.po
+++ b/po/live-installer-nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2020-03-09 22:55+0000\n"
 "Last-Translator: Pjotr12345 <Unknown>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -24,8 +24,8 @@ msgid "Welcome to the 17g Installer."
 msgstr "Welkom bij het installatieprogramma van 17G."
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 #, fuzzy
 msgid ""
 "This program will ask you some questions and set up system on your computer."
@@ -33,12 +33,12 @@ msgstr ""
 "Dit programma zal u enkele vragen stellen en 17G installeren op uw computer."
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr "Toetsenbordmodel:"
 
@@ -48,10 +48,12 @@ msgid "Type here to test your keyboard"
 msgstr "Tik hier om uw toetsenbordindeling uit te proberen"
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -60,13 +62,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Tijdzone"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr "Geautomatiseerde installatie"
 
@@ -76,12 +78,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr "Wis een schijf en installeer 17G erop."
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr "Schijf:"
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Partitie bewerken"
@@ -92,43 +94,43 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 "Gebruik LVM (Logical Volume Management, alleen voor ervaren gebruikers)"
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr "Versleutel het besturingssysteem"
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr "Wachtwoordzin"
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr "Bevestig de wachtwoordzin"
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr "Dit biedt extra veiligheid, maar kan uren duren."
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr "Vul de schijf met willekeurige gegevens"
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr "Handmatige schijfindeling"
 
@@ -146,7 +148,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Expertmodus"
@@ -156,146 +158,152 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 #, fuzzy
 msgid "Minimal installation"
 msgstr "Geautomatiseerde installatie"
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Verversen"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Formatteren als"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr "Grub-opstartmenu installeren op:"
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Partities bewerken"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr "Uw naam:"
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr "De naam van uw computer:"
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr "Kies een gebruikersnaam:"
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 "De naam die uw computer gebruikt wanneer hij communiceert met andere "
 "computers."
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr "Kies een wachtwoord:"
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Automatisch aanmelden"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr "Mijn wachtwoord vergen om aan te melden"
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr "Mijn persoonlijke map versleutelen"
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr "Bevestig uw wachtwoord:"
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 #, fuzzy
 msgid "Automated installation enabled!"
 msgstr "Geautomatiseerde installatie op %s"
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr "Welkom"
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -326,6 +334,744 @@ msgstr ""
 #, fuzzy
 msgid "Welcome to 17g"
 msgstr "Welkom"
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "Oké"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Nee"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Ja"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Tijdzone"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, fuzzy, python-format
+msgid "Welcome to the %s Installer."
+msgstr "Welkom bij het installatieprogramma van 17G."
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr "Welke taal wilt u gebruiken?"
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Taal"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr "Waar bevindt u zich?"
+
+#: live-installer/frontend/tui_interface.py:57
+#, fuzzy
+msgid "What keyboard would you like to use?"
+msgstr "Welke taal wilt u gebruiken?"
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Toetsenbordmodel:"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Installatietype"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Type"
+
+#: live-installer/frontend/tui_interface.py:80
+#, fuzzy
+msgid "Select a disk?"
+msgstr "Kies a.u.b. een schijf."
+
+#: live-installer/frontend/tui_interface.py:84
+#, fuzzy
+msgid "Disk"
+msgstr "Schijf:"
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, fuzzy, python-format
+msgid "Welcome to %s"
+msgstr "Welkom"
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Land"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Indeling"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Bestandindices aan het berekenen...."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr "Installatieprogramma"
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Toetsenbordindeling"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr "Wat is uw toetsenbordindeling?"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr "Gebruikersaccount"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr "Wie bent u?"
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr "Installatietype"
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Waar wilt u 17G installeren?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Schijfindeling"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Samenvatting"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr "Installeren"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+#, fuzzy
+msgid "Automated Install"
+msgstr "Geautomatiseerde installatie"
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Vorige"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr "Volgende"
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr "Tik hier om uw toetsenbordindeling uit te proberen"
+
+#: live-installer/frontend/gtk_interface.py:546
+#, fuzzy
+msgid "Erase a disk and install system on it."
+msgstr "Wis een schijf en installeer 17G erop."
+
+#: live-installer/frontend/gtk_interface.py:559
+#, fuzzy
+msgid "Manually create, resize or choose partitions for system."
+msgstr "Handmatig partities maken, kiezen of grootte veranderen voor 17G"
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Partities bewerken"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Apparaat"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Besturingssysteem"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Koppelpunt"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Formatteren als"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Grootte"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Vrije ruimte"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr "Waarschuwing"
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr "Dit zal alle gegevens op %s wissen. Weet u het zeker?"
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Installeren"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr "Geef a.u.b. een wachtwoordzin op voor de versleuteling."
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Uw wachtwoorden komen niet overeen."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Afbreken?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Weet u zeker dat u de installatie wil afbreken?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Kies a.u.b. een taal."
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Geef a.u.b. een naam op voor uw computer."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Geef a.u.b. uw volledige naam op."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Uw wachtwoorden komen niet overeen."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "De EFI-partitie is te klein. Die moet tenminste 35 MB zijn."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Kies a.u.b. een partitie voor root (/)."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, fuzzy, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+"Er is een rootpartitie nodig om Linux Mint op te installeren.\n"
+"\n"
+" - Koppelpunt: /\n"
+" - Aangeraden grootte: minimaal 30GB\n"
+" - Aangeraden formattering van bestandssysteem: EXT4\n"
+"\n"
+"Let op: de momentopnamefunctie van Timeshift voor btrfs vergt het gebruik "
+"van:\n"
+" - subvolume-koppelpunt /@\n"
+" - btrfs als formattering van het bestandssysteem\n"
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "De EFI-partitie is niet opstartbaar. Bewerk a.u.b. de partitievlaggen."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "De EFI-partitie is te klein. Die moet tenminste 35 MB zijn."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "De EFI-partitie moet worden geformatteerd als vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Kies a.u.b. een EFI-partitie."
+
+#: live-installer/frontend/gtk_interface.py:1301
+#, fuzzy
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+"Er is een EFI-systeempartitie benodigd met de volgende kenmerken:\n"
+"\n"
+" - Koppelpunt: /boot/efi\n"
+" - Partitievlaggen: Opstartbaar (Bootable)\n"
+" -Grootte: tenminste 35 MB (maar 100 MB wordt aangeraden)\n"
+" - Formattering: vfat of fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr "Kies a.u.b. een schijf."
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Geef a.u.b. een gebruikersnaam op."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Taal- en landinstellingen (regionalisatie)"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Taal: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Tijdzone: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Toetsenbordindeling: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Gebruikersinstellingen"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Echte naam: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Gebruikersnaam: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Automatisch aanmelden: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "ingeschakeld"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "uitgeschakeld"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Systeeminstellingen"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr "Computernaam: "
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+#, fuzzy
+msgid "Install updates after installation"
+msgstr "Geautomatiseerde installatie"
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Bewerkingen van bestandssysteem"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Opstartlader installeren op %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Opstartlader niet installeren"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Gebruik reeds aangekoppelde /target."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr "Geautomatiseerde installatie op %s"
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Formatteer %(path)s as %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Koppel %(path)s aan als %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Koppel %(path)s aan als %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr "LVM: "
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr "Schijfversleuteling: "
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Installatie voltooid"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"De installatie is thans voltooid. Wilt u de computer herstarten om uw nieuwe "
+"systeem te gebruiken?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Installatiefout"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Verwijderbaar:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Bewerken"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Toewijzen aan /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"De partitietabel voor %s kon niet worden geschreven. Herstart de computer en "
+"probeer het opnieuw."
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"De partitie %s kon niet worden aangemaakt. De installatie wordt gestaakt. "
+"Herstart de computer en probeer het opnieuw."
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Logische partitie"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Uitgebreide partitie"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Onbekend"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Partitie bewerken"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Partitie bewerken"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Apparaat:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Formatteren als:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Koppelpunt:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Afbreken"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
+msgstr ""
 
 #: live-installer/validate.py:12
 msgid "Please provide a username."
@@ -435,10 +1181,6 @@ msgstr "Uw wachtwoorden komen niet overeen."
 msgid "Please provide a password for your user account."
 msgstr "Geef a.u.b. een wachtwoord op voor uw gebruikersaccount."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -467,7 +1209,7 @@ msgstr ""
 "Aankoppelinformatie betreffende het bestandssysteem wegschrijven in /etc/"
 "fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Bezig met koppelen van %(partition)s aan %(mountpoint)s"
@@ -489,49 +1231,49 @@ msgstr "Partities aanmaken op %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Bezig met formatteren van %(partition)s als %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Computernaam instellen"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Taal en land instellen"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Computernaam instellen"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Toetsenbordopties instellen"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Live-configuratie (pakketten) aan het verwijderen"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Opstartlader installeren"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Opstartlader instellen"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -539,673 +1281,17 @@ msgstr ""
 "WAARSCHUWING: opstartlader Grub werd niet juist ingesteld! U dient deze "
 "handmatig in te stellen."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Installatie voltooid"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Opstartlader controleren"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Land"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Taal"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Indeling"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Variant"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Bestandindices aan het berekenen...."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr "Installatieprogramma"
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr "Welke taal wilt u gebruiken?"
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr "Waar bevindt u zich?"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Toetsenbordindeling"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr "Wat is uw toetsenbordindeling?"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr "Gebruikersaccount"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr "Wie bent u?"
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr "Installatietype"
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Waar wilt u 17G installeren?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Schijfindeling"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Samenvatting"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr "Installeren"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-#, fuzzy
-msgid "Automated install"
-msgstr "Geautomatiseerde installatie"
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Vorige"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr "Volgende"
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, fuzzy, python-format
-msgid "Welcome to the %s Installer."
-msgstr "Welkom bij het installatieprogramma van 17G."
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr "Tik hier om uw toetsenbordindeling uit te proberen"
-
-#: live-installer/frontend/gtk_interface.py:542
-#, fuzzy
-msgid "Erase a disk and install system on it."
-msgstr "Wis een schijf en installeer 17G erop."
-
-#: live-installer/frontend/gtk_interface.py:555
-#, fuzzy
-msgid "Manually create, resize or choose partitions for system."
-msgstr "Handmatig partities maken, kiezen of grootte veranderen voor 17G"
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Partities bewerken"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Apparaat"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Type"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Besturingssysteem"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Koppelpunt"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Formatteren als"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Grootte"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Vrije ruimte"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Installeren"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr "Geef a.u.b. een wachtwoordzin op voor de versleuteling."
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Uw wachtwoorden komen niet overeen."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Afbreken?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Weet u zeker dat u de installatie wil afbreken?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Kies a.u.b. een taal."
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Geef a.u.b. een naam op voor uw computer."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Geef a.u.b. uw volledige naam op."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Uw wachtwoorden komen niet overeen."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "De EFI-partitie is te klein. Die moet tenminste 35 MB zijn."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Kies a.u.b. een partitie voor root (/)."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, fuzzy, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-"Er is een rootpartitie nodig om Linux Mint op te installeren.\n"
-"\n"
-" - Koppelpunt: /\n"
-" - Aangeraden grootte: minimaal 30GB\n"
-" - Aangeraden formattering van bestandssysteem: EXT4\n"
-"\n"
-"Let op: de momentopnamefunctie van Timeshift voor btrfs vergt het gebruik "
-"van:\n"
-" - subvolume-koppelpunt /@\n"
-" - btrfs als formattering van het bestandssysteem\n"
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "De EFI-partitie is niet opstartbaar. Bewerk a.u.b. de partitievlaggen."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "De EFI-partitie is te klein. Die moet tenminste 35 MB zijn."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "De EFI-partitie moet worden geformatteerd als vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Kies a.u.b. een EFI-partitie."
-
-#: live-installer/frontend/gtk_interface.py:1226
-#, fuzzy
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-"Er is een EFI-systeempartitie benodigd met de volgende kenmerken:\n"
-"\n"
-" - Koppelpunt: /boot/efi\n"
-" - Partitievlaggen: Opstartbaar (Bootable)\n"
-" -Grootte: tenminste 35 MB (maar 100 MB wordt aangeraden)\n"
-" - Formattering: vfat of fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr "Kies a.u.b. een schijf."
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr "Waarschuwing"
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr "Dit zal alle gegevens op %s wissen. Weet u het zeker?"
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Geef a.u.b. een gebruikersnaam op."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Taal- en landinstellingen (regionalisatie)"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Taal: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Tijdzone: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Toetsenbordindeling: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Gebruikersinstellingen"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Echte naam: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Gebruikersnaam: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Automatisch aanmelden: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "ingeschakeld"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "uitgeschakeld"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Systeeminstellingen"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr "Computernaam: "
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-#, fuzzy
-msgid "Install updates after installation"
-msgstr "Geautomatiseerde installatie"
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Bewerkingen van bestandssysteem"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Opstartlader installeren op %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Opstartlader niet installeren"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Gebruik reeds aangekoppelde /target."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr "Geautomatiseerde installatie op %s"
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Formatteer %(path)s as %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Koppel %(path)s aan als %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr "LVM: "
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr "Schijfversleuteling: "
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"De installatie is thans voltooid. Wilt u de computer herstarten om uw nieuwe "
-"systeem te gebruiken?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Installatiefout"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, fuzzy, python-format
-msgid "Welcome to %s"
-msgstr "Welkom"
-
-#: live-installer/frontend/tui_interface.py:57
-#, fuzzy
-msgid "What keyboard would you like to use?"
-msgstr "Welke taal wilt u gebruiken?"
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Toetsenbordmodel:"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Installatietype"
-
-#: live-installer/frontend/tui_interface.py:80
-#, fuzzy
-msgid "Select a disk?"
-msgstr "Kies a.u.b. een schijf."
-
-#: live-installer/frontend/tui_interface.py:84
-#, fuzzy
-msgid "Disk"
-msgstr "Schijf:"
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Tijdzone"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Verwijderbaar:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Bewerken"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Toewijzen aan /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"De partitietabel voor %s kon niet worden geschreven. Herstart de computer en "
-"probeer het opnieuw."
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"De partitie %s kon niet worden aangemaakt. De installatie wordt gestaakt. "
-"Herstart de computer en probeer het opnieuw."
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Logische partitie"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Uitgebreide partitie"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Onbekend"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Partitie bewerken"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Partitie bewerken"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Apparaat:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Formatteren als:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Koppelpunt:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Afbreken"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "Oké"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Nee"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Ja"
 
 #~ msgid "Quit"
 #~ msgstr "Afsluiten"

--- a/po/live-installer-nn.po
+++ b/po/live-installer-nn.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2011-09-21 00:39+0000\n"
 "Last-Translator: Yngve Spjeld Landro <l10n@landro.net>\n"
 "Language-Team: Norwegian Nynorsk <nn@li.org>\n"
@@ -24,19 +24,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -45,10 +45,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -57,13 +59,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -72,12 +74,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -148,141 +150,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Systeminnstillingar"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -311,6 +319,702 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Tastaturutforming: "
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Installasjonsfeil"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Type"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Utforming"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Eining"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Operativsystem"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Monteringspunkt"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Storleik"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Ledig plass"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Lokalisering"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Språk: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Tidssone: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Tastaturutforming: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Brukarinnstillingar"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Verkeleg namn: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Brukarnamn: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Systeminnstillingar"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Filsystemhandlingar"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Installer ikkje oppstartslastaren"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Monterer %(partition)s i %(mountpoint)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Installasjonen er ferdig"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Installasjonsfeil"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Systeminnstillingar"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -406,10 +1110,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -436,7 +1136,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Monterer %(partition)s i %(mountpoint)s"
@@ -456,49 +1156,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Lagrar vertsnamnet"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Lagrar områdeopplysningane"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Lagrar vertsnamnet"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Lagrar tastaturvala"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Fjernar mellombelse innstillingar (pakkar)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Installerer oppstartslastaren"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Set opp oppstartslastaren"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -506,630 +1206,16 @@ msgstr ""
 "ÅTVARING: Oppstartslastaren (grub) vart ikkje sett opp rett. Du må endra han "
 "opp manuelt."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Installasjonen er ferdig"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Kontrollerer oppstartslastaren"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Utforming"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Variant"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Eining"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Type"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Operativsystem"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Monteringspunkt"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Storleik"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Ledig plass"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Lokalisering"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Språk: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Tidssone: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Tastaturutforming: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Brukarinnstillingar"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Verkeleg namn: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Brukarnamn: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Systeminnstillingar"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Filsystemhandlingar"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Installer ikkje oppstartslastaren"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Installasjonsfeil"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Tastaturutforming: "
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Installasjonsfeil"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Systeminnstillingar"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-nn.po
+++ b/po/live-installer-nn.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2011-09-21 00:39+0000\n"
 "Last-Translator: Yngve Spjeld Landro <l10n@landro.net>\n"
 "Language-Team: Norwegian Nynorsk <nn@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -187,9 +187,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -293,6 +293,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -323,8 +328,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -412,23 +417,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Utforming"
-
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Variant"
-
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -446,9 +522,103 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Ledig plass"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Systeminnstillingar"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Utforming"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -563,18 +733,6 @@ msgstr ""
 msgid "Size"
 msgstr "Storleik"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Ledig plass"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -606,25 +764,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -859,7 +998,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Installasjonen er ferdig"
 
@@ -878,139 +1017,6 @@ msgstr "Installasjonsfeil"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Systeminnstillingar"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1156,49 +1162,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Lagrar vertsnamnet"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Lagrar områdeopplysningane"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Lagrar vertsnamnet"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Lagrar tastaturvala"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Fjernar mellombelse innstillingar (pakkar)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Installerer oppstartslastaren"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Set opp oppstartslastaren"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1206,15 +1212,15 @@ msgstr ""
 "ÅTVARING: Oppstartslastaren (grub) vart ikkje sett opp rett. Du må endra han "
 "opp manuelt."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Kontrollerer oppstartslastaren"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-oc.po
+++ b/po/live-installer-oc.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2016-10-04 19:41+0000\n"
 "Last-Translator: Cédric VALMARY (Tot en òc) <cvalmary@yahoo.fr>\n"
 "Language-Team: Occitan (post 1500) <oc@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Fus orari"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Modificar la particion"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "Go"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Mòde expèrt"
@@ -149,142 +151,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Refrescar"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Formatar en"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Modificar las particions"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Se connectar automaticament"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -313,6 +321,705 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Fus orari"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Lenga"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Disposicion del clavièr"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Installacion en pausa"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Tipe"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "País"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Presentacion"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Varianta"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Indexacion dels fichièrs ..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Disposicion del clavièr"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Particionament"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Resumit"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Modificar las particions"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Periferic"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Sistèma operatiu"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Punt de montatge"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Formatar en"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Talha"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Espaci disponible"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Quitar ?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Causissètz una lenga"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Indicatz vòstre nom complet."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Indicatz vòstre nom complet."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Sasissètz un identificant."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Traduccions"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Lenga : "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Fus orari : "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Agençament del clavièr : "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Paramètres utilizaire"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Nom vertadièr : "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Nom d'utilizaire : "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Connexion automatica : "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "activat"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "desactivat"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Paramètres del sistèma"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Operacions del sistèma de fichièrs"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Installar pas cap de cargador d'amorsatge"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Formatatge de %(path)s en %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Montatge de %(path)s dins %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Montatge de %(path)s dins %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Installacion acabada"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Error al moment de l'installacion"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "o"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "Ko"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "Mo"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "To"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Amovible :"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Editar"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Atribuir a /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Particion espandida"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Desconeguda"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Modificar la particion"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Modificar la particion"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Periferic :"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Punt de montatge :"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -408,10 +1115,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -438,7 +1141,7 @@ msgstr "Creacion del compte utilizaire"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Montatge de %(partition)s sus %(mountpoint)s"
@@ -458,49 +1161,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formatatge de %(partition)s en %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Definicion del nom d'òste"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Configuracion dels paramètres regionals"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Definicion del nom d'òste"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Configuracion de las opcions de clavièr"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Supression dels paquets del sistèma live"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Installacion del cargador d'amorsatge"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Configuracion del cargador d'amorsatge"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -508,633 +1211,16 @@ msgstr ""
 "ATENCION : lo cargador d'amorsatge GRUB es pas estat configurat "
 "corrèctament ! Lo vos cal configurar manualament."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Installacion acabada"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Verificacion del cargador d'amorsatge"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "País"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Lenga"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Presentacion"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Varianta"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Indexacion dels fichièrs ..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Disposicion del clavièr"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Particionament"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Resumit"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Modificar las particions"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Periferic"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Tipe"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Sistèma operatiu"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Punt de montatge"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Formatar en"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Talha"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Espaci disponible"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Quitar ?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Causissètz una lenga"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Indicatz vòstre nom complet."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Indicatz vòstre nom complet."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Sasissètz un identificant."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Traduccions"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Lenga : "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Fus orari : "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Agençament del clavièr : "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Paramètres utilizaire"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Nom vertadièr : "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Nom d'utilizaire : "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Connexion automatica : "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "activat"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "desactivat"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Paramètres del sistèma"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Operacions del sistèma de fichièrs"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Installar pas cap de cargador d'amorsatge"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Formatatge de %(path)s en %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Montatge de %(path)s dins %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Error al moment de l'installacion"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Disposicion del clavièr"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Installacion en pausa"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Fus orari"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "o"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "Ko"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "Mo"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "To"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Amovible :"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Editar"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Atribuir a /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Particion espandida"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Desconeguda"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Modificar la particion"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Modificar la particion"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Periferic :"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Punt de montatge :"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-oc.po
+++ b/po/live-installer-oc.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2016-10-04 19:41+0000\n"
 "Last-Translator: Cédric VALMARY (Tot en òc) <cvalmary@yahoo.fr>\n"
 "Language-Team: Occitan (post 1500) <oc@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "Go"
 
@@ -189,9 +189,9 @@ msgid "Format"
 msgstr "Formatar en"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -295,6 +295,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Formatar en"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -325,8 +331,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -415,23 +421,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "País"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "o"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Presentacion"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "Ko"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Varianta"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "Mo"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Indexacion dels fichièrs ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "To"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Amovible :"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Editar"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Atribuir a /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -449,10 +526,104 @@ msgstr "Indexacion dels fichièrs ..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Espaci disponible"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Particion espandida"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Desconeguda"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Modificar la particion"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Modificar la particion"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Periferic :"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Punt de montatge :"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "País"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Presentacion"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Varianta"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Indexacion dels fichièrs ..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -566,18 +737,6 @@ msgstr "Formatar en"
 msgid "Size"
 msgstr "Talha"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Espaci disponible"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -609,25 +768,6 @@ msgstr "Quitar ?"
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -864,7 +1004,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Installacion acabada"
 
@@ -883,139 +1023,6 @@ msgstr "Error al moment de l'installacion"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "o"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "Ko"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "Mo"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "To"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Amovible :"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Editar"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Atribuir a /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Particion espandida"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Desconeguda"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Modificar la particion"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Modificar la particion"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Periferic :"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Punt de montatge :"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1161,49 +1168,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formatatge de %(partition)s en %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Definicion del nom d'òste"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Configuracion dels paramètres regionals"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Definicion del nom d'òste"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Configuracion de las opcions de clavièr"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Supression dels paquets del sistèma live"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Installacion del cargador d'amorsatge"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Configuracion del cargador d'amorsatge"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1211,15 +1218,15 @@ msgstr ""
 "ATENCION : lo cargador d'amorsatge GRUB es pas estat configurat "
 "corrèctament ! Lo vos cal configurar manualament."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Verificacion del cargador d'amorsatge"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-om.po
+++ b/po/live-installer-om.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2013-10-20 18:51+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Oromo <om@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,140 +149,146 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 msgid "Edit Partitions"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -308,6 +316,699 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+msgid "Keyboard Model"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:73
+msgid "Installation type?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -403,10 +1104,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -433,7 +1130,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr ""
@@ -453,671 +1150,60 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 msgid "Removing extra packages"
 msgstr ""
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr ""
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-msgid "Keyboard Model"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:73
-msgid "Installation type?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""

--- a/po/live-installer-om.po
+++ b/po/live-installer-om.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2013-10-20 18:51+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Oromo <om@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -291,6 +291,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -320,8 +325,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -407,23 +412,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -441,9 +517,102 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -558,18 +727,6 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -601,25 +758,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -854,7 +992,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr ""
 
@@ -873,138 +1011,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1150,60 +1156,60 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 msgid "Removing extra packages"
 msgstr ""
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""

--- a/po/live-installer-pa.po
+++ b/po/live-installer-pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2015-07-17 16:02+0000\n"
 "Last-Translator: Gurdit Singh Bedi <gurditsbedi@gmail.com>\n"
 "Language-Team: Punjabi <pa@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,141 +149,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "ਸਿਸਟਮ ਸੈਟਿੰਗ"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -310,6 +318,702 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "ਕੀਬੋਰਡ ਲੇਆਉਟ: "
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "ਇੰਸਟਾਲੇਸ਼ਨ  ਗਲਤੀ"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "ਕਿਸਮ"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "ਲੇਆਉਟ"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "ਵੇਰੀਐਂਟ"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "ਜੰਤਰ"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "ਅੱਪਰੇਟਿੰਗ ਸਿਸਟਮ"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "ਮਾਊਂਟ ਪੁਆਇੰਟ"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "ਸਾਈਜ਼"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "ਖਾਲੀ ਥਾਂ"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "ਲੋਕਲਾਈਜ਼ੇਸ਼ਨ"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "ਭਾਸ਼ਾ "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "ਸਮਾਂ-ਖੇਤਰ: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "ਕੀਬੋਰਡ ਲੇਆਉਟ: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "ਯੂਜ਼ਰ ਸੈਟਿੰਗ"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "ਅਸਲੀ ਨਾਂ: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "ਯੂਜ਼ਰ ਨਾਂ: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "ਸਿਸਟਮ ਸੈਟਿੰਗ"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "ਫਾਇਲ ਸਿਸਟਮ ਚੋਣਾਂ"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "ਬੂਟਲੋਡਰ ਨਾ ਇੰਸਟਾਲ ਕਰੋ"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "%(partition)s ਨੂੰ %(mountpoint)s ਵਜੋਂ ਮਾਊਂਟ ਕਰੋ"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "ਇੰਸਟਾਲੇਸ਼ਨ ਪੂਰੀ ਹੋਈ"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "ਇੰਸਟਾਲੇਸ਼ਨ  ਗਲਤੀ"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "ਸਿਸਟਮ ਸੈਟਿੰਗ"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -405,10 +1109,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -435,7 +1135,7 @@ msgstr "ਨਵੇਂ ਉਪਭੋਗੀ ਨੂੰ ਸ਼ਾਮਿਲ ਕੀਤ�
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "%(partition)s ਨੂੰ %(mountpoint)s ਵਜੋਂ ਮਾਊਂਟ ਕਰੋ"
@@ -455,49 +1155,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "ਹੋਸਟ-ਨਾਂ ਸੈੱਟ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "ਲੋਕੇਲ ਸੈੱਟ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "ਹੋਸਟ-ਨਾਂ ਸੈੱਟ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "ਕੀਬੋਰਡ ਚੋਣ ਸੈੱਟ ਕੀਤੀ ਜਾ ਰਹੀ ਹੈ"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "ਲਾਈਵ ਸੰਰਚਨਾ ਹਟਾਈ ਜਾ ਰਹੀ ਹੈ (ਪੈਕੇਜ)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "ਬੂਟ ਲੋਡਰ ਇੰਸਟਾਲ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "ਬੂਟਲੋਡਰ ਦੀ ਸੰਰਚਨਾ ਜਾਰੀ"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -505,630 +1205,16 @@ msgstr ""
 "ਚੇਤਾਵਨੀ: ਗਰਬ ਬੂਟਲੋਡਰ ਸਹੀ ਤਰੀਕੇ ਨਾਲ ਕਨਫਿਗਰ ਨਹੀ ਕੀਤਾ ਗਿਆ ਸੀ! ਤੁਹਾਨੂੰ ਇਸ ਨੂੰ ਮੈਨੂਅਲੀ "
 "ਕਨਫਿਗਰ ਕਰਨ ਦੀ ਲੋੜ ਹੈ |"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "ਇੰਸਟਾਲੇਸ਼ਨ ਪੂਰੀ ਹੋਈ"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "ਬੂਟਲੋਡਰ ਦੀ ਜਾਂਚ"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "ਲੇਆਉਟ"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "ਵੇਰੀਐਂਟ"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "ਜੰਤਰ"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "ਕਿਸਮ"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "ਅੱਪਰੇਟਿੰਗ ਸਿਸਟਮ"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "ਮਾਊਂਟ ਪੁਆਇੰਟ"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "ਸਾਈਜ਼"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "ਖਾਲੀ ਥਾਂ"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "ਲੋਕਲਾਈਜ਼ੇਸ਼ਨ"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "ਭਾਸ਼ਾ "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "ਸਮਾਂ-ਖੇਤਰ: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "ਕੀਬੋਰਡ ਲੇਆਉਟ: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "ਯੂਜ਼ਰ ਸੈਟਿੰਗ"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "ਅਸਲੀ ਨਾਂ: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "ਯੂਜ਼ਰ ਨਾਂ: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "ਸਿਸਟਮ ਸੈਟਿੰਗ"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "ਫਾਇਲ ਸਿਸਟਮ ਚੋਣਾਂ"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "ਬੂਟਲੋਡਰ ਨਾ ਇੰਸਟਾਲ ਕਰੋ"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "ਇੰਸਟਾਲੇਸ਼ਨ  ਗਲਤੀ"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "ਕੀਬੋਰਡ ਲੇਆਉਟ: "
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "ਇੰਸਟਾਲੇਸ਼ਨ  ਗਲਤੀ"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "ਸਿਸਟਮ ਸੈਟਿੰਗ"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-pa.po
+++ b/po/live-installer-pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2015-07-17 16:02+0000\n"
 "Last-Translator: Gurdit Singh Bedi <gurditsbedi@gmail.com>\n"
 "Language-Team: Punjabi <pa@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -292,6 +292,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -322,8 +327,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -411,23 +416,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "ਲੇਆਉਟ"
-
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "ਵੇਰੀਐਂਟ"
-
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -445,9 +521,103 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "ਖਾਲੀ ਥਾਂ"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "ਸਿਸਟਮ ਸੈਟਿੰਗ"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "ਲੇਆਉਟ"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "ਵੇਰੀਐਂਟ"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -562,18 +732,6 @@ msgstr ""
 msgid "Size"
 msgstr "ਸਾਈਜ਼"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "ਖਾਲੀ ਥਾਂ"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -605,25 +763,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -858,7 +997,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "ਇੰਸਟਾਲੇਸ਼ਨ ਪੂਰੀ ਹੋਈ"
 
@@ -877,139 +1016,6 @@ msgstr "ਇੰਸਟਾਲੇਸ਼ਨ  ਗਲਤੀ"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "ਸਿਸਟਮ ਸੈਟਿੰਗ"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1155,49 +1161,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "ਹੋਸਟ-ਨਾਂ ਸੈੱਟ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "ਲੋਕੇਲ ਸੈੱਟ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "ਹੋਸਟ-ਨਾਂ ਸੈੱਟ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "ਕੀਬੋਰਡ ਚੋਣ ਸੈੱਟ ਕੀਤੀ ਜਾ ਰਹੀ ਹੈ"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "ਲਾਈਵ ਸੰਰਚਨਾ ਹਟਾਈ ਜਾ ਰਹੀ ਹੈ (ਪੈਕੇਜ)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "ਬੂਟ ਲੋਡਰ ਇੰਸਟਾਲ ਕੀਤਾ ਜਾ ਰਿਹਾ ਹੈ"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "ਬੂਟਲੋਡਰ ਦੀ ਸੰਰਚਨਾ ਜਾਰੀ"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1205,15 +1211,15 @@ msgstr ""
 "ਚੇਤਾਵਨੀ: ਗਰਬ ਬੂਟਲੋਡਰ ਸਹੀ ਤਰੀਕੇ ਨਾਲ ਕਨਫਿਗਰ ਨਹੀ ਕੀਤਾ ਗਿਆ ਸੀ! ਤੁਹਾਨੂੰ ਇਸ ਨੂੰ ਮੈਨੂਅਲੀ "
 "ਕਨਫਿਗਰ ਕਰਨ ਦੀ ਲੋੜ ਹੈ |"
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "ਬੂਟਲੋਡਰ ਦੀ ਜਾਂਚ"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-pl.po
+++ b/po/live-installer-pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2020-02-04 20:38+0000\n"
 "Last-Translator: Kacper Paczos <Unknown>\n"
 "Language-Team: Polish <pl@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Strefa czasowa"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Edycja partycji"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Tryb zaawansowany"
@@ -149,142 +151,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Odśwież"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Sformatuj jako"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Edycja partycji"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Zaloguj automatycznie"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr "Powitanie"
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -315,6 +323,713 @@ msgstr ""
 #, fuzzy
 msgid "Welcome to 17g"
 msgstr "Powitanie"
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "OK"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Nie"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Tak"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Strefa czasowa"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr "Jakiego języka chcesz używać?"
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Język"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr "Gdzie się znajdujesz?"
+
+#: live-installer/frontend/tui_interface.py:57
+#, fuzzy
+msgid "What keyboard would you like to use?"
+msgstr "Jakiego języka chcesz używać?"
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Układ klawiatury"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Instalacja jest wstrzymana"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Rodzaj"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, fuzzy, python-format
+msgid "Welcome to %s"
+msgstr "Powitanie"
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Kraj"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Układ"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Wariant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Obliczanie indeksów plików..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr "Instalator"
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Układ klawiatury"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr "Konto użytkownika"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr "Kim jesteś?"
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Gdzie chcesz zainstalować 17G?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Partycjonowanie"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Podsumowanie"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Wstecz"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Edycja partycji"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Urządzenie"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "System operacyjny"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Punkt montowania"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Sformatuj jako"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Rozmiar"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Wolna przestrzeń"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Zainstaluj"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Twoje hasło nie pasuje."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Zakończyć?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Czy na pewno chcesz opuścić instalator?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Proszę wybrać język"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Prosimy podać hasło dla Twojego konta użytkownika."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Prosimy o podanie swojego pełnego imienia i nazwiska."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Twoje hasło nie pasuje."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "Partycja EFI nie jest rozruchową. Proszę zmienić flagi partycji."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Prosimy wybrać partycję root (/)."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "Partycja EFI nie jest rozruchową. Proszę zmienić flagi partycji."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "Partycja EFI musi zostać sformatowana jako vfat."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "Partycja EFI musi zostać sformatowana jako vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Prosimy zaznaczyć partycję EFI."
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Prosimy podać nazwę użytkownika."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Lokalizacja"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Język: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Strefa czasowa: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Układ klawiatury: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Ustawienia użytkownika"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Imię i nazwisko: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Nazwa użytkownika: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Automatyczne logowanie: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "włączony"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "wyłączony"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Ustawienia systemu"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Operacje systemu plików"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Instalacja programu rozruchowego na %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Nie instaluj programu rozruchowego"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Użyj już zamontowanego /target."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Sformatuj %(path)s jako %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Zamontuj %(path)s jako %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Zamontuj %(path)s jako %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Instalacja zakończona"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Instalacja jest już ukończona. Czy chcesz uruchomić ponownie komputer, aby "
+"móc użyć nowego systemu?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Błąd instalacyjny"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Wymienny:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Edycja"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Przypisz do /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Partycja logiczna"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Partycja rozszerzona"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Nieznane"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Edycja partycji"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Edycja partycji"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Urządzenie:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Formatuj jako:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Punkt montowania:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Anuluj"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
+msgstr ""
 
 #: live-installer/validate.py:12
 msgid "Please provide a username."
@@ -422,10 +1137,6 @@ msgstr "Twoje hasło nie pasuje."
 msgid "Please provide a password for your user account."
 msgstr "Prosimy podać hasło dla Twojego konta użytkownika."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -452,7 +1163,7 @@ msgstr "Dodawanie nowego użytkownika do systemu"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Zapisywanie informacji montowania systemu plików do /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Montowanie %(partition)s na %(mountpoint)s"
@@ -472,49 +1183,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formatowanie %(partition)s jako %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Ustawianie nazwy komputera"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Ustawianie opcji lokalnych"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Ustawianie nazwy komputera"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Ustawianie opcji klawiatury"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Usuwanie konfiguracji live (pakiety)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Instalowanie programu rozruchowego"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Konfigurowanie programu rozruchowego"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -522,642 +1233,17 @@ msgstr ""
 "OSTRZEŻENIE: Program rozruchowy grub nie został poprawnie skonfigurowany! "
 "Zachodzi potrzeba jego ręcznego skonfigurowania."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Instalacja zakończona"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Sprawdzanie programu rozruchowego"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Kraj"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Język"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Układ"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Wariant"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Obliczanie indeksów plików..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr "Instalator"
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr "Jakiego języka chcesz używać?"
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr "Gdzie się znajdujesz?"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Układ klawiatury"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr "Konto użytkownika"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr "Kim jesteś?"
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Gdzie chcesz zainstalować 17G?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Partycjonowanie"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Podsumowanie"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Wstecz"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Edycja partycji"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Urządzenie"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Rodzaj"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "System operacyjny"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Punkt montowania"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Sformatuj jako"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Rozmiar"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Wolna przestrzeń"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Zainstaluj"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Twoje hasło nie pasuje."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Zakończyć?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Czy na pewno chcesz opuścić instalator?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Proszę wybrać język"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Prosimy podać hasło dla Twojego konta użytkownika."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Prosimy o podanie swojego pełnego imienia i nazwiska."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Twoje hasło nie pasuje."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "Partycja EFI nie jest rozruchową. Proszę zmienić flagi partycji."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Prosimy wybrać partycję root (/)."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "Partycja EFI nie jest rozruchową. Proszę zmienić flagi partycji."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "Partycja EFI musi zostać sformatowana jako vfat."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "Partycja EFI musi zostać sformatowana jako vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Prosimy zaznaczyć partycję EFI."
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Prosimy podać nazwę użytkownika."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Lokalizacja"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Język: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Strefa czasowa: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Układ klawiatury: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Ustawienia użytkownika"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Imię i nazwisko: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Nazwa użytkownika: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Automatyczne logowanie: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "włączony"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "wyłączony"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Ustawienia systemu"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Operacje systemu plików"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Instalacja programu rozruchowego na %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Nie instaluj programu rozruchowego"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Użyj już zamontowanego /target."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Sformatuj %(path)s jako %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Zamontuj %(path)s jako %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Instalacja jest już ukończona. Czy chcesz uruchomić ponownie komputer, aby "
-"móc użyć nowego systemu?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Błąd instalacyjny"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, fuzzy, python-format
-msgid "Welcome to %s"
-msgstr "Powitanie"
-
-#: live-installer/frontend/tui_interface.py:57
-#, fuzzy
-msgid "What keyboard would you like to use?"
-msgstr "Jakiego języka chcesz używać?"
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Układ klawiatury"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Instalacja jest wstrzymana"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Strefa czasowa"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Wymienny:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Edycja"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Przypisz do /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Partycja logiczna"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Partycja rozszerzona"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Nieznane"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Edycja partycji"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Edycja partycji"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Urządzenie:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Formatuj jako:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Punkt montowania:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Anuluj"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "OK"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Nie"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Tak"
 
 #~ msgid "Quit"
 #~ msgstr "Wyjdź"

--- a/po/live-installer-pl.po
+++ b/po/live-installer-pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2020-02-04 20:38+0000\n"
 "Last-Translator: Kacper Paczos <Unknown>\n"
 "Language-Team: Polish <pl@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -189,9 +189,9 @@ msgid "Format"
 msgstr "Sformatuj jako"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -295,6 +295,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Sformatuj jako"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -326,8 +332,8 @@ msgstr "Powitanie"
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "OK"
 
@@ -417,23 +423,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr "Powitanie"
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Kraj"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Układ"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Wariant"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Obliczanie indeksów plików..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Wymienny:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Edycja"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Przypisz do /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -451,10 +528,104 @@ msgstr "Obliczanie indeksów plików..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr "Instalator"
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Wolna przestrzeń"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Partycja logiczna"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Partycja rozszerzona"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Nieznane"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Edycja partycji"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Edycja partycji"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Urządzenie:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Formatuj jako:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Punkt montowania:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Anuluj"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Kraj"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Układ"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Wariant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Obliczanie indeksów plików..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -569,18 +740,6 @@ msgstr "Sformatuj jako"
 msgid "Size"
 msgstr "Rozmiar"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Wolna przestrzeń"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -613,25 +772,6 @@ msgstr "Zakończyć?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Czy na pewno chcesz opuścić instalator?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -871,7 +1011,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Instalacja zakończona"
 
@@ -892,139 +1032,6 @@ msgstr "Błąd instalacyjny"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Wymienny:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Edycja"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Przypisz do /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Partycja logiczna"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Partycja rozszerzona"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Nieznane"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Edycja partycji"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Edycja partycji"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Urządzenie:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Formatuj jako:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Punkt montowania:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Anuluj"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1183,49 +1190,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formatowanie %(partition)s jako %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Ustawianie nazwy komputera"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Ustawianie opcji lokalnych"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Ustawianie nazwy komputera"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Ustawianie opcji klawiatury"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Usuwanie konfiguracji live (pakiety)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Instalowanie programu rozruchowego"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Konfigurowanie programu rozruchowego"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1233,15 +1240,15 @@ msgstr ""
 "OSTRZEŻENIE: Program rozruchowy grub nie został poprawnie skonfigurowany! "
 "Zachodzi potrzeba jego ręcznego skonfigurowania."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Sprawdzanie programu rozruchowego"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-pt.po
+++ b/po/live-installer-pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2023-10-31 23:07+0000\n"
 "Last-Translator: Hugo Carvalho <hugokarvalho@hotmail.com>\n"
 "Language-Team: Portuguese <hugokarvalho@hotmail.com>\n"
@@ -24,8 +24,8 @@ msgid "Welcome to the 17g Installer."
 msgstr "Bem-vindo ao Instalador 17g."
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
@@ -33,12 +33,12 @@ msgstr ""
 "computador."
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr "Aceito os termos do Acordo de Licença"
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr "Modelo do teclado:"
 
@@ -47,10 +47,12 @@ msgid "Type here to test your keyboard"
 msgstr "Escreva algo aqui para testar o teclado"
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr "etiqueta"
 
@@ -59,13 +61,13 @@ msgid "Continent"
 msgstr "Continente"
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Fuso horário"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr "Instalação automatizada"
 
@@ -74,12 +76,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr "Apagar disco e instalar o LMDE."
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr "Disco:"
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr "Criar partição swap"
 
@@ -89,42 +91,42 @@ msgstr "1"
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr "Utilizar LVM (Logical Volume Management)"
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr "Encriptar o sistema operativo"
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr "Palavra-passe"
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr "Confirmação de palavra-passse"
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr "Isto proporciona segurança extra, mas pode levar horas."
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr "Preenche o disco com dados aleatórios"
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr "Particionamento manual"
 
@@ -141,7 +143,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr "Remover o Windows existente e instalar o LMDE."
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr "Modo avançado"
 
@@ -150,12 +152,12 @@ msgid "The setup tool will not do partitioning."
 msgstr "A ferramenta de configuração não irá fazer a particionamento."
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr "Instalação mínima"
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
@@ -164,130 +166,136 @@ msgstr ""
 "utilitários."
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr "Instalar o sistema com atualizações"
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr "Se ligar a Internet, as atualizações serão instaladas."
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Recarregar"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr "Eliminar"
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr "Formatar"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr "Criar"
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr "Instalar menu de arranque GRUB em:"
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 msgid "Edit Partitions"
 msgstr "Editar partições"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr "Legacy"
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr "O seu nome:"
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr "O nome do seu computador:"
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr "Escolha um nome de utilizador:"
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 "O nome que este computador utiliza para comunicar com outros computadores."
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr "Escolha uma palavra-passe:"
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Iniciar sessão automaticamente"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr "Pedir palavra-passe para iniciar sessão"
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr "Encriptar a minha pasta pessoal"
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr "Confirme a sua palavra-passe:"
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr "O comprimento deve ter no mínimo 8 caracteres"
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr "Instalação automatizada ativada!"
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr "0.0"
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr "Não desligue o computador durante o processo de instalação."
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr "Equipa 17g"
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr "Bem-vindo"
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr "/dev/sda1"
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
 msgstr "apenas leitura"
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
+msgstr ""
 
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
@@ -317,6 +325,733 @@ msgstr ""
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
 msgstr "Bem-vindo ao 17g"
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "OK"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Não"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Sim"
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr "Selecionar fuso horário"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr "Bem-vindo ao Instalador %s."
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr "Qual é o idioma que deseja utilizar?"
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Idioma"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr "Qual é a sua localização?"
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr "Qual teclado gostaria de utilizar?"
+
+#: live-installer/frontend/tui_interface.py:64
+msgid "Keyboard Model"
+msgstr "Modelo do teclado"
+
+#: live-installer/frontend/tui_interface.py:73
+msgid "Installation type?"
+msgstr "Tipo de instalação?"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Tipo"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr "Selecionar um disco?"
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr "Disco"
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr "Experimentar o %s"
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr "Está atualmente a executar o %s a partir do meio de suporte 'live'."
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+"Pode instalar o %s agora, ou escolher \"Instalar no disco rígido\" no Menu "
+"de Aplicações mais tarde."
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr "Bem-vindo ao %s"
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "País"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Disposição"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variante"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "A calcular índice de ficheiros..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr "Instalador"
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr "Acordo de Licença"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Disposição do teclado"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr "Qual é o seu esquema de teclado?"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr "Conta de utilizador"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr "Quem é você?"
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr "Tipo de instalação"
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr "Onde pretende instalar o sistema?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Particionamento"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Resumo"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr "Verifique se tudo está correto"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr "A instalar"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr "Aguarde..."
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+#, fuzzy
+msgid "Automated Install"
+msgstr "Instalação automatizada"
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Voltar"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr "Seguinte"
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr "Escreva algo aqui para testar a disposição do teclado"
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr "Apagar um disco e instalar um sistema no mesmo."
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+"Criar, redimensionar ou escolher manualmente as partições para o sistema."
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr "A ferramenta de configuração não irá fazer o particionamento"
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr "Remover o Windows e Instalar"
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr "Remover o Windows existente e instalar o sistema."
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Editar partições"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Dispositivo"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Sistema operativo"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Ponto de montagem"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Formatar como"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Tamanho"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Espaço livre"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr "Apenas leitura"
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr "Aviso"
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr "Está prestes a eliminar todos os dados em %s. Tem a certeza?"
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Instalar"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr "Introduza a palavra-passe para a encriptação."
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "As suas palavras-passe não coincidem."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Sair?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Sair do instalador?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr "Tem a certeza?"
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr "Nova partição será criada em {}"
+
+#: live-installer/frontend/gtk_interface.py:1009
+#, fuzzy
+msgid "subvolume {} will removed from {}."
+msgstr "A partição {} será removida de {}."
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr "A partição {} será removida de {}."
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr "A partição {} será formada de {}."
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Escolha o idioma"
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Forneça uma disposição de teclado para o seu computador."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Introduza o nome completo."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr "As suas palavras-passe não são fortes."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+"Tipo de sistema de ficheiros root não especificado. A instalação continuará "
+"sem a formatação do disco. Quer continuar?"
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+"A partição root é demasiado pequena. Deveria ter pelo menos 16 GB. Quer "
+"continuar?"
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Selecione uma partição root (/)."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+"Necessita de uma partição 'root' para instalar o %s.\n"
+"\n"
+" - Ponto de montagem: /\n"
+" - Tamanho recomendado: 30GB\n"
+" - Sistema de ficheiros recomendado: ext4\n"
+"\n"
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+"A partição EFI não é de arranque. Quer definir uma 'flag' de arranque(boot)?"
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "A partição EFI é demasiado pequena. Deve ter pelo menos 100MB."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "A partição EFI tem que ser formatada como vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Selecione a partição EFI."
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+"Necessita de uma partição de sistema EFI com os seguintes requisitos:\n"
+"\n"
+" - Ponto de montagem: /boot/efi\n"
+" - Flags de partição: Bootable\n"
+" - Tamanho: no mínimo 100MB\n"
+" - Formato: vfat ou fat32\n"
+"\n"
+"Para assegurar compatibilidade com sistemas Windows, recomendamos que "
+"utilize a primeira partição do disco como a partição de sistema EFI.\n"
+" "
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr "Selecione um disco."
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr "Forneça um dispositivo para instalar o grub."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Localização"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Idioma: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Fuso horário: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Disposição do teclado: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Definições de utilizador"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Nome verdadeiro: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Nome de utilizador: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr "Palavra-passe: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Início de sessão automático: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "ativo"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "inativo"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Definições do sistema"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr "Nome do computador: "
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr "Tipo de BIOS: "
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr "Instalar atualizações após a instalação"
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Operações de sistema de ficheiros"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Instalar carregador de arranque em %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Não instalar carregador de arranque"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Utilizar /target montado."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr " (com %s GB swap)"
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr "Instalação automatizada em %s"
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Formatar %(path)s como %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Montar %(path)s como %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Montar %(path)s como %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr "LVM: "
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr "Encriptação de disco: "
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Instalação concluída"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"A instalação está agora concluída. Deseja reiniciar o computador agora e "
+"utilizar o seu novo sistema?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Erro de instalação"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr "Erro"
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Removível:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Editar"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr "Atribuir a %s"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+"Disco: tabela de partições {} corrompida ou não existe. Quer criar uma nova "
+"tabela de partições?"
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"A tabela de partição não pôde ser escrita para %s. Reinicie o computador e "
+"tente novamente."
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"A partição %s não pôde ser criada. A instalação irá parar. Reinicie o "
+"computador e tente novamente."
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Partição lógica"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Partição expandida"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Desconhecido"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr "bootloader/recovery"
+
+#: live-installer/frontend/partitioning.py:742
+msgid "EFI System Partition"
+msgstr "Partição do sistema EFI"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Editar partição"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Dispositivo:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Formatar como:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Ponto de montagem:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
+msgstr "Tem de ser o root!"
 
 #: live-installer/validate.py:12
 msgid "Please provide a username."
@@ -413,10 +1148,6 @@ msgstr "A sua palavra-passe deve ter números"
 msgid "Please provide a password for your user account."
 msgstr "Introduza a palavra-passe da sua conta de utilizador."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr "Tem de ser o root!"
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -444,7 +1175,7 @@ msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 "A gravar a informação de montagem do sistema de ficheiros em /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "A montar %(partition)s em %(mountpoint)s"
@@ -465,47 +1196,47 @@ msgstr "A criar partições em %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "A formatar %(partition)s como %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "A definir nome da máquina"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "A definir idioma"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 msgid "Setting timezone"
 msgstr "A definir fuso horário"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "A definir opções de teclado"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 msgid "Removing extra packages"
 msgstr "A remover pacotes extra"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr "A limpar o gestor de pacotes"
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr "A gerar initramfs"
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr "A preparar a instalação do carregador de arranque"
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "A instalar carregador de arranque"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "A configurar carregador de arranque"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -513,660 +1244,17 @@ msgstr ""
 "Aviso: o carregador de arranque Grub não foi configurado corretamente! Terá "
 "que o configurar manualmente."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr "A tentar instalar atualizações"
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Instalação concluída"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "A verificar carregador de arranque"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr "Falha ao executar o comando (Saiu com {}):"
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "País"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Idioma"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Disposição"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Variante"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "A calcular índice de ficheiros..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr "Instalador"
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr "Acordo de Licença"
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr "Qual é o idioma que deseja utilizar?"
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr "Qual é a sua localização?"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Disposição do teclado"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr "Qual é o seu esquema de teclado?"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr "Conta de utilizador"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr "Quem é você?"
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr "Tipo de instalação"
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr "Onde pretende instalar o sistema?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Particionamento"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Resumo"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr "Verifique se tudo está correto"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr "A instalar"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr "Aguarde..."
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr "Instalação automatizada"
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Voltar"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr "Seguinte"
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr "Bem-vindo ao Instalador %s."
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr "Escreva algo aqui para testar a disposição do teclado"
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr "Apagar um disco e instalar um sistema no mesmo."
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-"Criar, redimensionar ou escolher manualmente as partições para o sistema."
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr "A ferramenta de configuração não irá fazer o particionamento"
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr "Remover o Windows e Instalar"
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr "Remover o Windows existente e instalar o sistema."
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Editar partições"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Dispositivo"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Tipo"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Sistema operativo"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Ponto de montagem"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Formatar como"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Tamanho"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Espaço livre"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr "Apenas leitura"
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Instalar"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr "Introduza a palavra-passe para a encriptação."
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "As suas palavras-passe não coincidem."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Sair?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Sair do instalador?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr "Tem a certeza?"
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr "Nova partição será criada em {}"
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr "A partição {} será removida de {}."
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr "A partição {} será formada de {}."
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Escolha o idioma"
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Forneça uma disposição de teclado para o seu computador."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Introduza o nome completo."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr "As suas palavras-passe não são fortes."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-"Tipo de sistema de ficheiros root não especificado. A instalação continuará "
-"sem a formatação do disco. Quer continuar?"
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-"A partição root é demasiado pequena. Deveria ter pelo menos 16 GB. Quer "
-"continuar?"
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Selecione uma partição root (/)."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-"Necessita de uma partição 'root' para instalar o %s.\n"
-"\n"
-" - Ponto de montagem: /\n"
-" - Tamanho recomendado: 30GB\n"
-" - Sistema de ficheiros recomendado: ext4\n"
-"\n"
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-"A partição EFI não é de arranque. Quer definir uma 'flag' de arranque(boot)?"
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "A partição EFI é demasiado pequena. Deve ter pelo menos 100MB."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "A partição EFI tem que ser formatada como vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Selecione a partição EFI."
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-"Necessita de uma partição de sistema EFI com os seguintes requisitos:\n"
-"\n"
-" - Ponto de montagem: /boot/efi\n"
-" - Flags de partição: Bootable\n"
-" - Tamanho: no mínimo 100MB\n"
-" - Formato: vfat ou fat32\n"
-"\n"
-"Para assegurar compatibilidade com sistemas Windows, recomendamos que "
-"utilize a primeira partição do disco como a partição de sistema EFI.\n"
-" "
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr "Selecione um disco."
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr "Aviso"
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr "Está prestes a eliminar todos os dados em %s. Tem a certeza?"
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr "Forneça um dispositivo para instalar o grub."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Localização"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Idioma: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Fuso horário: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Disposição do teclado: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Definições de utilizador"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Nome verdadeiro: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Nome de utilizador: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr "Palavra-passe: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Início de sessão automático: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "ativo"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "inativo"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Definições do sistema"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr "Nome do computador: "
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr "Tipo de BIOS: "
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr "Instalar atualizações após a instalação"
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Operações de sistema de ficheiros"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Instalar carregador de arranque em %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Não instalar carregador de arranque"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Utilizar /target montado."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr " (com %s GB swap)"
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr "Instalação automatizada em %s"
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Formatar %(path)s como %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Montar %(path)s como %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr "LVM: "
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr "Encriptação de disco: "
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"A instalação está agora concluída. Deseja reiniciar o computador agora e "
-"utilizar o seu novo sistema?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Erro de instalação"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr "Erro"
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr "Experimentar o %s"
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr "Está atualmente a executar o %s a partir do meio de suporte 'live'."
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-"Pode instalar o %s agora, ou escolher \"Instalar no disco rígido\" no Menu "
-"de Aplicações mais tarde."
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr "Bem-vindo ao %s"
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr "Qual teclado gostaria de utilizar?"
-
-#: live-installer/frontend/tui_interface.py:64
-msgid "Keyboard Model"
-msgstr "Modelo do teclado"
-
-#: live-installer/frontend/tui_interface.py:73
-msgid "Installation type?"
-msgstr "Tipo de instalação?"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr "Selecionar um disco?"
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr "Disco"
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr "Selecionar fuso horário"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Removível:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Editar"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr "Atribuir a %s"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-"Disco: tabela de partições {} corrompida ou não existe. Quer criar uma nova "
-"tabela de partições?"
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"A tabela de partição não pôde ser escrita para %s. Reinicie o computador e "
-"tente novamente."
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"A partição %s não pôde ser criada. A instalação irá parar. Reinicie o "
-"computador e tente novamente."
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Partição lógica"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Partição expandida"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Desconhecido"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr "bootloader/recovery"
-
-#: live-installer/frontend/partitioning.py:582
-msgid "EFI System Partition"
-msgstr "Partição do sistema EFI"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Editar partição"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Dispositivo:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Formatar como:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Ponto de montagem:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "OK"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Não"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Sim"
 
 #~ msgid "Quit"
 #~ msgstr "Sair"

--- a/po/live-installer-pt.po
+++ b/po/live-installer-pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2023-10-31 23:07+0000\n"
 "Last-Translator: Hugo Carvalho <hugokarvalho@hotmail.com>\n"
 "Language-Team: Portuguese <hugokarvalho@hotmail.com>\n"
@@ -91,7 +91,7 @@ msgstr "1"
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -191,9 +191,9 @@ msgid "Format"
 msgstr "Formatar"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr "Criar"
 
@@ -297,6 +297,12 @@ msgstr "apenas leitura"
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Formatar como"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr "Experimentar 17g"
@@ -328,8 +334,8 @@ msgstr "Bem-vindo ao 17g"
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "OK"
 
@@ -417,23 +423,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr "Bem-vindo ao %s"
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "País"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Disposição"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Variante"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "A calcular índice de ficheiros..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Removível:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr "Apenas leitura"
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Editar"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr "Atribuir a %s"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -451,10 +528,109 @@ msgstr "A calcular índice de ficheiros..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr "Instalador"
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+"Disco: tabela de partições {} corrompida ou não existe. Quer criar uma nova "
+"tabela de partições?"
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Espaço livre"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"A tabela de partição não pôde ser escrita para %s. Reinicie o computador e "
+"tente novamente."
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"A partição %s não pôde ser criada. A instalação irá parar. Reinicie o "
+"computador e tente novamente."
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Partição lógica"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Partição expandida"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Desconhecido"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr "bootloader/recovery"
+
+#: live-installer/frontend/partitioning.py:754
+msgid "EFI System Partition"
+msgstr "Partição do sistema EFI"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Editar partição"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Dispositivo:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Formatar como:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Ponto de montagem:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "País"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Disposição"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variante"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "A calcular índice de ficheiros..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -570,18 +746,6 @@ msgstr "Formatar como"
 msgid "Size"
 msgstr "Tamanho"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Espaço livre"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr "Apenas leitura"
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -614,25 +778,6 @@ msgstr "Sair?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Sair do instalador?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -888,7 +1033,7 @@ msgid "Disk Encryption: "
 msgstr "Encriptação de disco: "
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Instalação concluída"
 
@@ -910,144 +1055,6 @@ msgstr "Erro de instalação"
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
 msgstr "Erro"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Removível:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Editar"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr "Atribuir a %s"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-"Disco: tabela de partições {} corrompida ou não existe. Quer criar uma nova "
-"tabela de partições?"
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"A tabela de partição não pôde ser escrita para %s. Reinicie o computador e "
-"tente novamente."
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"A partição %s não pôde ser criada. A instalação irá parar. Reinicie o "
-"computador e tente novamente."
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Partição lógica"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Partição expandida"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Desconhecido"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr "bootloader/recovery"
-
-#: live-installer/frontend/partitioning.py:742
-msgid "EFI System Partition"
-msgstr "Partição do sistema EFI"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Editar partição"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Dispositivo:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Formatar como:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Ponto de montagem:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
-msgstr ""
 
 #: live-installer/main.py:38
 msgid "You must be root!"
@@ -1196,47 +1203,47 @@ msgstr "A criar partições em %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "A formatar %(partition)s como %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "A definir nome da máquina"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "A definir idioma"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 msgid "Setting timezone"
 msgstr "A definir fuso horário"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "A definir opções de teclado"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 msgid "Removing extra packages"
 msgstr "A remover pacotes extra"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr "A limpar o gestor de pacotes"
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr "A gerar initramfs"
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr "A preparar a instalação do carregador de arranque"
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "A instalar carregador de arranque"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "A configurar carregador de arranque"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1244,15 +1251,15 @@ msgstr ""
 "Aviso: o carregador de arranque Grub não foi configurado corretamente! Terá "
 "que o configurar manualmente."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr "A tentar instalar atualizações"
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "A verificar carregador de arranque"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr "Falha ao executar o comando (Saiu com {}):"
 

--- a/po/live-installer-pt_BR.po
+++ b/po/live-installer-pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2020-03-10 18:54+0000\n"
 "Last-Translator: Alberlan Lopes <alberlan@gmail.com>\n"
 "Language-Team: Brazilian Portuguese <pt_BR@li.org>\n"
@@ -94,7 +94,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -196,9 +196,9 @@ msgid "Format"
 msgstr "Formatar como"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -303,6 +303,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Formatar como"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -334,8 +340,8 @@ msgstr "Bem Vindo"
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "OK"
 
@@ -427,23 +433,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr "Bem Vindo"
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "País"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Leiaute"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Variante"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Calculando índices de arquivo..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Removível:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Editar"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Atribuir à /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -461,10 +538,108 @@ msgstr "Calculando índices de arquivo..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr "Instalador"
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Espaço livre"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"A tabela de partições não pode ser gravada em %s. Reinicie o computador e "
+"tente novamente."
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"A partição %s não pode ser criada. A instalação será interrompida. Reinicie "
+"o computador e tente novamente."
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Partição lógica"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Partição estendida"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Desconhecido(a)"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Editar partição"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Editar partição"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Dispositivo:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Formatar como:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Ponto de montagem:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "País"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Leiaute"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variante"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Calculando índices de arquivo..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -582,18 +757,6 @@ msgstr "Formatar como"
 msgid "Size"
 msgstr "Tamanho"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Espaço livre"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -626,25 +789,6 @@ msgstr "Sair?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Tem certeza de que deseja sair do instalador?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -907,7 +1051,7 @@ msgid "Disk Encryption: "
 msgstr "Criptografia de disco: "
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Instalação concluída"
 
@@ -928,143 +1072,6 @@ msgstr "Erro na instalação"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Removível:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Editar"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Atribuir à /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"A tabela de partições não pode ser gravada em %s. Reinicie o computador e "
-"tente novamente."
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"A partição %s não pode ser criada. A instalação será interrompida. Reinicie "
-"o computador e tente novamente."
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Partição lógica"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Partição estendida"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Desconhecido(a)"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Editar partição"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Editar partição"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Dispositivo:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Formatar como:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Ponto de montagem:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1228,49 +1235,49 @@ msgstr "Criando partições no %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formatando %(partition)s como %(format)s..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Definindo o nome do host"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Definindo localização"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Definindo o nome do host"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Definindo opções de teclado"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Removendo configuração live (pacotes)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Instalando o carregador de inicialização"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Configurando o carregador de inicialização"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1278,15 +1285,15 @@ msgstr ""
 "ATENÇÃO: O carregador de inicialização GRUB não foi configurado "
 "corretamente! Você irá precisar configurar manualmente."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Verificando o carregador de inicialização"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-pt_BR.po
+++ b/po/live-installer-pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2020-03-10 18:54+0000\n"
 "Last-Translator: Alberlan Lopes <alberlan@gmail.com>\n"
 "Language-Team: Brazilian Portuguese <pt_BR@li.org>\n"
@@ -24,8 +24,8 @@ msgid "Welcome to the 17g Installer."
 msgstr "Bem-vindo ao instalador do 17G."
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 #, fuzzy
 msgid ""
 "This program will ask you some questions and set up system on your computer."
@@ -33,12 +33,12 @@ msgstr ""
 "Este programa fará algumas perguntas e configurará o 17G no seu computador."
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr "Modelo do teclado:"
 
@@ -48,10 +48,12 @@ msgid "Type here to test your keyboard"
 msgstr "Digite aqui para testar o layout do teclado"
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -60,13 +62,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Fuso horário"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr "Instalação automatizada"
 
@@ -76,12 +78,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr "Apaguar um disco e instale o 17G nele."
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr "Disco:"
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Editar partição"
@@ -92,42 +94,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr "Use LVM (Gerenciamento de volume lógico)"
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr "Criptografar o sistema operacional"
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr "Frase de acesso"
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr "Confirmar senha"
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr "Isto fornece segurança extra mas pode levar horas."
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr "Preenchendo o disco com dados aleatórios"
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr "Particionamento Manual"
 
@@ -145,7 +147,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Modo avançado"
@@ -155,144 +157,150 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 #, fuzzy
 msgid "Minimal installation"
 msgstr "Instalação automatizada"
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Atualizar"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Formatar como"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr "Instale o menu de inicialização do GRUB em:"
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Editar partições"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr "Seu nome:"
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr "Nome do seu computador:"
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr "Escolha um nome de usuário:"
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr "O nome que ele usa quando se comunica com outros computadores."
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr "Escolha uma senha:"
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Iniciar sessão automaticamente"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr "Solicitar minha senha para entrar"
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr "Criptografar minha pasta pessoal"
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr "Confirme sua senha:"
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 #, fuzzy
 msgid "Automated installation enabled!"
 msgstr "Instalação automatizada em %s"
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr "Bem Vindo"
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -323,6 +331,745 @@ msgstr ""
 #, fuzzy
 msgid "Welcome to 17g"
 msgstr "Bem Vindo"
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "OK"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Não"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Sim"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Fuso horário"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, fuzzy, python-format
+msgid "Welcome to the %s Installer."
+msgstr "Bem-vindo ao instalador do 17G."
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr "Qual idioma você gostaria de usar?"
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Idioma"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr "Onde você está?"
+
+#: live-installer/frontend/tui_interface.py:57
+#, fuzzy
+msgid "What keyboard would you like to use?"
+msgstr "Qual idioma você gostaria de usar?"
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Modelo do teclado:"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Tipo de instalação"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Tipo"
+
+#: live-installer/frontend/tui_interface.py:80
+#, fuzzy
+msgid "Select a disk?"
+msgstr "Por favor, selecione um disco."
+
+#: live-installer/frontend/tui_interface.py:84
+#, fuzzy
+msgid "Disk"
+msgstr "Disco:"
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, fuzzy, python-format
+msgid "Welcome to %s"
+msgstr "Bem Vindo"
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "País"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Leiaute"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variante"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Calculando índices de arquivo..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr "Instalador"
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Leiaute do teclado"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr "Qual é o seu layout de teclado?"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr "Conta de usuário"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr "Quem é você?"
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr "Tipo de instalação"
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Onde você deseja instalar o 17G?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Particionando"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Resumo"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr "Instalando"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+#, fuzzy
+msgid "Automated Install"
+msgstr "Instalação automatizada"
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Voltar"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr "Próxima"
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr "Digite aqui para testar o layout do teclado"
+
+#: live-installer/frontend/gtk_interface.py:546
+#, fuzzy
+msgid "Erase a disk and install system on it."
+msgstr "Apaguar um disco e instale o 17G nele."
+
+#: live-installer/frontend/gtk_interface.py:559
+#, fuzzy
+msgid "Manually create, resize or choose partitions for system."
+msgstr "Crie, redimensione ou escolha manualmente partições para o 17G."
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Editar partições"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Dispositivo"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Sistema operacional"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Ponto de montagem"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Formatar como"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Tamanho"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Espaço livre"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr "Atenção"
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr "Isso excluirá todos os dados em%s. Você tem certeza?"
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Instalar"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr "Forneça uma senha para a criptografia."
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Suas senhas não coincidem."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Sair?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Tem certeza de que deseja sair do instalador?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Por favor, escolha um idioma"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Por favor escolha um nome para sau computador."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Por favor, informe seu nome completo."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Suas senhas não coincidem."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "A partição EFI é muito pequena. Deve ter pelo menos 35 MB."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Por favor, selecione uma partição raiz (/)."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, fuzzy, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+"É necessária uma partição raiz para instalar o Linux Mint.\n"
+"\n"
+" -Ponto de montagem: /\n"
+" -Tamanho recomendado: 30GB\n"
+" -Formato de sistema de arquivos recomendado: ext4\n"
+"\n"
+"Nota: O recurso de capturas instantâneas do btrfs com mudança de horário "
+"requer o uso de:\n"
+" -subvolume Ponto de montagem /@\n"
+" -btrfs como formato de sistema de arquivos\n"
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+"A partição EFI não é inicializável. Por favor, edite as flags da partição."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "A partição EFI é muito pequena. Deve ter pelo menos 35 MB."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "A partição EFI deve ser formatada como vfat"
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Por favor, selecione uma partição EFI."
+
+#: live-installer/frontend/gtk_interface.py:1301
+#, fuzzy
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+"É necessária uma partição do sistema EFI com os seguintes requisitos:\n"
+"\n"
+" - Ponto de montagem: /boot/efi\n"
+" - Sinalizadores de partição: inicializável\n"
+" - Tamanho: pelo menos 35 MB (100 MB ou mais recomendado)\n"
+" - Formato: vfat ou fat32\n"
+"\n"
+"Para garantir a compatibilidade com o Windows, nós recomendamos que você use "
+"a primeira partição do disco como a partição do sistema EFI.\n"
+" "
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr "Por favor, selecione um disco."
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Por favor, informe um nome de usuário."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Localização"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Idioma: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Fuso horário: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Leiaute do teclado: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Configurações de usuário"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Nome completo: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Nome de usuário: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Início de sessão automático "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "ativado"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "desativado"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Configurações do sistema"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr "Nome do computador: "
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+#, fuzzy
+msgid "Install updates after installation"
+msgstr "Instalação automatizada"
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Operações de sistema de arquivos"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Instalar o carregador de inicialização em %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Não instalar o carregador de inicialização"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Utilizar /target já montada."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr "Instalação automatizada em %s"
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Formatar %(path)s em %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Montar %(path)s em %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Montar %(path)s em %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr "LVM: "
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr "Criptografia de disco: "
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Instalação concluída"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Instalação completa. Você deseja reiniciar o computador para utilizar o novo "
+"sistema?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Erro na instalação"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Removível:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Editar"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Atribuir à /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"A tabela de partições não pode ser gravada em %s. Reinicie o computador e "
+"tente novamente."
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"A partição %s não pode ser criada. A instalação será interrompida. Reinicie "
+"o computador e tente novamente."
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Partição lógica"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Partição estendida"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Desconhecido(a)"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Editar partição"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Editar partição"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Dispositivo:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Formatar como:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Ponto de montagem:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
+msgstr ""
 
 #: live-installer/validate.py:12
 msgid "Please provide a username."
@@ -432,10 +1179,6 @@ msgstr "Suas senhas não coincidem."
 msgid "Please provide a password for your user account."
 msgstr "Por favor, informe uma senha para sua conta de usuário."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -463,7 +1206,7 @@ msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 "Gravando informações para a montagem do sistema de arquivos em /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Montando %(partition)s em %(mountpoint)s"
@@ -485,49 +1228,49 @@ msgstr "Criando partições no %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formatando %(partition)s como %(format)s..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Definindo o nome do host"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Definindo localização"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Definindo o nome do host"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Definindo opções de teclado"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Removendo configuração live (pacotes)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Instalando o carregador de inicialização"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Configurando o carregador de inicialização"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -535,674 +1278,17 @@ msgstr ""
 "ATENÇÃO: O carregador de inicialização GRUB não foi configurado "
 "corretamente! Você irá precisar configurar manualmente."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Instalação concluída"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Verificando o carregador de inicialização"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "País"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Idioma"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Leiaute"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Variante"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Calculando índices de arquivo..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr "Instalador"
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr "Qual idioma você gostaria de usar?"
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr "Onde você está?"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Leiaute do teclado"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr "Qual é o seu layout de teclado?"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr "Conta de usuário"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr "Quem é você?"
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr "Tipo de instalação"
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Onde você deseja instalar o 17G?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Particionando"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Resumo"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr "Instalando"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-#, fuzzy
-msgid "Automated install"
-msgstr "Instalação automatizada"
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Voltar"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr "Próxima"
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, fuzzy, python-format
-msgid "Welcome to the %s Installer."
-msgstr "Bem-vindo ao instalador do 17G."
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr "Digite aqui para testar o layout do teclado"
-
-#: live-installer/frontend/gtk_interface.py:542
-#, fuzzy
-msgid "Erase a disk and install system on it."
-msgstr "Apaguar um disco e instale o 17G nele."
-
-#: live-installer/frontend/gtk_interface.py:555
-#, fuzzy
-msgid "Manually create, resize or choose partitions for system."
-msgstr "Crie, redimensione ou escolha manualmente partições para o 17G."
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Editar partições"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Dispositivo"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Tipo"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Sistema operacional"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Ponto de montagem"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Formatar como"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Tamanho"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Espaço livre"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Instalar"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr "Forneça uma senha para a criptografia."
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Suas senhas não coincidem."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Sair?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Tem certeza de que deseja sair do instalador?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Por favor, escolha um idioma"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Por favor escolha um nome para sau computador."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Por favor, informe seu nome completo."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Suas senhas não coincidem."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "A partição EFI é muito pequena. Deve ter pelo menos 35 MB."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Por favor, selecione uma partição raiz (/)."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, fuzzy, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-"É necessária uma partição raiz para instalar o Linux Mint.\n"
-"\n"
-" -Ponto de montagem: /\n"
-" -Tamanho recomendado: 30GB\n"
-" -Formato de sistema de arquivos recomendado: ext4\n"
-"\n"
-"Nota: O recurso de capturas instantâneas do btrfs com mudança de horário "
-"requer o uso de:\n"
-" -subvolume Ponto de montagem /@\n"
-" -btrfs como formato de sistema de arquivos\n"
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-"A partição EFI não é inicializável. Por favor, edite as flags da partição."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "A partição EFI é muito pequena. Deve ter pelo menos 35 MB."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "A partição EFI deve ser formatada como vfat"
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Por favor, selecione uma partição EFI."
-
-#: live-installer/frontend/gtk_interface.py:1226
-#, fuzzy
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-"É necessária uma partição do sistema EFI com os seguintes requisitos:\n"
-"\n"
-" - Ponto de montagem: /boot/efi\n"
-" - Sinalizadores de partição: inicializável\n"
-" - Tamanho: pelo menos 35 MB (100 MB ou mais recomendado)\n"
-" - Formato: vfat ou fat32\n"
-"\n"
-"Para garantir a compatibilidade com o Windows, nós recomendamos que você use "
-"a primeira partição do disco como a partição do sistema EFI.\n"
-" "
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr "Por favor, selecione um disco."
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr "Atenção"
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr "Isso excluirá todos os dados em%s. Você tem certeza?"
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Por favor, informe um nome de usuário."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Localização"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Idioma: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Fuso horário: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Leiaute do teclado: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Configurações de usuário"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Nome completo: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Nome de usuário: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Início de sessão automático "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "ativado"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "desativado"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Configurações do sistema"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr "Nome do computador: "
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-#, fuzzy
-msgid "Install updates after installation"
-msgstr "Instalação automatizada"
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Operações de sistema de arquivos"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Instalar o carregador de inicialização em %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Não instalar o carregador de inicialização"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Utilizar /target já montada."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr "Instalação automatizada em %s"
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Formatar %(path)s em %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Montar %(path)s em %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr "LVM: "
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr "Criptografia de disco: "
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Instalação completa. Você deseja reiniciar o computador para utilizar o novo "
-"sistema?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Erro na instalação"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, fuzzy, python-format
-msgid "Welcome to %s"
-msgstr "Bem Vindo"
-
-#: live-installer/frontend/tui_interface.py:57
-#, fuzzy
-msgid "What keyboard would you like to use?"
-msgstr "Qual idioma você gostaria de usar?"
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Modelo do teclado:"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Tipo de instalação"
-
-#: live-installer/frontend/tui_interface.py:80
-#, fuzzy
-msgid "Select a disk?"
-msgstr "Por favor, selecione um disco."
-
-#: live-installer/frontend/tui_interface.py:84
-#, fuzzy
-msgid "Disk"
-msgstr "Disco:"
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Fuso horário"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Removível:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Editar"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Atribuir à /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"A tabela de partições não pode ser gravada em %s. Reinicie o computador e "
-"tente novamente."
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"A partição %s não pode ser criada. A instalação será interrompida. Reinicie "
-"o computador e tente novamente."
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Partição lógica"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Partição estendida"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Desconhecido(a)"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Editar partição"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Editar partição"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Dispositivo:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Formatar como:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Ponto de montagem:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "OK"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Não"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Sim"
 
 #~ msgid "Quit"
 #~ msgstr "Sair"

--- a/po/live-installer-ro.po
+++ b/po/live-installer-ro.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2020-02-12 18:51+0000\n"
 "Last-Translator: Daniel Slavu <Unknown>\n"
 "Language-Team: Romanian <ro@li.org>\n"
@@ -24,8 +24,8 @@ msgid "Welcome to the 17g Installer."
 msgstr "Bine ați venit la instalatorul 17G."
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 #, fuzzy
 msgid ""
 "This program will ask you some questions and set up system on your computer."
@@ -34,12 +34,12 @@ msgstr ""
 "computer."
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr "Model de tastatură:"
 
@@ -49,10 +49,12 @@ msgid "Type here to test your keyboard"
 msgstr "Tastați aici pentru a testa aspectul tastaturii"
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -61,13 +63,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Fus orar"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr "Instalare automată"
 
@@ -77,12 +79,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr "Ștergeți un disc și instalați 17G pe el."
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr "Disc:"
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Editează partiția"
@@ -93,42 +95,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr "Utilizați LVM (Managementul Volumului Logic)"
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr "Criptați sistemul de operare"
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr "Parolă de acces"
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr "Confirmă parolă de acces"
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr "Partitionare manuala"
 
@@ -146,7 +148,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Mod expert"
@@ -156,144 +158,150 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 #, fuzzy
 msgid "Minimal installation"
 msgstr "Instalare automată"
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Reîmprospătare"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Formatează ca"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr "Instalați meniul de încărcare GRUB pe:"
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Editare partiţii"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr "Numele tău:"
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr "Numele computerului dvs.:"
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr "Alege un nume de utilizator:"
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr "Numele utilizat pentru a comunica cu alte calculatoare."
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr "Alegeți o parolă:"
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Autentificare automată"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr "Solicitați parola pentru a vă autentifica"
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr "Criptează-mi dosarul personal"
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr "Confirmați parola:"
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 #, fuzzy
 msgid "Automated installation enabled!"
 msgstr "Instalare automată pe %s"
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr "Bun venit"
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -324,6 +332,741 @@ msgstr ""
 #, fuzzy
 msgid "Welcome to 17g"
 msgstr "Bun venit"
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "OK"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Nu"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Da"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Fus orar"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, fuzzy, python-format
+msgid "Welcome to the %s Installer."
+msgstr "Bine ați venit la instalatorul 17G."
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr "Ce limbă ai dori să folosești?"
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Limbă"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr "Unde vă aflați?"
+
+#: live-installer/frontend/tui_interface.py:57
+#, fuzzy
+msgid "What keyboard would you like to use?"
+msgstr "Ce limbă ai dori să folosești?"
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Model de tastatură:"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Tip instalare"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Tip"
+
+#: live-installer/frontend/tui_interface.py:80
+#, fuzzy
+msgid "Select a disk?"
+msgstr "Vă rugăm să selectați un disc."
+
+#: live-installer/frontend/tui_interface.py:84
+#, fuzzy
+msgid "Disk"
+msgstr "Disc:"
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, fuzzy, python-format
+msgid "Welcome to %s"
+msgstr "Bun venit"
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Țară"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Aranjament"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variantă"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Se calculează indexurile fișierelor..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr "Instalator"
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Aranjament tastatură"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr "Care este aspectul tastaturii tale?"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr "Cont utilizator"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr "Cine sunteți?"
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr "Tip instalare"
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Unde doriți să instalați 17G?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Se partiționează"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Rezumat"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr "Se instalează"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+#, fuzzy
+msgid "Automated Install"
+msgstr "Instalare automată"
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Înapoi"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr "Următorul"
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr "Tastați aici pentru a testa aspectul tastaturii"
+
+#: live-installer/frontend/gtk_interface.py:546
+#, fuzzy
+msgid "Erase a disk and install system on it."
+msgstr "Ștergeți un disc și instalați 17G pe el."
+
+#: live-installer/frontend/gtk_interface.py:559
+#, fuzzy
+msgid "Manually create, resize or choose partitions for system."
+msgstr "Creați manual, redimensionați sau alegeți partiții pentru 17G."
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Editare partiţii"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Dispozitiv"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Sistem de operare"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Loc de montare"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Formatează ca"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Dimensiune"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Spaţiu liber"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr "Atenție"
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr "Aceasta va șterge toate datele de pe %s. Esti sigur?"
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Instalare"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr "Vă rugăm să furnizați o parolă pentru criptare."
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Parolele tale nu se potrivesc."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Renunțați?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Sigur doriți să ieșiți din programul de instalare?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Alegeți o limbă"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Furnizați o parolă pentru contul de utilizator."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Furnizați numele dumneavoastră complet."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Parolele tale nu se potrivesc."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "Partiția EFI este prea mică. Trebuie să fie de cel puțin 35 MB."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Alegeți o partiţie root (/)"
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, fuzzy, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+"Este necesară o partiție rădăcină pentru a instala Linux Mint on.\n"
+"\n"
+" - Punctul de montare: /\n"
+" - Dimensiunea recomandată: 30 GB\n"
+" - Formatul fișierelor de sistem recomandat: ext4\n"
+"\n"
+"Notă: caracteristica instantanee btrfs necesită utilizarea de:\n"
+" - subvolumul punctului de montaj /@\n"
+" - btrfs ca format de fișiere de sistem\n"
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+"Partiția EFI nu este bootabilă (nu se poate utiliza de către sistemul de "
+"operare). Editați steagurile/însemnele partiției."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "Partiția EFI este prea mică. Trebuie să fie de cel puțin 35 MB."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "Partiția EFI trebuie să fie formatată ca și vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Selectați o partiţie EFI."
+
+#: live-installer/frontend/gtk_interface.py:1301
+#, fuzzy
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+"Este necesară o partiție de sistem EFI cu următoarele cerințe:\n"
+"\n"
+" - Punct de montare: /boot/efi\n"
+" - Steaguri partiție: Bootable\n"
+" - Dimensiune: cel puțin 35 MB (100MB sau mai mult recomandat)\n"
+" - Format: vfat sau fat32\n"
+"\n"
+"Pentru a asigura compatibilitatea cu Windows, vă recomandăm să utilizați "
+"prima partiție a discului ca partiție a sistemului EFI.\n"
+" "
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr "Vă rugăm să selectați un disc."
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Furnizați un nume de utilizator."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Localizare"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Limbă: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Fus orar: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Aranjament tastatură: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Setări utilizator"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Nume real: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Nume utilizator: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Autentificare automată: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "activată"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "dezactivată"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Setări sistem"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+#, fuzzy
+msgid "Install updates after installation"
+msgstr "Instalare automată"
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Operațiunile sistemului de fișiere"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Instalează programul de pornire a sistemului pe %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Nu instala programul de pornire a sistemului"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Utilizează /target deja montat."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr "Instalare automată pe %s"
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Formatează %(path)s ca %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Montează %(path)s ca %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Montează %(path)s ca %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr "LVM: "
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr "Criptarea discului: "
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Instalare finalizată"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Instalarea este acum completă. Doriți să reporniți computerul pentru a "
+"utiliza noul sistem?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Eroare la instalare"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Detaşabil:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Editare"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Atribuire către /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Partiţie logică"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Partiție extinsă"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Necunoscută"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Editează partiția"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Editează partiția"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Dispozitiv:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Formatează ca:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Loc de montare:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Anulare"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
+msgstr ""
 
 #: live-installer/validate.py:12
 msgid "Please provide a username."
@@ -431,10 +1174,6 @@ msgstr "Parolele tale nu se potrivesc."
 msgid "Please provide a password for your user account."
 msgstr "Furnizați o parolă pentru contul de utilizator."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -461,7 +1200,7 @@ msgstr "Se adaugă un utilizator nou în sistem"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Se scrie informația de montare a sistemului de fișiere în /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Se montează %(partition)s în %(mountpoint)s"
@@ -481,49 +1220,49 @@ msgstr "Crearea de partiții pe %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Se formatează %(partition)s în %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Se setează numele de gazdă"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Se setează datele de localizare"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Se setează numele de gazdă"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Se setează opțiunile tastaturii"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Se elimină configurația anterioară (a pachetelor)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Se instalează programul de pornire a sistemului"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Se configurează programul de pornire a sistemului"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -531,670 +1270,17 @@ msgstr ""
 "AVERTISMENT: Programul de pornire a sistemului nu a fost configurat corect! "
 "Trebuie să-l configurați manual."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Instalare finalizată"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Se verifică programul de pornire a sistemului"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Țară"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Limbă"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Aranjament"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Variantă"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Se calculează indexurile fișierelor..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr "Instalator"
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr "Ce limbă ai dori să folosești?"
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr "Unde vă aflați?"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Aranjament tastatură"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr "Care este aspectul tastaturii tale?"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr "Cont utilizator"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr "Cine sunteți?"
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr "Tip instalare"
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Unde doriți să instalați 17G?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Se partiționează"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Rezumat"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr "Se instalează"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-#, fuzzy
-msgid "Automated install"
-msgstr "Instalare automată"
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Înapoi"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr "Următorul"
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, fuzzy, python-format
-msgid "Welcome to the %s Installer."
-msgstr "Bine ați venit la instalatorul 17G."
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr "Tastați aici pentru a testa aspectul tastaturii"
-
-#: live-installer/frontend/gtk_interface.py:542
-#, fuzzy
-msgid "Erase a disk and install system on it."
-msgstr "Ștergeți un disc și instalați 17G pe el."
-
-#: live-installer/frontend/gtk_interface.py:555
-#, fuzzy
-msgid "Manually create, resize or choose partitions for system."
-msgstr "Creați manual, redimensionați sau alegeți partiții pentru 17G."
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Editare partiţii"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Dispozitiv"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Tip"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Sistem de operare"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Loc de montare"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Formatează ca"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Dimensiune"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Spaţiu liber"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Instalare"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr "Vă rugăm să furnizați o parolă pentru criptare."
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Parolele tale nu se potrivesc."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Renunțați?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Sigur doriți să ieșiți din programul de instalare?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Alegeți o limbă"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Furnizați o parolă pentru contul de utilizator."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Furnizați numele dumneavoastră complet."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Parolele tale nu se potrivesc."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "Partiția EFI este prea mică. Trebuie să fie de cel puțin 35 MB."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Alegeți o partiţie root (/)"
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, fuzzy, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-"Este necesară o partiție rădăcină pentru a instala Linux Mint on.\n"
-"\n"
-" - Punctul de montare: /\n"
-" - Dimensiunea recomandată: 30 GB\n"
-" - Formatul fișierelor de sistem recomandat: ext4\n"
-"\n"
-"Notă: caracteristica instantanee btrfs necesită utilizarea de:\n"
-" - subvolumul punctului de montaj /@\n"
-" - btrfs ca format de fișiere de sistem\n"
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-"Partiția EFI nu este bootabilă (nu se poate utiliza de către sistemul de "
-"operare). Editați steagurile/însemnele partiției."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "Partiția EFI este prea mică. Trebuie să fie de cel puțin 35 MB."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "Partiția EFI trebuie să fie formatată ca și vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Selectați o partiţie EFI."
-
-#: live-installer/frontend/gtk_interface.py:1226
-#, fuzzy
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-"Este necesară o partiție de sistem EFI cu următoarele cerințe:\n"
-"\n"
-" - Punct de montare: /boot/efi\n"
-" - Steaguri partiție: Bootable\n"
-" - Dimensiune: cel puțin 35 MB (100MB sau mai mult recomandat)\n"
-" - Format: vfat sau fat32\n"
-"\n"
-"Pentru a asigura compatibilitatea cu Windows, vă recomandăm să utilizați "
-"prima partiție a discului ca partiție a sistemului EFI.\n"
-" "
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr "Vă rugăm să selectați un disc."
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr "Atenție"
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr "Aceasta va șterge toate datele de pe %s. Esti sigur?"
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Furnizați un nume de utilizator."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Localizare"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Limbă: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Fus orar: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Aranjament tastatură: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Setări utilizator"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Nume real: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Nume utilizator: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Autentificare automată: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "activată"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "dezactivată"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Setări sistem"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-#, fuzzy
-msgid "Install updates after installation"
-msgstr "Instalare automată"
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Operațiunile sistemului de fișiere"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Instalează programul de pornire a sistemului pe %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Nu instala programul de pornire a sistemului"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Utilizează /target deja montat."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr "Instalare automată pe %s"
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Formatează %(path)s ca %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Montează %(path)s ca %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr "LVM: "
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr "Criptarea discului: "
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Instalarea este acum completă. Doriți să reporniți computerul pentru a "
-"utiliza noul sistem?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Eroare la instalare"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, fuzzy, python-format
-msgid "Welcome to %s"
-msgstr "Bun venit"
-
-#: live-installer/frontend/tui_interface.py:57
-#, fuzzy
-msgid "What keyboard would you like to use?"
-msgstr "Ce limbă ai dori să folosești?"
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Model de tastatură:"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Tip instalare"
-
-#: live-installer/frontend/tui_interface.py:80
-#, fuzzy
-msgid "Select a disk?"
-msgstr "Vă rugăm să selectați un disc."
-
-#: live-installer/frontend/tui_interface.py:84
-#, fuzzy
-msgid "Disk"
-msgstr "Disc:"
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Fus orar"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Detaşabil:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Editare"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Atribuire către /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Partiţie logică"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Partiție extinsă"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Necunoscută"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Editează partiția"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Editează partiția"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Dispozitiv:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Formatează ca:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Loc de montare:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Anulare"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "OK"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Nu"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Da"
 
 #~ msgid "Quit"
 #~ msgstr "Ieșire"

--- a/po/live-installer-ro.po
+++ b/po/live-installer-ro.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2020-02-12 18:51+0000\n"
 "Last-Translator: Daniel Slavu <Unknown>\n"
 "Language-Team: Romanian <ro@li.org>\n"
@@ -95,7 +95,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -197,9 +197,9 @@ msgid "Format"
 msgstr "Formatează ca"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -304,6 +304,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Formatează ca"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -335,8 +341,8 @@ msgstr "Bun venit"
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "OK"
 
@@ -428,23 +434,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr "Bun venit"
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Țară"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Aranjament"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Variantă"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Se calculează indexurile fișierelor..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Detaşabil:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Editare"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Atribuire către /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -462,10 +539,104 @@ msgstr "Se calculează indexurile fișierelor..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr "Instalator"
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Spaţiu liber"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Partiţie logică"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Partiție extinsă"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Necunoscută"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Editează partiția"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Editează partiția"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Dispozitiv:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Formatează ca:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Loc de montare:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Anulare"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Țară"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Aranjament"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variantă"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Se calculează indexurile fișierelor..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -583,18 +754,6 @@ msgstr "Formatează ca"
 msgid "Size"
 msgstr "Dimensiune"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Spaţiu liber"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -627,25 +786,6 @@ msgstr "Renunțați?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Sigur doriți să ieșiți din programul de instalare?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -908,7 +1048,7 @@ msgid "Disk Encryption: "
 msgstr "Criptarea discului: "
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Instalare finalizată"
 
@@ -929,139 +1069,6 @@ msgstr "Eroare la instalare"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Detaşabil:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Editare"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Atribuire către /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Partiţie logică"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Partiție extinsă"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Necunoscută"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Editează partiția"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Editează partiția"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Dispozitiv:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Formatează ca:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Loc de montare:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Anulare"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1220,49 +1227,49 @@ msgstr "Crearea de partiții pe %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Se formatează %(partition)s în %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Se setează numele de gazdă"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Se setează datele de localizare"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Se setează numele de gazdă"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Se setează opțiunile tastaturii"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Se elimină configurația anterioară (a pachetelor)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Se instalează programul de pornire a sistemului"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Se configurează programul de pornire a sistemului"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1270,15 +1277,15 @@ msgstr ""
 "AVERTISMENT: Programul de pornire a sistemului nu a fost configurat corect! "
 "Trebuie să-l configurați manual."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Se verifică programul de pornire a sistemului"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-ru.po
+++ b/po/live-installer-ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2020-03-13 10:54+0000\n"
 "Last-Translator: Vlad Orlov <Unknown>\n"
 "Language-Team: Russian <ru@li.org>\n"
@@ -94,7 +94,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "ГБ"
 
@@ -198,9 +198,9 @@ msgid "Format"
 msgstr "Форматировать в"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -305,6 +305,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Форматировать в"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -336,8 +342,8 @@ msgstr "Добро пожаловать"
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "ОК"
 
@@ -429,23 +435,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr "Добро пожаловать"
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Регион"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "Б"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Раскладка"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "кБ"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Разновидность"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "МБ"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Вычисление файловых индексов ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "ТБ"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Съёмные:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Изменить"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Назначить /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -463,10 +540,108 @@ msgstr "Вычисление файловых индексов ..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr "Программа установки"
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Свободное место"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"Не удалось записать таблицу разделов для %s. Перезагрузите компьютер и "
+"попробуйте ещё раз."
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"Не удалось создать раздел %s. Установка будет прекращена. Перезагрузите "
+"компьютер и попробуйте ещё раз."
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Логический раздел"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Расширенный раздел"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Неизвестный"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Изменить раздел"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Изменить раздел"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Устройство:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Форматировать в:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Точка монтирования:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Отмена"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Регион"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Раскладка"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Разновидность"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Вычисление файловых индексов ..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -584,18 +759,6 @@ msgstr "Форматировать в"
 msgid "Size"
 msgstr "Размер"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Свободное место"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -628,25 +791,6 @@ msgstr "Выйти?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Вы уверены, что хотите прервать установку?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -909,7 +1053,7 @@ msgid "Disk Encryption: "
 msgstr "Шифрование диска: "
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Установка завершена"
 
@@ -930,143 +1074,6 @@ msgstr "Ошибка установки"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "Б"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "кБ"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "МБ"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "ТБ"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Съёмные:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Изменить"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Назначить /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"Не удалось записать таблицу разделов для %s. Перезагрузите компьютер и "
-"попробуйте ещё раз."
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"Не удалось создать раздел %s. Установка будет прекращена. Перезагрузите "
-"компьютер и попробуйте ещё раз."
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Логический раздел"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Расширенный раздел"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Неизвестный"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Изменить раздел"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Изменить раздел"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Устройство:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Форматировать в:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Точка монтирования:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Отмена"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1229,49 +1236,49 @@ msgstr "Создание разделов на %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Форматирование %(partition)s в %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Настройка имени хоста"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Установка локали"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Настройка имени хоста"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Установка настроек клавиатуры"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Удаление конфигурации (приложений)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Установка загрузчика"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Конфигурирование загрузчика"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1279,15 +1286,15 @@ msgstr ""
 "ВНИМАНИЕ: Загрузчик grub не был правильно сконфигурирован! Вам нужно "
 "настроить его вручную."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Проверка загрузчика"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-ru.po
+++ b/po/live-installer-ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2020-03-13 10:54+0000\n"
 "Last-Translator: Vlad Orlov <Unknown>\n"
 "Language-Team: Russian <ru@li.org>\n"
@@ -24,8 +24,8 @@ msgid "Welcome to the 17g Installer."
 msgstr "Добро пожаловать в программу установки 17G."
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 #, fuzzy
 msgid ""
 "This program will ask you some questions and set up system on your computer."
@@ -33,12 +33,12 @@ msgstr ""
 "Эта программа задаст вам несколько вопросов и установит 17G на ваш компьютер."
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr "Модель клавиатуры:"
 
@@ -48,10 +48,12 @@ msgid "Type here to test your keyboard"
 msgstr "Поле для проверки вашей раскладки клавиатуры"
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -60,13 +62,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Часовой пояс"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr "Автоматическая установка"
 
@@ -76,12 +78,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr "Стереть диск и установить на нём 17G."
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr "Диск:"
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Изменить раздел"
@@ -92,44 +94,44 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "ГБ"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr "Использовать LVM (менеджер логических томов)"
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr "Зашифровать операционную систему"
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr "Парольная фраза"
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr "Подтвердите парольную фразу"
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 "Это обеспечивает дополнительную безопасность, но может занять несколько "
 "часов."
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr "Заполнить диск случайными данными"
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr "Ручная разметка"
 
@@ -147,7 +149,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Продвинутый метод"
@@ -157,144 +159,150 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 #, fuzzy
 msgid "Minimal installation"
 msgstr "Автоматическая установка"
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Обновить"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Форматировать в"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr "Установить загрузочное меню GRUB на:"
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Изменить разделы диска"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr "Ваше имя:"
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr "Имя вашего компьютера:"
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr "Введите имя пользователя:"
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr "Имя, используемое при связи с другими компьютерами."
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr "Задайте пароль:"
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Входить в систему автоматически"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr "Запрашивать пароль при входе в систему"
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr "Шифрование домашней папки"
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr "Подтвердите пароль:"
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 #, fuzzy
 msgid "Automated installation enabled!"
 msgstr "Автоматическая установка на %s"
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr "Добро пожаловать"
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -325,6 +333,745 @@ msgstr ""
 #, fuzzy
 msgid "Welcome to 17g"
 msgstr "Добро пожаловать"
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "ОК"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Нет"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Да"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Часовой пояс"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, fuzzy, python-format
+msgid "Welcome to the %s Installer."
+msgstr "Добро пожаловать в программу установки 17G."
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr "Какой язык вы предпочитаете использовать?"
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Язык"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr "Где вы находитесь?"
+
+#: live-installer/frontend/tui_interface.py:57
+#, fuzzy
+msgid "What keyboard would you like to use?"
+msgstr "Какой язык вы предпочитаете использовать?"
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Модель клавиатуры:"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Тип установки"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Тип"
+
+#: live-installer/frontend/tui_interface.py:80
+#, fuzzy
+msgid "Select a disk?"
+msgstr "Пожалуйста, выберите диск."
+
+#: live-installer/frontend/tui_interface.py:84
+#, fuzzy
+msgid "Disk"
+msgstr "Диск:"
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, fuzzy, python-format
+msgid "Welcome to %s"
+msgstr "Добро пожаловать"
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Регион"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Раскладка"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Разновидность"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Вычисление файловых индексов ..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr "Программа установки"
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Раскладка клавиатуры"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr "Какая у вас раскладка клавиатуры?"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr "Учётная запись пользователя"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr "Кто вы?"
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr "Тип установки"
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Куда вы хотите установить 17G?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Разметка дисков"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Сводная информация"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr "Установка"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+#, fuzzy
+msgid "Automated Install"
+msgstr "Автоматическая установка"
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Назад"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr "Далее"
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr "Поле для проверки вашей раскладки клавиатуры"
+
+#: live-installer/frontend/gtk_interface.py:546
+#, fuzzy
+msgid "Erase a disk and install system on it."
+msgstr "Стереть диск и установить на нём 17G."
+
+#: live-installer/frontend/gtk_interface.py:559
+#, fuzzy
+msgid "Manually create, resize or choose partitions for system."
+msgstr "Вручную создать, изменить размер или выбрать разделы для 17G."
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Изменить разделы диска"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Устройство"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Операционная система"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Точка монтирования"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Форматировать в"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Размер"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Свободное место"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr "Предупреждение"
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr "Все данные на %s будут удалены. Вы уверены?"
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Установить"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr "Пожалуйста, укажите парольную фразу для шифрования."
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Ваши пароли не совпадают."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Выйти?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Вы уверены, что хотите прервать установку?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Пожалуйста, выберите язык"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Пожалуйста, укажите имя Вашего компьютера."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Пожалуйста, укажите Ваше полное имя."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Ваши пароли не совпадают."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "Раздел EFI слишком мал. Он должен быть не менее 35 МБ."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Пожалуйста, выберите корневой (/) раздел."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, fuzzy, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+"Для установки Linux Mint требуется корневой раздел.\n"
+"\n"
+" - Точка монтирования: /\n"
+" - Рекомендуемый размер: 30 ГБ\n"
+" - Рекомендуемый тип файловой системы: ext4\n"
+"\n"
+"Примечание: для создания снимков btrfs в timeshift требуется:\n"
+" - точка монтирования подраздела /@\n"
+" - тип файловой системы btrfs\n"
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+"Раздел EFI  не является загрузочным. Пожалуйста, отредактируйте метки "
+"раздела."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "Раздел EFI слишком мал. Он должен быть не менее 35 МБ."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "Раздел EFI должен быть отформатирован как vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Пожалуйста, укажите раздел EFI."
+
+#: live-installer/frontend/gtk_interface.py:1301
+#, fuzzy
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+"Требуется системный раздел EFI со следующими параметрами:\n"
+"\n"
+" - Точка монтирования: /boot/efi\n"
+" - Флаги раздела: Bootable\n"
+" - Размер: не менее 35 МБ (рекомендуется не менее 100 МБ)\n"
+" - Тип файловой системы: vfat или fat32\n"
+"\n"
+"Для обеспечения совместимости с Windows рекомендуется использовать в "
+"качестве системного раздела EFI первый раздел диска.\n"
+" "
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr "Пожалуйста, выберите диск."
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Пожалуйста, укажите  имя пользователя."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Локализация"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Язык: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Часовой пояс: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Раскладка клавиатуры: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Настройки пользователя"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Настоящее имя: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Имя пользователя: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Автоматический вход: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "включён"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "отключён"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Системные настройки"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr "Имя компьютера: "
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+#, fuzzy
+msgid "Install updates after installation"
+msgstr "Автоматическая установка"
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Операции с файловой системой"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Установить загрузчик на %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Не устанавливать загрузчик"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Использовать уже смонтированный /target."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr "Автоматическая установка на %s"
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Форматировать %(path)s в %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Монтировать %(path)s в %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Монтировать %(path)s в %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr "LVM: "
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr "Шифрование диска: "
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Установка завершена"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Установка завершена. Вы хотите перезагрузить компьютер  для применения "
+"изменений?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Ошибка установки"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "Б"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "кБ"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "МБ"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "ТБ"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Съёмные:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Изменить"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Назначить /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"Не удалось записать таблицу разделов для %s. Перезагрузите компьютер и "
+"попробуйте ещё раз."
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"Не удалось создать раздел %s. Установка будет прекращена. Перезагрузите "
+"компьютер и попробуйте ещё раз."
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Логический раздел"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Расширенный раздел"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Неизвестный"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Изменить раздел"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Изменить раздел"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Устройство:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Форматировать в:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Точка монтирования:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Отмена"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
+msgstr ""
 
 #: live-installer/validate.py:12
 msgid "Please provide a username."
@@ -434,10 +1181,6 @@ msgstr "Ваши пароли не совпадают."
 msgid "Please provide a password for your user account."
 msgstr "Пожалуйста, укажите пароль пользовательского аккаунта."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -464,7 +1207,7 @@ msgstr "Добавление нового пользователя в систе
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Запись информации о монтировании файловой системы в /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Монтирование %(partition)s в %(mountpoint)s"
@@ -486,49 +1229,49 @@ msgstr "Создание разделов на %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Форматирование %(partition)s в %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Настройка имени хоста"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Установка локали"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Настройка имени хоста"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Установка настроек клавиатуры"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Удаление конфигурации (приложений)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Установка загрузчика"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Конфигурирование загрузчика"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -536,674 +1279,17 @@ msgstr ""
 "ВНИМАНИЕ: Загрузчик grub не был правильно сконфигурирован! Вам нужно "
 "настроить его вручную."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Установка завершена"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Проверка загрузчика"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Регион"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Язык"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Раскладка"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Разновидность"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Вычисление файловых индексов ..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr "Программа установки"
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr "Какой язык вы предпочитаете использовать?"
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr "Где вы находитесь?"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Раскладка клавиатуры"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr "Какая у вас раскладка клавиатуры?"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr "Учётная запись пользователя"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr "Кто вы?"
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr "Тип установки"
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Куда вы хотите установить 17G?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Разметка дисков"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Сводная информация"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr "Установка"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-#, fuzzy
-msgid "Automated install"
-msgstr "Автоматическая установка"
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Назад"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr "Далее"
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, fuzzy, python-format
-msgid "Welcome to the %s Installer."
-msgstr "Добро пожаловать в программу установки 17G."
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr "Поле для проверки вашей раскладки клавиатуры"
-
-#: live-installer/frontend/gtk_interface.py:542
-#, fuzzy
-msgid "Erase a disk and install system on it."
-msgstr "Стереть диск и установить на нём 17G."
-
-#: live-installer/frontend/gtk_interface.py:555
-#, fuzzy
-msgid "Manually create, resize or choose partitions for system."
-msgstr "Вручную создать, изменить размер или выбрать разделы для 17G."
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Изменить разделы диска"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Устройство"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Тип"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Операционная система"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Точка монтирования"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Форматировать в"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Размер"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Свободное место"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Установить"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr "Пожалуйста, укажите парольную фразу для шифрования."
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Ваши пароли не совпадают."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Выйти?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Вы уверены, что хотите прервать установку?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Пожалуйста, выберите язык"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Пожалуйста, укажите имя Вашего компьютера."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Пожалуйста, укажите Ваше полное имя."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Ваши пароли не совпадают."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "Раздел EFI слишком мал. Он должен быть не менее 35 МБ."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Пожалуйста, выберите корневой (/) раздел."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, fuzzy, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-"Для установки Linux Mint требуется корневой раздел.\n"
-"\n"
-" - Точка монтирования: /\n"
-" - Рекомендуемый размер: 30 ГБ\n"
-" - Рекомендуемый тип файловой системы: ext4\n"
-"\n"
-"Примечание: для создания снимков btrfs в timeshift требуется:\n"
-" - точка монтирования подраздела /@\n"
-" - тип файловой системы btrfs\n"
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-"Раздел EFI  не является загрузочным. Пожалуйста, отредактируйте метки "
-"раздела."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "Раздел EFI слишком мал. Он должен быть не менее 35 МБ."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "Раздел EFI должен быть отформатирован как vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Пожалуйста, укажите раздел EFI."
-
-#: live-installer/frontend/gtk_interface.py:1226
-#, fuzzy
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-"Требуется системный раздел EFI со следующими параметрами:\n"
-"\n"
-" - Точка монтирования: /boot/efi\n"
-" - Флаги раздела: Bootable\n"
-" - Размер: не менее 35 МБ (рекомендуется не менее 100 МБ)\n"
-" - Тип файловой системы: vfat или fat32\n"
-"\n"
-"Для обеспечения совместимости с Windows рекомендуется использовать в "
-"качестве системного раздела EFI первый раздел диска.\n"
-" "
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr "Пожалуйста, выберите диск."
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr "Предупреждение"
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr "Все данные на %s будут удалены. Вы уверены?"
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Пожалуйста, укажите  имя пользователя."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Локализация"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Язык: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Часовой пояс: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Раскладка клавиатуры: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Настройки пользователя"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Настоящее имя: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Имя пользователя: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Автоматический вход: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "включён"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "отключён"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Системные настройки"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr "Имя компьютера: "
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-#, fuzzy
-msgid "Install updates after installation"
-msgstr "Автоматическая установка"
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Операции с файловой системой"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Установить загрузчик на %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Не устанавливать загрузчик"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Использовать уже смонтированный /target."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr "Автоматическая установка на %s"
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Форматировать %(path)s в %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Монтировать %(path)s в %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr "LVM: "
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr "Шифрование диска: "
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Установка завершена. Вы хотите перезагрузить компьютер  для применения "
-"изменений?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Ошибка установки"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, fuzzy, python-format
-msgid "Welcome to %s"
-msgstr "Добро пожаловать"
-
-#: live-installer/frontend/tui_interface.py:57
-#, fuzzy
-msgid "What keyboard would you like to use?"
-msgstr "Какой язык вы предпочитаете использовать?"
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Модель клавиатуры:"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Тип установки"
-
-#: live-installer/frontend/tui_interface.py:80
-#, fuzzy
-msgid "Select a disk?"
-msgstr "Пожалуйста, выберите диск."
-
-#: live-installer/frontend/tui_interface.py:84
-#, fuzzy
-msgid "Disk"
-msgstr "Диск:"
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Часовой пояс"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "Б"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "кБ"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "МБ"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "ТБ"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Съёмные:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Изменить"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Назначить /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"Не удалось записать таблицу разделов для %s. Перезагрузите компьютер и "
-"попробуйте ещё раз."
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"Не удалось создать раздел %s. Установка будет прекращена. Перезагрузите "
-"компьютер и попробуйте ещё раз."
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Логический раздел"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Расширенный раздел"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Неизвестный"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Изменить раздел"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Изменить раздел"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Устройство:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Форматировать в:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Точка монтирования:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Отмена"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "ОК"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Нет"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Да"
 
 #~ msgid "Quit"
 #~ msgstr "Выход"

--- a/po/live-installer-sc.po
+++ b/po/live-installer-sc.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2018-08-20 17:55+0000\n"
 "Last-Translator: amm <Unknown>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,19 +18,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -39,10 +39,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -51,13 +53,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Fusu oràriu"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -66,12 +68,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Modìfica partitzione"
@@ -82,42 +84,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -134,7 +136,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Modalidade"
@@ -144,141 +146,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Atualiza"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Modìfica partitziones"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -307,6 +315,709 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "Andat bene"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Nono"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Emmo"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Fusu oràriu"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Limba"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Assentu tastiera"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Installatzione pausada"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Genia"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Istadu"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Dispositzione"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variante"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Carculende ìnditzes de archìvios..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Assentu tastiera"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Seguru chi boles essire dae s'installadore?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Resumu"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "In segus"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Modìfica partitziones"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Dispositivu"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Sistema operativu"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Mannària"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Ispàtziu lìberu"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Installa"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Sas craes non currispondent."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Boles essire?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Seguru chi boles essire dae s'installadore?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Sèbera una limba"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Fruni una crae pro su contu de utente tuo."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Fruni su nùmene tuo cumpletu."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Sas craes non currispondent."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Fruni su nùmene utente."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Localizatzione"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Limba: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Fusu oràriu: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Assentu tastiera: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Cunfiguratziones de utente"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Nùmene reale: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Nùmene de Impitadore: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Imbucada in automàticu: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "ativadu"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "disabilitadu"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Sèberos de sistema"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Operatziones de archìviu de sistema"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Installatzione cumpleta. Do you want to restart your computer to use the new "
+"system?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Faddina in s'installatzione"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Modìfica"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Partitzione lògica"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Partitzione estèndida"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Disconnotu"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Modìfica partitzione"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Modìfica partitzione"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Dispositivu:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Cantzella"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -411,10 +1122,6 @@ msgstr "Sas craes non currispondent."
 msgid "Please provide a password for your user account."
 msgstr "Fruni una crae pro su contu de utente tuo."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -441,7 +1148,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr ""
@@ -461,684 +1168,63 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 msgid "Removing extra packages"
 msgstr ""
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr ""
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Istadu"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Limba"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Dispositzione"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Variante"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Carculende ìnditzes de archìvios..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Assentu tastiera"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Seguru chi boles essire dae s'installadore?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Resumu"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "In segus"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Modìfica partitziones"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Dispositivu"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Genia"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Sistema operativu"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Mannària"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Ispàtziu lìberu"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Installa"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Sas craes non currispondent."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Boles essire?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Seguru chi boles essire dae s'installadore?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Sèbera una limba"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Fruni una crae pro su contu de utente tuo."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Fruni su nùmene tuo cumpletu."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Sas craes non currispondent."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Fruni su nùmene utente."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Localizatzione"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Limba: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Fusu oràriu: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Assentu tastiera: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Cunfiguratziones de utente"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Nùmene reale: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Nùmene de Impitadore: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Imbucada in automàticu: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "ativadu"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "disabilitadu"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Sèberos de sistema"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Operatziones de archìviu de sistema"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Installatzione cumpleta. Do you want to restart your computer to use the new "
-"system?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Faddina in s'installatzione"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Assentu tastiera"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Installatzione pausada"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Fusu oràriu"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Modìfica"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Partitzione lògica"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Partitzione estèndida"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Disconnotu"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Modìfica partitzione"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Modìfica partitzione"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Dispositivu:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Cantzella"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "Andat bene"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Nono"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Emmo"
 
 #~ msgid "Quit"
 #~ msgstr "Essi"

--- a/po/live-installer-sc.po
+++ b/po/live-installer-sc.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2018-08-20 17:55+0000\n"
 "Last-Translator: amm <Unknown>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -84,7 +84,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -183,9 +183,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -289,6 +289,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -319,8 +324,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "Andat bene"
 
@@ -409,23 +414,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Istadu"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Dispositzione"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Variante"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Carculende ìnditzes de archìvios..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Modìfica"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -443,10 +519,104 @@ msgstr "Carculende ìnditzes de archìvios..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Ispàtziu lìberu"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Partitzione lògica"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Partitzione estèndida"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Disconnotu"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Modìfica partitzione"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Modìfica partitzione"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Dispositivu:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Cantzella"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Istadu"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Dispositzione"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variante"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Carculende ìnditzes de archìvios..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -561,18 +731,6 @@ msgstr ""
 msgid "Size"
 msgstr "Mannària"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Ispàtziu lìberu"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -605,25 +763,6 @@ msgstr "Boles essire?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Seguru chi boles essire dae s'installadore?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -860,7 +999,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr ""
 
@@ -881,139 +1020,6 @@ msgstr "Faddina in s'installatzione"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Modìfica"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Partitzione lògica"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Partitzione estèndida"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Disconnotu"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Modìfica partitzione"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Modìfica partitzione"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Dispositivu:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Cantzella"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1168,61 +1174,61 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 msgid "Removing extra packages"
 msgstr ""
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-sco.po
+++ b/po/live-installer-sco.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2010-12-16 21:16+0000\n"
 "Last-Translator: Johnny McKenzie <Unknown>\n"
 "Language-Team: Scots <sco@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,140 +149,146 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 msgid "Edit Partitions"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -308,6 +316,699 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+msgid "Keyboard Model"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:73
+msgid "Installation type?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -403,10 +1104,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -433,7 +1130,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr ""
@@ -453,672 +1150,61 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Removin' live configurments (packages)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr ""
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-msgid "Keyboard Model"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:73
-msgid "Installation type?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""

--- a/po/live-installer-sco.po
+++ b/po/live-installer-sco.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2010-12-16 21:16+0000\n"
 "Last-Translator: Johnny McKenzie <Unknown>\n"
 "Language-Team: Scots <sco@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -291,6 +291,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -320,8 +325,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -407,23 +412,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -441,9 +517,102 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -558,18 +727,6 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -601,25 +758,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -854,7 +992,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr ""
 
@@ -873,138 +1011,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1150,61 +1156,61 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Removin' live configurments (packages)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""

--- a/po/live-installer-shn.po
+++ b/po/live-installer-shn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2014-04-29 15:08+0000\n"
 "Last-Translator: Rockworld <sumoisrock@gmail.com>\n"
 "Language-Team: Shan <shn@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -291,6 +291,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -320,8 +325,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -407,23 +412,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -441,9 +517,102 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -558,18 +727,6 @@ msgstr ""
 msgid "Size"
 msgstr "သႅၼ်း"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -601,25 +758,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -854,7 +992,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr ""
 
@@ -873,138 +1011,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1150,60 +1156,60 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 msgid "Removing extra packages"
 msgstr ""
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""

--- a/po/live-installer-shn.po
+++ b/po/live-installer-shn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2014-04-29 15:08+0000\n"
 "Last-Translator: Rockworld <sumoisrock@gmail.com>\n"
 "Language-Team: Shan <shn@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,140 +149,146 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 msgid "Edit Partitions"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -308,6 +316,699 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "ၽႃႇသႃႇၵႂၢမ်း"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+msgid "Keyboard Model"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:73
+msgid "Installation type?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "သႅၼ်း"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "ၵၢၼ်ပိၼ်ႇၽႃႇသႃႇ"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -403,10 +1104,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -433,7 +1130,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr ""
@@ -453,671 +1150,60 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 msgid "Removing extra packages"
 msgstr ""
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr ""
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "ၽႃႇသႃႇၵႂၢမ်း"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "သႅၼ်း"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "ၵၢၼ်ပိၼ်ႇၽႃႇသႃႇ"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-msgid "Keyboard Model"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:73
-msgid "Installation type?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""

--- a/po/live-installer-si.po
+++ b/po/live-installer-si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2014-02-08 06:03+0000\n"
 "Last-Translator: Prabhath Mannapperuma <d.p.mannapperuma@gmail.com>\n"
 "Language-Team: Sinhalese <si@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -292,6 +292,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -322,8 +327,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -411,23 +416,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "සැකැස්ම"
-
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "විචල්‍ය"
-
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -445,9 +521,103 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "නිදහස් අවකාශය"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "පද්ධති සැකසුම්"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "සැකැස්ම"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "විචල්‍ය"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -562,18 +732,6 @@ msgstr ""
 msgid "Size"
 msgstr "ප්‍රමාණය"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "නිදහස් අවකාශය"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -605,25 +763,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -858,7 +997,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "ස්ථාපනය අවසානයි"
 
@@ -877,139 +1016,6 @@ msgstr "ස්ථාපනයේ දෝෂය"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "පද්ධති සැකසුම්"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1155,62 +1161,62 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "යතුරු පුවරු විකල්ප සකසමින්"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "යතුරු පුවරු විකල්ප සකසමින්"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 msgid "Removing extra packages"
 msgstr ""
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "ඇරඹුම් ප්‍රවේශ කාරකය පිහිටුවමින්"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "ඇරඹුම් ප්‍රවේශ කාරකය වින්‍යාසගතකරමින්"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "ඇරඹුම් ප්‍රවේශ කාරකය පරික්ෂා කරමින්"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-si.po
+++ b/po/live-installer-si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2014-02-08 06:03+0000\n"
 "Last-Translator: Prabhath Mannapperuma <d.p.mannapperuma@gmail.com>\n"
 "Language-Team: Sinhalese <si@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,141 +149,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "පද්ධති සැකසුම්"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -310,6 +318,702 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "යතුරුපුවරුවේ සැකැස්ම: "
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "ස්ථාපනයේ දෝෂය"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "වර්‍ගය"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "සැකැස්ම"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "විචල්‍ය"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "උපාංගය"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "මෙහෙයුම් පද්ධතිය"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "ප්‍රමාණය"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "නිදහස් අවකාශය"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "ස්වදේශිකරණය"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "භාෂාව: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "වේලා කලාපය: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "යතුරුපුවරුවේ සැකැස්ම: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "පරිශීලක සැකසුම්"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "සැබෑ නාමය: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "පරිශීලක නාමය: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "පද්ධති සැකසුම්"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Mounting %(partition)s on %(mountpoint)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "ස්ථාපනය අවසානයි"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "ස්ථාපනයේ දෝෂය"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "පද්ධති සැකසුම්"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -405,10 +1109,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -435,7 +1135,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Mounting %(partition)s on %(mountpoint)s"
@@ -455,677 +1155,63 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "යතුරු පුවරු විකල්ප සකසමින්"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "යතුරු පුවරු විකල්ප සකසමින්"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 msgid "Removing extra packages"
 msgstr ""
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "ඇරඹුම් ප්‍රවේශ කාරකය පිහිටුවමින්"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "ඇරඹුම් ප්‍රවේශ කාරකය වින්‍යාසගතකරමින්"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "ස්ථාපනය අවසානයි"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "ඇරඹුම් ප්‍රවේශ කාරකය පරික්ෂා කරමින්"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "සැකැස්ම"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "විචල්‍ය"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "උපාංගය"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "වර්‍ගය"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "මෙහෙයුම් පද්ධතිය"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "ප්‍රමාණය"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "නිදහස් අවකාශය"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "ස්වදේශිකරණය"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "භාෂාව: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "වේලා කලාපය: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "යතුරුපුවරුවේ සැකැස්ම: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "පරිශීලක සැකසුම්"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "සැබෑ නාමය: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "පරිශීලක නාමය: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "පද්ධති සැකසුම්"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "ස්ථාපනයේ දෝෂය"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "යතුරුපුවරුවේ සැකැස්ම: "
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "ස්ථාපනයේ දෝෂය"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "පද්ධති සැකසුම්"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-sk.po
+++ b/po/live-installer-sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2018-10-13 12:22+0000\n"
 "Last-Translator: Vendelín Slezák <Unknown>\n"
 "Language-Team: Slovak <sk@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -189,9 +189,9 @@ msgid "Format"
 msgstr "Formátovať ako"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -295,6 +295,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Formátovať ako"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -325,8 +331,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "OK"
 
@@ -415,23 +421,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Krajina"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Rozloženie"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Variant"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Výpočet indexov súborov..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Odstrániteľné:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Upraviť"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Priradiť k /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -449,10 +526,104 @@ msgstr "Výpočet indexov súborov..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Voľné miesto"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Logický oddiel"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Rozšírený oddiel"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Neznámy"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Upraviť oddiel"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Upraviť oddiel"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Zariadenie:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Formátovať ako:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Bod pripojenia:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Zrušiť"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Krajina"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Rozloženie"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Výpočet indexov súborov..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -567,18 +738,6 @@ msgstr "Formátovať ako"
 msgid "Size"
 msgstr "Veľkosť"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Voľné miesto"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -611,25 +770,6 @@ msgstr "Ukončiť?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Ste si istý, že chcete ukončiť inštaláciu?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -869,7 +1009,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Inštalácia dokončená"
 
@@ -889,139 +1029,6 @@ msgstr "Chyba inštalácie"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Odstrániteľné:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Upraviť"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Priradiť k /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Logický oddiel"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Rozšírený oddiel"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Neznámy"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Upraviť oddiel"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Upraviť oddiel"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Zariadenie:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Formátovať ako:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Bod pripojenia:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Zrušiť"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1180,64 +1187,64 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formátuje %(partition)s ako %(format)s..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Nastavuje sa názov počítača"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Nastavujú sa národné nastavenia"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Nastavuje sa názov počítača"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Nastavujú sa možnosti klávesnice"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Odstraňujú sa live konfigurácie (balíky)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Inštaluje sa zavádzač"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Nastavuje sa zavádzač"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 "UPOZORNENIE: Zavádzač grub nebol správne nastavený! Musíte ho nastaviť ručne."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Kontroluje sa zavádzač"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-sk.po
+++ b/po/live-installer-sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2018-10-13 12:22+0000\n"
 "Last-Translator: Vendelín Slezák <Unknown>\n"
 "Language-Team: Slovak <sk@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Časové pásmo"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Upraviť oddiel"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Rozšírený režim"
@@ -149,142 +151,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Obnoviť"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Formátovať ako"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Upraviť diskové oddiely"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Prihlásiť automaticky"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -313,6 +321,711 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "OK"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Nie"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Áno"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Časové pásmo"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Jazyk"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Rozloženie klávesnice"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Inštalácia pozastavená"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Typ"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Krajina"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Rozloženie"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Výpočet indexov súborov..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Rozloženie klávesnice"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Ste si istý, že chcete ukončiť inštaláciu?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Rozdelenie diskových oddielov"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Zhrnutie"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Späť"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Upraviť diskové oddiely"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Zariadenie"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Operačný systém"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Bod pripojenia"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Formátovať ako"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Veľkosť"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Voľné miesto"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Inštalovať"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Vaše heslá sa nezhodujú."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Ukončiť?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Ste si istý, že chcete ukončiť inštaláciu?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Prosím zvoľte jazyk"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Prosím zadajte heslo pre váš účet."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Prosím zadajte vaše celé meno."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Vaše heslá sa nezhodujú."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "Diskový oddiel EFI nie je spustiteľným. Prosím upravte jeho príznaky."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Prosím zvoľte koreňový (/) diskový oddiel."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "Diskový oddiel EFI nie je spustiteľným. Prosím upravte jeho príznaky."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "Diskový oddiel EFI musí byť naformátovaný ako vfat."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "Diskový oddiel EFI musí byť naformátovaný ako vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Prosím zvoľte diskový oddiel EFI."
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Prosím zadajte používateľské meno."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Lokalizácia"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Jazyk: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Časové pásmo: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Rozloženie klávesnice: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Používateľské nastavenia"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Skutočné meno: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Použivateľské meno: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Automatické prihlásovanie: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "zapnuté"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "Vypnuté"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Systémové nastavenia"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Operácie so súborovým systémom"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Nainštalovať zavádzač na %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Neinštalovať zavádzač"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Použite už pripojený /target."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Formátovať %(path)s ako %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Pripojiť %(path)s ako %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Pripojiť %(path)s ako %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Inštalácia dokončená"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Inštalácia je hotová. Chcete počítač pre použitie nového systému reštartovať?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Chyba inštalácie"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Odstrániteľné:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Upraviť"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Priradiť k /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Logický oddiel"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Rozšírený oddiel"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Neznámy"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Upraviť oddiel"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Upraviť oddiel"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Zariadenie:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Formátovať ako:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Bod pripojenia:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Zrušiť"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -421,10 +1134,6 @@ msgstr "Vaše heslá sa nezhodujú."
 msgid "Please provide a password for your user account."
 msgstr "Prosím zadajte heslo pre váš účet."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -451,7 +1160,7 @@ msgstr "Pridáva sa nový používateľ do systému"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Zapisovanie informácií o pripojenom súborovom systéme do /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Pripája sa %(partition)s na %(mountpoint)s"
@@ -471,689 +1180,66 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formátuje %(partition)s ako %(format)s..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Nastavuje sa názov počítača"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Nastavujú sa národné nastavenia"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Nastavuje sa názov počítača"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Nastavujú sa možnosti klávesnice"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Odstraňujú sa live konfigurácie (balíky)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Inštaluje sa zavádzač"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Nastavuje sa zavádzač"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 "UPOZORNENIE: Zavádzač grub nebol správne nastavený! Musíte ho nastaviť ručne."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Inštalácia dokončená"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Kontroluje sa zavádzač"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Krajina"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Jazyk"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Rozloženie"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Variant"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Výpočet indexov súborov..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Rozloženie klávesnice"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Ste si istý, že chcete ukončiť inštaláciu?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Rozdelenie diskových oddielov"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Zhrnutie"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Späť"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Upraviť diskové oddiely"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Zariadenie"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Typ"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Operačný systém"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Bod pripojenia"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Formátovať ako"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Veľkosť"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Voľné miesto"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Inštalovať"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Vaše heslá sa nezhodujú."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Ukončiť?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Ste si istý, že chcete ukončiť inštaláciu?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Prosím zvoľte jazyk"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Prosím zadajte heslo pre váš účet."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Prosím zadajte vaše celé meno."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Vaše heslá sa nezhodujú."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "Diskový oddiel EFI nie je spustiteľným. Prosím upravte jeho príznaky."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Prosím zvoľte koreňový (/) diskový oddiel."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "Diskový oddiel EFI nie je spustiteľným. Prosím upravte jeho príznaky."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "Diskový oddiel EFI musí byť naformátovaný ako vfat."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "Diskový oddiel EFI musí byť naformátovaný ako vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Prosím zvoľte diskový oddiel EFI."
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Prosím zadajte používateľské meno."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Lokalizácia"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Jazyk: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Časové pásmo: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Rozloženie klávesnice: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Používateľské nastavenia"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Skutočné meno: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Použivateľské meno: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Automatické prihlásovanie: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "zapnuté"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "Vypnuté"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Systémové nastavenia"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Operácie so súborovým systémom"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Nainštalovať zavádzač na %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Neinštalovať zavádzač"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Použite už pripojený /target."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Formátovať %(path)s ako %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Pripojiť %(path)s ako %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Inštalácia je hotová. Chcete počítač pre použitie nového systému reštartovať?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Chyba inštalácie"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Rozloženie klávesnice"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Inštalácia pozastavená"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Časové pásmo"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Odstrániteľné:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Upraviť"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Priradiť k /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Logický oddiel"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Rozšírený oddiel"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Neznámy"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Upraviť oddiel"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Upraviť oddiel"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Zariadenie:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Formátovať ako:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Bod pripojenia:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Zrušiť"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "OK"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Nie"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Áno"
 
 #~ msgid "Quit"
 #~ msgstr "Zavrieť"

--- a/po/live-installer-sl.po
+++ b/po/live-installer-sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2019-03-08 21:38+0000\n"
 "Last-Translator: MountainLynx <Unknown>\n"
 "Language-Team: Slovenian <sl@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Časovni pas"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Uredi razdelek"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Napredni način"
@@ -149,142 +151,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Osveži"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Formatiraj kot"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Uredi razdelke"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Prijavi me samodejno"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -313,6 +321,712 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "V redu"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Ne"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Da"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Časovni pas"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Jezik"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Razporeditev tipk"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Namestitev je v premoru"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Vrsta"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Država"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Razporeditev"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Različica"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Računanje datotečnih kazal ..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Razporeditev tipk"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Ali ste prepričani, da želite končati namestilnik?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Ustvarjanje razdelkov"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Povzetek"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Nazaj"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Uredi razdelke"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Naprava"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Operacijski sistem"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Priklopna točka"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Formatiraj kot"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Velikost"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Nezaseden prostor"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Namesti"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Vaši gesli se ne ujemata."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Končaj?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Ali ste prepričani, da želite končati namestilnik?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Izberite jezik"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Vpišite geslo za vaš uporabniški račun."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Vpišite svoje ime in priimek."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Vaši gesli se ne ujemata."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "Razdelek EFI ni zagonski. Uredite zastavice razdelka."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Izberite korenski (/) razdelek."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "Razdelek EFI ni zagonski. Uredite zastavice razdelka."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "Razdelek EFI mora biti zapisan kot vfat."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "Razdelek EFI mora biti zapisan kot vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Izberite razdelek EFI."
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Vpišite uporabniško ime."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Krajevna prilagoditev"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Jezik: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Časovni pas: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Razporeditev tipk: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Uporabniške nastavitve"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Pravo ime: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Uporabniško ime: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Samodejna prijava: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "omogočeno"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "onemogočeno"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Sistemske nastavitve"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Opravila datotečnega sistema"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Namesti zagonski nalagalnik na %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Ne namesti zagonskega nalagalnika"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Uporabi že priklopljen /target."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Formatiraj %(path)s kot %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Priklopi %(path)s kot %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Priklopi %(path)s kot %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Namestitev je končana"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Namestitev je zdaj končana. Ali želite znova zagnati računalnik za uporabo "
+"novega sistema?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Napaka med namestitvijo"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Odstranljivo:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Uredi"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Dodeli v /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Logični razdelek"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Razširjeni razdelek"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Neznano"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Uredi razdelek"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Uredi razdelek"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Naprava:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Formatiraj kot:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Priklopna točka:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Prekliči"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -421,10 +1135,6 @@ msgstr "Vaši gesli se ne ujemata."
 msgid "Please provide a password for your user account."
 msgstr "Vpišite geslo za vaš uporabniški račun."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -451,7 +1161,7 @@ msgstr "Dodajanje novega uporabnika v sistem"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Zapisovanje podatkov o priklopu datotečnega sistema v /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Priklapljanje %(partition)s na %(mountpoint)s"
@@ -471,49 +1181,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formatiranje %(partition)s kot %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Določanje imena gostitelja"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Določanje jezikovnih oznak"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Določanje imena gostitelja"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Določanje možnosti tipkovnice"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Odstranjevanje \"žive\" nastavitve (paketi)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Nameščanje zagonskega nalagalnika"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Nastavljanje zagonskega nalagalnika"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -521,641 +1231,17 @@ msgstr ""
 "OPOZORILO: zagonski nalagalnik grub ni bil pravilno nastavljen! Potrebno ga "
 "je nastaviti ročno."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Namestitev je končana"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Preverjanje zagonskega nalagalnika"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Država"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Jezik"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Razporeditev"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Različica"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Računanje datotečnih kazal ..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Razporeditev tipk"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Ali ste prepričani, da želite končati namestilnik?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Ustvarjanje razdelkov"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Povzetek"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Nazaj"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Uredi razdelke"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Naprava"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Vrsta"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Operacijski sistem"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Priklopna točka"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Formatiraj kot"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Velikost"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Nezaseden prostor"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Namesti"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Vaši gesli se ne ujemata."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Končaj?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Ali ste prepričani, da želite končati namestilnik?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Izberite jezik"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Vpišite geslo za vaš uporabniški račun."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Vpišite svoje ime in priimek."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Vaši gesli se ne ujemata."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "Razdelek EFI ni zagonski. Uredite zastavice razdelka."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Izberite korenski (/) razdelek."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "Razdelek EFI ni zagonski. Uredite zastavice razdelka."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "Razdelek EFI mora biti zapisan kot vfat."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "Razdelek EFI mora biti zapisan kot vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Izberite razdelek EFI."
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Vpišite uporabniško ime."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Krajevna prilagoditev"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Jezik: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Časovni pas: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Razporeditev tipk: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Uporabniške nastavitve"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Pravo ime: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Uporabniško ime: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Samodejna prijava: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "omogočeno"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "onemogočeno"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Sistemske nastavitve"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Opravila datotečnega sistema"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Namesti zagonski nalagalnik na %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Ne namesti zagonskega nalagalnika"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Uporabi že priklopljen /target."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Formatiraj %(path)s kot %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Priklopi %(path)s kot %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Namestitev je zdaj končana. Ali želite znova zagnati računalnik za uporabo "
-"novega sistema?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Napaka med namestitvijo"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Razporeditev tipk"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Namestitev je v premoru"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Časovni pas"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Odstranljivo:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Uredi"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Dodeli v /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Logični razdelek"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Razširjeni razdelek"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Neznano"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Uredi razdelek"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Uredi razdelek"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Naprava:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Formatiraj kot:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Priklopna točka:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Prekliči"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "V redu"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Ne"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Da"
 
 #~ msgid "Quit"
 #~ msgstr "Izhod"

--- a/po/live-installer-sl.po
+++ b/po/live-installer-sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2019-03-08 21:38+0000\n"
 "Last-Translator: MountainLynx <Unknown>\n"
 "Language-Team: Slovenian <sl@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -189,9 +189,9 @@ msgid "Format"
 msgstr "Formatiraj kot"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -295,6 +295,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Formatiraj kot"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -325,8 +331,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "V redu"
 
@@ -415,23 +421,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Država"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Razporeditev"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Različica"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Računanje datotečnih kazal ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Odstranljivo:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Uredi"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Dodeli v /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -449,10 +526,104 @@ msgstr "Računanje datotečnih kazal ..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Nezaseden prostor"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Logični razdelek"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Razširjeni razdelek"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Neznano"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Uredi razdelek"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Uredi razdelek"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Naprava:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Formatiraj kot:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Priklopna točka:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Prekliči"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Država"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Razporeditev"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Različica"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Računanje datotečnih kazal ..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -567,18 +738,6 @@ msgstr "Formatiraj kot"
 msgid "Size"
 msgstr "Velikost"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Nezaseden prostor"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -611,25 +770,6 @@ msgstr "Končaj?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Ali ste prepričani, da želite končati namestilnik?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -869,7 +1009,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Namestitev je končana"
 
@@ -890,139 +1030,6 @@ msgstr "Napaka med namestitvijo"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Odstranljivo:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Uredi"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Dodeli v /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Logični razdelek"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Razširjeni razdelek"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Neznano"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Uredi razdelek"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Uredi razdelek"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Naprava:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Formatiraj kot:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Priklopna točka:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Prekliči"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1181,49 +1188,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formatiranje %(partition)s kot %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Določanje imena gostitelja"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Določanje jezikovnih oznak"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Določanje imena gostitelja"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Določanje možnosti tipkovnice"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Odstranjevanje \"žive\" nastavitve (paketi)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Nameščanje zagonskega nalagalnika"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Nastavljanje zagonskega nalagalnika"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1231,15 +1238,15 @@ msgstr ""
 "OPOZORILO: zagonski nalagalnik grub ni bil pravilno nastavljen! Potrebno ga "
 "je nastaviti ročno."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Preverjanje zagonskega nalagalnika"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-sn.po
+++ b/po/live-installer-sn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2011-07-13 10:32+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Shona <sn@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,140 +149,146 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 msgid "Edit Partitions"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -308,6 +316,699 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+msgid "Keyboard Model"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:73
+msgid "Installation type?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -403,10 +1104,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -433,7 +1130,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr ""
@@ -453,671 +1150,60 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 msgid "Removing extra packages"
 msgstr ""
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr ""
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-msgid "Keyboard Model"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:73
-msgid "Installation type?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""

--- a/po/live-installer-sn.po
+++ b/po/live-installer-sn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2011-07-13 10:32+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Shona <sn@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -291,6 +291,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -320,8 +325,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -407,23 +412,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -441,9 +517,102 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -558,18 +727,6 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -601,25 +758,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -854,7 +992,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr ""
 
@@ -873,138 +1011,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1150,60 +1156,60 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 msgid "Removing extra packages"
 msgstr ""
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""

--- a/po/live-installer-so.po
+++ b/po/live-installer-so.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2012-06-04 16:32+0000\n"
 "Last-Translator: Ismael Omar <ismaelhssn@gmail.com>\n"
 "Language-Team: Somali <so@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -292,6 +292,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -322,8 +327,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -411,23 +416,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Qaabka muuqaalka"
-
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Ka duwan"
-
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -445,9 +521,103 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Masaaxadda banaan"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Setting-yadda siistamka"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Qaabka muuqaalka"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Ka duwan"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -562,18 +732,6 @@ msgstr ""
 msgid "Size"
 msgstr "Xajmiga"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Masaaxadda banaan"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -605,25 +763,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -858,7 +997,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Shubiddu wey dhamaatay"
 
@@ -877,139 +1016,6 @@ msgstr "Qalad haka shubidda"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Setting-yadda siistamka"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1155,49 +1161,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Fadhiisinayaa sooraha"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Fadhiisinayaa maxaliga"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Fadhiisinayaa sooraha"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Fadhiisinayaa qiyaaraadka kiiboorka"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Bixinayaa tafdiilaadka xayda ah (kurjumadda)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Shubayaa rarekiciyaha"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Hagaajinayaa rarekiciyaha"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1205,15 +1211,15 @@ msgstr ""
 "DIGNIIN: rarekiciyaha ma dhameystirmin diyaar gareyntiisa! Waxaa u "
 "baahantahay inaad adigu gacmahaada ku saxdid"
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Hubinayaa rarekiciyaha"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-so.po
+++ b/po/live-installer-so.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2012-06-04 16:32+0000\n"
 "Last-Translator: Ismael Omar <ismaelhssn@gmail.com>\n"
 "Language-Team: Somali <so@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,141 +149,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Setting-yadda siistamka"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -310,6 +318,702 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Qaabka kiiboorka: "
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Qalad haka shubidda"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Nooca"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Qaabka muuqaalka"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Ka duwan"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Aaladda"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Siistamka Shaqeynaya"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "barta rakibidda"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Xajmiga"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Masaaxadda banaan"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Maxaliyeynta"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Luqadda: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Soonaha saacadda: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Qaabka kiiboorka: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Setting-yadda isticmaalaha"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Magaca runta ah: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Magaca isticmaalaha: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Setting-yadda siistamka"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "howlaha feel siistamka"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Ha shubin rarekiciyaha"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Rakibayaa %(partition)s dusha %(mountpoint)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Shubiddu wey dhamaatay"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Qalad haka shubidda"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Setting-yadda siistamka"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -405,10 +1109,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -435,7 +1135,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Rakibayaa %(partition)s dusha %(mountpoint)s"
@@ -455,49 +1155,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Fadhiisinayaa sooraha"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Fadhiisinayaa maxaliga"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Fadhiisinayaa sooraha"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Fadhiisinayaa qiyaaraadka kiiboorka"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Bixinayaa tafdiilaadka xayda ah (kurjumadda)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Shubayaa rarekiciyaha"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Hagaajinayaa rarekiciyaha"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -505,630 +1205,16 @@ msgstr ""
 "DIGNIIN: rarekiciyaha ma dhameystirmin diyaar gareyntiisa! Waxaa u "
 "baahantahay inaad adigu gacmahaada ku saxdid"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Shubiddu wey dhamaatay"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Hubinayaa rarekiciyaha"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Qaabka muuqaalka"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Ka duwan"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Aaladda"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Nooca"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Siistamka Shaqeynaya"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "barta rakibidda"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Xajmiga"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Masaaxadda banaan"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Maxaliyeynta"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Luqadda: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Soonaha saacadda: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Qaabka kiiboorka: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Setting-yadda isticmaalaha"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Magaca runta ah: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Magaca isticmaalaha: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Setting-yadda siistamka"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "howlaha feel siistamka"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Ha shubin rarekiciyaha"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Qalad haka shubidda"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Qaabka kiiboorka: "
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Qalad haka shubidda"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Setting-yadda siistamka"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-sq.po
+++ b/po/live-installer-sq.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2016-07-21 13:03+0000\n"
 "Last-Translator: Indrit Bashkimi <indrit.bashkimi@gmail.com>\n"
 "Language-Team: Albanian <sq@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Zonë kohe"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Modifiko particionet"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Mënyra e avancuar"
@@ -149,142 +151,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Rifresko"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Formato si"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Modifiko particionet"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Hyr automatikisht"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -313,6 +321,712 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Zonë kohe"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Gjuha"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Skema e tastierës"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Gabim instalimi"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Lloji"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Shteti"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Faqosja"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Varianti"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Duke llogaritur indekset e skedarëve"
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Skema e tastierës"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Jeni të sigurt që dëshironi të dilni nga instaluesi?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Particionimi"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Përmbledhje"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Modifiko particionet"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Pajisja"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Sistemi operativ"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Pika e montimit"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Formato si"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Përmasa"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Hapësira e lirë"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Fjalëkalimet nuk përputhen."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Të Dal?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Jeni të sigurt që dëshironi të dilni nga instaluesi?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Zgjidhni një gjuhë"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Ju lutemi jepni një fjalëkalim për llogarinë tuaj."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Ju lutemi jepni emrin tuaj të plotë."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Fjalëkalimet nuk përputhen."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "Ndarje EFI nuk është bootable. Ju lutemi editoni flamujt ndarje."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "Ndarje EFI nuk është bootable. Ju lutemi editoni flamujt ndarje."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "Ndarje EFI duhet të jetë i formatuar si VFAT."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "Ndarje EFI duhet të jetë i formatuar si VFAT."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Ju lutemi jepni një emër përdoruesi."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Lokalizimi"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Gjuha: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Zona Kohore: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Dalja e tastierës: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Parametrat e përdoruesve"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Emri i vërtetë: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Emri i përdruesit: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "aktivizuar"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "çaktivizuar"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Parametrat e sistemit"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Veprimet e sistemit të skedarëve"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Mos e instalo ngarkuesin e nisjes"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Duke montuar %(partition)s në %(mountpoint)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Instalimi përfundoi"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Instalimi u kompletua. Dëshironi të rindizni kompjuterin për të përdorur "
+"sistemin e ri?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Gabim instalimi"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Ndrysho"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Panjohur"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Modifiko particionet"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Pajisja:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Formato si:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Pika e montimit:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -421,10 +1135,6 @@ msgstr "Fjalëkalimet nuk përputhen."
 msgid "Please provide a password for your user account."
 msgstr "Ju lutemi jepni një fjalëkalim për llogarinë tuaj."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -451,7 +1161,7 @@ msgstr "Duke shtuar përdoruesin e ri në sistem"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Duke shkruat informacionet e montimit të filesystem-it në /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Duke montuar %(partition)s në %(mountpoint)s"
@@ -471,49 +1181,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Duke formatuar %(partition)s si %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Duke vendosur hostname-in"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Duke vendosur lokalet"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Duke vendosur hostname-in"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Duke vendosur opsionet e tastierës"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Duke hequr konfigurimin live (paketat)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Duke instaluar bootloader-in"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Duke konfiguruar ngarkuesin e sistemit"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -521,640 +1231,16 @@ msgstr ""
 "KUJDES: Ngarkuesi i sistemit grub nuk u konfigurua siç duhet! Ju duhet ta "
 "konfiguroni atë në mënyrë manuale."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Instalimi përfundoi"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Duke kontrolluar ngarkuesin e sistemit"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Shteti"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Gjuha"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Faqosja"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Varianti"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Duke llogaritur indekset e skedarëve"
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Skema e tastierës"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Jeni të sigurt që dëshironi të dilni nga instaluesi?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Particionimi"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Përmbledhje"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Modifiko particionet"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Pajisja"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Lloji"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Sistemi operativ"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Pika e montimit"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Formato si"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Përmasa"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Hapësira e lirë"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Fjalëkalimet nuk përputhen."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Të Dal?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Jeni të sigurt që dëshironi të dilni nga instaluesi?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Zgjidhni një gjuhë"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Ju lutemi jepni një fjalëkalim për llogarinë tuaj."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Ju lutemi jepni emrin tuaj të plotë."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Fjalëkalimet nuk përputhen."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "Ndarje EFI nuk është bootable. Ju lutemi editoni flamujt ndarje."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "Ndarje EFI nuk është bootable. Ju lutemi editoni flamujt ndarje."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "Ndarje EFI duhet të jetë i formatuar si VFAT."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "Ndarje EFI duhet të jetë i formatuar si VFAT."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Ju lutemi jepni një emër përdoruesi."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Lokalizimi"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Gjuha: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Zona Kohore: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Dalja e tastierës: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Parametrat e përdoruesve"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Emri i vërtetë: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Emri i përdruesit: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "aktivizuar"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "çaktivizuar"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Parametrat e sistemit"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Veprimet e sistemit të skedarëve"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Mos e instalo ngarkuesin e nisjes"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Instalimi u kompletua. Dëshironi të rindizni kompjuterin për të përdorur "
-"sistemin e ri?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Gabim instalimi"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Skema e tastierës"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Gabim instalimi"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Zonë kohe"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Ndrysho"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Panjohur"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Modifiko particionet"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Pajisja:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Formato si:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Pika e montimit:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-sq.po
+++ b/po/live-installer-sq.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2016-07-21 13:03+0000\n"
 "Last-Translator: Indrit Bashkimi <indrit.bashkimi@gmail.com>\n"
 "Language-Team: Albanian <sq@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -189,9 +189,9 @@ msgid "Format"
 msgstr "Formato si"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -295,6 +295,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Formato si"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -325,8 +331,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -415,23 +421,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Shteti"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Faqosja"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Varianti"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Duke llogaritur indekset e skedarëve"
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Ndrysho"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -449,10 +526,104 @@ msgstr "Duke llogaritur indekset e skedarëve"
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Hapësira e lirë"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Panjohur"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Modifiko particionet"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Pajisja:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Formato si:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Pika e montimit:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Shteti"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Faqosja"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Varianti"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Duke llogaritur indekset e skedarëve"
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -567,18 +738,6 @@ msgstr "Formato si"
 msgid "Size"
 msgstr "Përmasa"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Hapësira e lirë"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -611,25 +770,6 @@ msgstr "Të Dal?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Jeni të sigurt që dëshironi të dilni nga instaluesi?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -869,7 +1009,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Instalimi përfundoi"
 
@@ -890,139 +1030,6 @@ msgstr "Gabim instalimi"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Ndrysho"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Panjohur"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Modifiko particionet"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Pajisja:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Formato si:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Pika e montimit:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1181,49 +1188,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Duke formatuar %(partition)s si %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Duke vendosur hostname-in"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Duke vendosur lokalet"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Duke vendosur hostname-in"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Duke vendosur opsionet e tastierës"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Duke hequr konfigurimin live (paketat)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Duke instaluar bootloader-in"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Duke konfiguruar ngarkuesin e sistemit"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1231,15 +1238,15 @@ msgstr ""
 "KUJDES: Ngarkuesi i sistemit grub nuk u konfigurua siç duhet! Ju duhet ta "
 "konfiguroni atë në mënyrë manuale."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Duke kontrolluar ngarkuesin e sistemit"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-sr.po
+++ b/po/live-installer-sr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2020-03-06 16:30+0000\n"
 "Last-Translator: Knez <Unknown>\n"
 "Language-Team: Serbian <gnom@prevod.org>\n"
@@ -96,7 +96,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -198,9 +198,9 @@ msgid "Format"
 msgstr "Форматирај као"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -305,6 +305,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Форматирај као"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -336,8 +342,8 @@ msgstr "Добродошли"
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "У реду"
 
@@ -429,23 +435,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr "Добродошли"
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Држава"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Распоред"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Варијанта"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Израчунавам индексе датотека ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Уклоњиво:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Уреди"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Додели за „/“"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -463,10 +540,108 @@ msgstr "Израчунавам индексе датотека ..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr "Инсталациони програм"
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Слободно"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"Таблица партиција није могла бити написана за %s. Поново покрените рачунар и "
+"покушајте поново."
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"Партиција %s не може да се направи. Инсталација ће се зауставити. Поново "
+"покрените рачунар и покушајте поново."
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Логичка партиција"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Проширена партиција"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "непознато"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Уреди партицију"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Уреди партицију"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Уређај:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Форматирај као:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Тачка монирања:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Откажи"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Држава"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Распоред"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Варијанта"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Израчунавам индексе датотека ..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -584,18 +759,6 @@ msgstr "Форматирај као"
 msgid "Size"
 msgstr "Величина"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Слободно"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -628,25 +791,6 @@ msgstr "Одустати?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Заиста желите да напустите програм за инсталацију?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -908,7 +1052,7 @@ msgid "Disk Encryption: "
 msgstr "Шифрирање диска: "
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Инсталација је завршена"
 
@@ -929,143 +1073,6 @@ msgstr "Грешка инсталације"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Уклоњиво:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Уреди"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Додели за „/“"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"Таблица партиција није могла бити написана за %s. Поново покрените рачунар и "
-"покушајте поново."
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"Партиција %s не може да се направи. Инсталација ће се зауставити. Поново "
-"покрените рачунар и покушајте поново."
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Логичка партиција"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Проширена партиција"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "непознато"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Уреди партицију"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Уреди партицију"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Уређај:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Форматирај као:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Тачка монирања:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Откажи"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1226,49 +1233,49 @@ msgstr "Креирајте партиције на %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Форматирам „%(partition)s“ као „%(format)s“ ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Постављам назив рачунара"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Постављам језик"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Постављам назив рачунара"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Подешавам опције тастатуре"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Уклањам подешавања и пакете за рад уживо"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Инсталирам подизач система"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Подешавам подизача система"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1276,15 +1283,15 @@ msgstr ""
 "УПОЗОРЕЊЕ: Подизач система није правилно подешен! Морате ручно да га "
 "подесите."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Проверавам подизача система"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-sr.po
+++ b/po/live-installer-sr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2020-03-06 16:30+0000\n"
 "Last-Translator: Knez <Unknown>\n"
 "Language-Team: Serbian <gnom@prevod.org>\n"
@@ -25,8 +25,8 @@ msgid "Welcome to the 17g Installer."
 msgstr "Добродошли у 17G инсталациони програм."
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 #, fuzzy
 msgid ""
 "This program will ask you some questions and set up system on your computer."
@@ -35,12 +35,12 @@ msgstr ""
 "рачунару."
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr "Модел тастатуре:"
 
@@ -50,10 +50,12 @@ msgid "Type here to test your keyboard"
 msgstr "Овде унесите нешто како бисте тестирали распоред тастатуре"
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -62,13 +64,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Временска зона"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr "Аутоматска инсталација"
 
@@ -78,12 +80,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr "Обриши диск и инсталирај 17G на њега."
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr "Диск:"
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Уреди партицију"
@@ -94,42 +96,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr "Користи LVM (Управитеља Логичким Уређајима)"
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr "Шифрирај оперативни систем"
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr "Лозинка"
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr "Потврди лозинку"
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr "Ручно партиционирање"
 
@@ -147,7 +149,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Напредни режим"
@@ -157,144 +159,150 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 #, fuzzy
 msgid "Minimal installation"
 msgstr "Аутоматска инсталација"
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Освежи"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Форматирај као"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr "Инсталирај GRUB изборник покретања система на:"
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Уредите партиције"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr "Ваше име:"
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr "Назив вашег рачунара:"
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr "Изаберите корисничко име:"
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr "Назив које ће се користити за комуникацију са осталим рачунарима."
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr "Изаберите лозинку:"
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Пријави ме без лозинке"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr "Затражи моју лозинку приликом пријаве"
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr "Шифрирај моју личну фасциклу"
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr "Потврдите вашу лозинку:"
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 #, fuzzy
 msgid "Automated installation enabled!"
 msgstr "Аутоматска инсталација на %s"
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr "Добродошли"
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -325,6 +333,744 @@ msgstr ""
 #, fuzzy
 msgid "Welcome to 17g"
 msgstr "Добродошли"
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "У реду"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Не"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Да"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Временска зона"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, fuzzy, python-format
+msgid "Welcome to the %s Installer."
+msgstr "Добродошли у 17G инсталациони програм."
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr "Који језик желите да користите?"
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Језик"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr "Где се налазите?"
+
+#: live-installer/frontend/tui_interface.py:57
+#, fuzzy
+msgid "What keyboard would you like to use?"
+msgstr "Који језик желите да користите?"
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Модел тастатуре:"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Врста инсталације"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Врста"
+
+#: live-installer/frontend/tui_interface.py:80
+#, fuzzy
+msgid "Select a disk?"
+msgstr "Изаберите диск."
+
+#: live-installer/frontend/tui_interface.py:84
+#, fuzzy
+msgid "Disk"
+msgstr "Диск:"
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, fuzzy, python-format
+msgid "Welcome to %s"
+msgstr "Добродошли"
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Држава"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Распоред"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Варијанта"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Израчунавам индексе датотека ..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr "Инсталациони програм"
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Распоред тастатуре"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr "Који је ваш распоред тастатуре?"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr "Кориснички налог"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr "Ко сте ви?"
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr "Врста инсталације"
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Где желите да инсталирате 17G?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Уређивање партиција"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Сажетак"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr "Инсталација"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+#, fuzzy
+msgid "Automated Install"
+msgstr "Аутоматска инсталација"
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Назад"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr "Следеће"
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr "Овде унесите нешто како бисте тестирали распоред тастатуре"
+
+#: live-installer/frontend/gtk_interface.py:546
+#, fuzzy
+msgid "Erase a disk and install system on it."
+msgstr "Обриши диск и инсталирај 17G на њега."
+
+#: live-installer/frontend/gtk_interface.py:559
+#, fuzzy
+msgid "Manually create, resize or choose partitions for system."
+msgstr "Ручно направите, промените величину или изаберите партицију за 17G."
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Уредите партиције"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Уређај"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Оперативни систем"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Тачка монтирања"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Форматирај као"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Величина"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Слободно"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr "Упозорење"
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr "Ово ће избрисати све податке на %s. Да ли сте сигурни?"
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Инсталирај"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr "Наведите лозинку за шифрирање."
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Лозинке се не поклапају."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Одустати?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Заиста желите да напустите програм за инсталацију?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Изаберите језик"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Упишите назив вашег рачунара."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Упишите ваше име и презиме."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Лозинке се не поклапају."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "EFI партиција је премала. Мора бити најмање 35МБ"
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Изаберите корену (/) партицију."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, fuzzy, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+"За инсталирање Линукс Минт-а потребна је коренска партиција.\n"
+"\n"
+" - Тачка монтаже: /\n"
+" - Препоручена величина: 30ГБ\n"
+" - Препоручени формат датотечног система: ект4\n"
+"\n"
+"Напомена: Функција креирања Timeshift btrfs снимке система захтева "
+"употребу:\n"
+" - тачке монтаже подуређаја / @\n"
+" - btrfs као формат датотечног система\n"
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "ЕФИ партиција није подизна. Уредите заставице партиције."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "EFI партиција је премала. Мора бити најмање 35МБ"
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "ЕФИ партиција мора да буде форматирана као „vfat“."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Изаберите ЕФИ партицију."
+
+#: live-installer/frontend/gtk_interface.py:1301
+#, fuzzy
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+"Потребна је партиција система ЕФИ са следећим карактеристикама:\n"
+"\n"
+" - Тачка монтирања: /boot/efi\n"
+" - Ознака партиције: Bootable\n"
+" - Величина: најмање 35МБ (препоручује се 100МБ или више)\n"
+" - Формат датотечног система: vfat или fat32\n"
+"\n"
+"Да бисте осигурали компатибилност са Виндовс-има, препоручујемо вам да прву "
+"партицију диска користите као EFI системску партицију.\n"
+" "
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr "Изаберите диск."
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Упишите корисничко име."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Локализација"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Језик: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Временска зона: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Распоред тастатуре: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Корисничка подешавања"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Право име: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Корисничко име: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Самостална пријава: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "укључена"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "искључена"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Подешавања система"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr "Назив рачунала: "
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+#, fuzzy
+msgid "Install updates after installation"
+msgstr "Аутоматска инсталација"
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Радње над системом датотека"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Инсталрирај подизач система на „%s“"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Не инсталирај подизач система"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Користи већ монтирани „/target“."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr "Аутоматска инсталација на %s"
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Форматирај „%(path)s“ као „%(filesystem)s“"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Монтирај „%(path)s“ као „%(mount)s“"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Монтирај „%(path)s“ као „%(mount)s“"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr "LVM: "
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr "Шифрирање диска: "
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Инсталација је завршена"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Инсталација је сада завршена. Да ли желите поново да покренете рачунар и "
+"користите ново инсталирани систем?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Грешка инсталације"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Уклоњиво:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Уреди"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Додели за „/“"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"Таблица партиција није могла бити написана за %s. Поново покрените рачунар и "
+"покушајте поново."
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"Партиција %s не може да се направи. Инсталација ће се зауставити. Поново "
+"покрените рачунар и покушајте поново."
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Логичка партиција"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Проширена партиција"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "непознато"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Уреди партицију"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Уреди партицију"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Уређај:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Форматирај као:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Тачка монирања:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Откажи"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
+msgstr ""
 
 #: live-installer/validate.py:12
 msgid "Please provide a username."
@@ -434,10 +1180,6 @@ msgstr "Лозинке се не поклапају."
 msgid "Please provide a password for your user account."
 msgstr "Упишите лозинку за свој кориснички налог."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -464,7 +1206,7 @@ msgstr "Додајем новог корисника систему"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Уписујем податке за качење система датотека у „/etc/fstab“"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Монтирам „%(partition)s“ на „%(mountpoint)s“"
@@ -484,49 +1226,49 @@ msgstr "Креирајте партиције на %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Форматирам „%(partition)s“ као „%(format)s“ ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Постављам назив рачунара"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Постављам језик"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Постављам назив рачунара"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Подешавам опције тастатуре"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Уклањам подешавања и пакете за рад уживо"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Инсталирам подизач система"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Подешавам подизача система"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -534,673 +1276,17 @@ msgstr ""
 "УПОЗОРЕЊЕ: Подизач система није правилно подешен! Морате ручно да га "
 "подесите."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Инсталација је завршена"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Проверавам подизача система"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Држава"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Језик"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Распоред"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Варијанта"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Израчунавам индексе датотека ..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr "Инсталациони програм"
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr "Који језик желите да користите?"
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr "Где се налазите?"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Распоред тастатуре"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr "Који је ваш распоред тастатуре?"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr "Кориснички налог"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr "Ко сте ви?"
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr "Врста инсталације"
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Где желите да инсталирате 17G?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Уређивање партиција"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Сажетак"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr "Инсталација"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-#, fuzzy
-msgid "Automated install"
-msgstr "Аутоматска инсталација"
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Назад"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr "Следеће"
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, fuzzy, python-format
-msgid "Welcome to the %s Installer."
-msgstr "Добродошли у 17G инсталациони програм."
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr "Овде унесите нешто како бисте тестирали распоред тастатуре"
-
-#: live-installer/frontend/gtk_interface.py:542
-#, fuzzy
-msgid "Erase a disk and install system on it."
-msgstr "Обриши диск и инсталирај 17G на њега."
-
-#: live-installer/frontend/gtk_interface.py:555
-#, fuzzy
-msgid "Manually create, resize or choose partitions for system."
-msgstr "Ручно направите, промените величину или изаберите партицију за 17G."
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Уредите партиције"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Уређај"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Врста"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Оперативни систем"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Тачка монтирања"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Форматирај као"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Величина"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Слободно"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Инсталирај"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr "Наведите лозинку за шифрирање."
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Лозинке се не поклапају."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Одустати?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Заиста желите да напустите програм за инсталацију?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Изаберите језик"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Упишите назив вашег рачунара."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Упишите ваше име и презиме."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Лозинке се не поклапају."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "EFI партиција је премала. Мора бити најмање 35МБ"
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Изаберите корену (/) партицију."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, fuzzy, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-"За инсталирање Линукс Минт-а потребна је коренска партиција.\n"
-"\n"
-" - Тачка монтаже: /\n"
-" - Препоручена величина: 30ГБ\n"
-" - Препоручени формат датотечног система: ект4\n"
-"\n"
-"Напомена: Функција креирања Timeshift btrfs снимке система захтева "
-"употребу:\n"
-" - тачке монтаже подуређаја / @\n"
-" - btrfs као формат датотечног система\n"
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "ЕФИ партиција није подизна. Уредите заставице партиције."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "EFI партиција је премала. Мора бити најмање 35МБ"
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "ЕФИ партиција мора да буде форматирана као „vfat“."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Изаберите ЕФИ партицију."
-
-#: live-installer/frontend/gtk_interface.py:1226
-#, fuzzy
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-"Потребна је партиција система ЕФИ са следећим карактеристикама:\n"
-"\n"
-" - Тачка монтирања: /boot/efi\n"
-" - Ознака партиције: Bootable\n"
-" - Величина: најмање 35МБ (препоручује се 100МБ или више)\n"
-" - Формат датотечног система: vfat или fat32\n"
-"\n"
-"Да бисте осигурали компатибилност са Виндовс-има, препоручујемо вам да прву "
-"партицију диска користите као EFI системску партицију.\n"
-" "
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr "Изаберите диск."
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr "Упозорење"
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr "Ово ће избрисати све податке на %s. Да ли сте сигурни?"
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Упишите корисничко име."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Локализација"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Језик: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Временска зона: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Распоред тастатуре: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Корисничка подешавања"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Право име: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Корисничко име: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Самостална пријава: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "укључена"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "искључена"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Подешавања система"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr "Назив рачунала: "
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-#, fuzzy
-msgid "Install updates after installation"
-msgstr "Аутоматска инсталација"
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Радње над системом датотека"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Инсталрирај подизач система на „%s“"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Не инсталирај подизач система"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Користи већ монтирани „/target“."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr "Аутоматска инсталација на %s"
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Форматирај „%(path)s“ као „%(filesystem)s“"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Монтирај „%(path)s“ као „%(mount)s“"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr "LVM: "
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr "Шифрирање диска: "
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Инсталација је сада завршена. Да ли желите поново да покренете рачунар и "
-"користите ново инсталирани систем?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Грешка инсталације"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, fuzzy, python-format
-msgid "Welcome to %s"
-msgstr "Добродошли"
-
-#: live-installer/frontend/tui_interface.py:57
-#, fuzzy
-msgid "What keyboard would you like to use?"
-msgstr "Који језик желите да користите?"
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Модел тастатуре:"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Врста инсталације"
-
-#: live-installer/frontend/tui_interface.py:80
-#, fuzzy
-msgid "Select a disk?"
-msgstr "Изаберите диск."
-
-#: live-installer/frontend/tui_interface.py:84
-#, fuzzy
-msgid "Disk"
-msgstr "Диск:"
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Временска зона"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Уклоњиво:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Уреди"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Додели за „/“"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"Таблица партиција није могла бити написана за %s. Поново покрените рачунар и "
-"покушајте поново."
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"Партиција %s не може да се направи. Инсталација ће се зауставити. Поново "
-"покрените рачунар и покушајте поново."
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Логичка партиција"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Проширена партиција"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "непознато"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Уреди партицију"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Уреди партицију"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Уређај:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Форматирај као:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Тачка монирања:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Откажи"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "У реду"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Не"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Да"
 
 #~ msgid "Quit"
 #~ msgstr "Одустати"

--- a/po/live-installer-sr@latin.po
+++ b/po/live-installer-sr@latin.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2018-09-20 12:47+0000\n"
 "Last-Translator: Knez <Unknown>\n"
 "Language-Team: Serbian Latin <sr@latin@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Vremenska zona"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Uređivanje particije"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Napredni način"
@@ -149,142 +151,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Osveži"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Formatiraj kao"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Uredi particije"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Automatska prijava"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -313,6 +321,712 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "U redu"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Ne"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Da"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Vremenska zona"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Jezik"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Raspored tastature"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Instalacija pauzirana"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Tip"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Država"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Raspored"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Varijanta:"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Obrada indeksiranja datoteka..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Raspored tastature"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Da li ste sigurni da želite zatvoriti instalacijski program?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Particioniranje"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Sažetak"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Prethodna"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Uredi particije"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Uređaj"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Operativni sistem"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Tačka montiranja"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Formatiraj kao"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Veličina"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Slobodan prostor"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Instaliraj"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Vaša lozinka se ne podudara."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Zatvori?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Da li ste sigurni da želite zatvoriti instalacijski program?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Izaberite jezik"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Molimo upišite lozinku za vaš korisnički nalog."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Upišite svoje ime i prezime."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Vaša lozinka se ne podudara."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "EFI particija ne može pokrenuti sistem. Izmenite oznake particije."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Izaberite korensku (/) particiju."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "EFI particija ne može pokrenuti sistem. Izmenite oznake particije."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "EFI particija mora biti formatirana u vfat datotečnom sistemu."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "EFI particija mora biti formatirana u vfat datotečnom sistemu."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Izaberite EFI particiju."
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Upišite svoje korisničko ime."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Lokalizacija"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Jezik: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Vremenska zona: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Raspored tastature: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Korisničke postavke"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Pravo ime "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Korisničko ime: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Automatska prijava: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "omogućena"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "onemogućena"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Sistemske postavke"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Funkcionisanje sistema datoteka"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Instaliraj učitača pokretanja sistema na %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Nemoj da instaliraš podizni učitavač"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Koristi već montirano /odredište."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Formatiraj %(path)s kao %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Montiraj %(path)s na %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Montiraj %(path)s na %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Instalacija je završena"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Instalacija je sada završena. Da li želite da ponovo pokrenete računar kako "
+"biste počeli da koristite svoj novi sistem?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Greška pri instalaciji"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Uklonjivo:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Uredi"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Dodeli /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Logička particija"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Proširena particija"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Nepoznata"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Uređivanje particije"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Uređivanje particije"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Uređaj:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Formatiraj kao:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Tačka montiranja:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Odustani"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -421,10 +1135,6 @@ msgstr "Vaša lozinka se ne podudara."
 msgid "Please provide a password for your user account."
 msgstr "Molimo upišite lozinku za vaš korisnički nalog."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -451,7 +1161,7 @@ msgstr "Dodavanje novog korisnika u sistem"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Napišite informacije o montiranju datotečnog sistema u /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Montiranje %(partition)s na %(mountpoint)s"
@@ -471,49 +1181,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formatiranje %(partition)s kao %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Podešavanje imena računara"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Lokalno podešavanje"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Podešavanje imena računara"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Podešavanje opcija za tastaturu"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Uklanjanje žive konfiguracije"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Instalacija podiznog učitavača"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Podešavanje podiznog učitavača"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -521,641 +1231,17 @@ msgstr ""
 "UPOZORENJE: Podizni učitavač nije pravilno konfigurisan! Morate da ga "
 "konfigurišete ručno."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Instalacija je završena"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Proveravanje podiznog učitavača"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Država"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Jezik"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Raspored"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Varijanta:"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Obrada indeksiranja datoteka..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Raspored tastature"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Da li ste sigurni da želite zatvoriti instalacijski program?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Particioniranje"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Sažetak"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Prethodna"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Uredi particije"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Uređaj"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Tip"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Operativni sistem"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Tačka montiranja"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Formatiraj kao"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Veličina"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Slobodan prostor"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Instaliraj"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Vaša lozinka se ne podudara."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Zatvori?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Da li ste sigurni da želite zatvoriti instalacijski program?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Izaberite jezik"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Molimo upišite lozinku za vaš korisnički nalog."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Upišite svoje ime i prezime."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Vaša lozinka se ne podudara."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "EFI particija ne može pokrenuti sistem. Izmenite oznake particije."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Izaberite korensku (/) particiju."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "EFI particija ne može pokrenuti sistem. Izmenite oznake particije."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "EFI particija mora biti formatirana u vfat datotečnom sistemu."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "EFI particija mora biti formatirana u vfat datotečnom sistemu."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Izaberite EFI particiju."
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Upišite svoje korisničko ime."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Lokalizacija"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Jezik: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Vremenska zona: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Raspored tastature: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Korisničke postavke"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Pravo ime "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Korisničko ime: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Automatska prijava: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "omogućena"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "onemogućena"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Sistemske postavke"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Funkcionisanje sistema datoteka"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Instaliraj učitača pokretanja sistema na %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Nemoj da instaliraš podizni učitavač"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Koristi već montirano /odredište."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Formatiraj %(path)s kao %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Montiraj %(path)s na %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Instalacija je sada završena. Da li želite da ponovo pokrenete računar kako "
-"biste počeli da koristite svoj novi sistem?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Greška pri instalaciji"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Raspored tastature"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Instalacija pauzirana"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Vremenska zona"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Uklonjivo:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Uredi"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Dodeli /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Logička particija"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Proširena particija"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Nepoznata"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Uređivanje particije"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Uređivanje particije"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Uređaj:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Formatiraj kao:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Tačka montiranja:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Odustani"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "U redu"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Ne"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Da"
 
 #~ msgid "Quit"
 #~ msgstr "Izađi"

--- a/po/live-installer-sr@latin.po
+++ b/po/live-installer-sr@latin.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2018-09-20 12:47+0000\n"
 "Last-Translator: Knez <Unknown>\n"
 "Language-Team: Serbian Latin <sr@latin@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -189,9 +189,9 @@ msgid "Format"
 msgstr "Formatiraj kao"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -295,6 +295,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Formatiraj kao"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -325,8 +331,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "U redu"
 
@@ -415,23 +421,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Država"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Raspored"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Varijanta:"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Obrada indeksiranja datoteka..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Uklonjivo:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Uredi"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Dodeli /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -449,10 +526,104 @@ msgstr "Obrada indeksiranja datoteka..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Slobodan prostor"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Logička particija"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Proširena particija"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Nepoznata"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Uređivanje particije"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Uređivanje particije"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Uređaj:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Formatiraj kao:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Tačka montiranja:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Odustani"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Država"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Raspored"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Varijanta:"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Obrada indeksiranja datoteka..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -567,18 +738,6 @@ msgstr "Formatiraj kao"
 msgid "Size"
 msgstr "Veličina"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Slobodan prostor"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -611,25 +770,6 @@ msgstr "Zatvori?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Da li ste sigurni da želite zatvoriti instalacijski program?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -869,7 +1009,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Instalacija je završena"
 
@@ -890,139 +1030,6 @@ msgstr "Greška pri instalaciji"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Uklonjivo:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Uredi"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Dodeli /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Logička particija"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Proširena particija"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Nepoznata"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Uređivanje particije"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Uređivanje particije"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Uređaj:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Formatiraj kao:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Tačka montiranja:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Odustani"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1181,49 +1188,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formatiranje %(partition)s kao %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Podešavanje imena računara"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Lokalno podešavanje"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Podešavanje imena računara"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Podešavanje opcija za tastaturu"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Uklanjanje žive konfiguracije"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Instalacija podiznog učitavača"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Podešavanje podiznog učitavača"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1231,15 +1238,15 @@ msgstr ""
 "UPOZORENJE: Podizni učitavač nije pravilno konfigurisan! Morate da ga "
 "konfigurišete ručno."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Proveravanje podiznog učitavača"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-sv.po
+++ b/po/live-installer-sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2020-03-10 19:38+0000\n"
 "Last-Translator: Jan-Olof Svensson <jan-olof.svensson@abc.se>\n"
 "Language-Team: Swedish <sv@li.org>\n"
@@ -94,7 +94,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -197,9 +197,9 @@ msgid "Format"
 msgstr "Formatera som"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -304,6 +304,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Formatera som"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -335,8 +341,8 @@ msgstr "Välkommen"
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "OK"
 
@@ -428,23 +434,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr "Välkommen"
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Land"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Utseende"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Variant"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Beräknar fil-index ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Borttagbar:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Redigera"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Tilldela till /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -462,10 +539,108 @@ msgstr "Beräknar fil-index ..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr "Installationsprogram"
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Ledigt utrymme"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"Partitionstabellen för %s kunde inte skrivas. Starta om datorn och försök "
+"igen."
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"Partitionen %s kunde inte skapas. Installationen avbryts. Starta om datorn "
+"och försök igen."
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Logisk partition"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Utökad partition"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Okänd"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Redigera partition"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Redigera partition"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Enhet:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Formatera som:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Monteringspunkt:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Land"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Utseende"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Beräknar fil-index ..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -584,18 +759,6 @@ msgstr "Formatera som"
 msgid "Size"
 msgstr "Storlek"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Ledigt utrymme"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -628,25 +791,6 @@ msgstr "Avsluta?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Är du säker på att du vill avsluta installationsprogrammet?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -908,7 +1052,7 @@ msgid "Disk Encryption: "
 msgstr "Skivkryptering: "
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Installationen är klar"
 
@@ -929,143 +1073,6 @@ msgstr "Installationsfel"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Borttagbar:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Redigera"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Tilldela till /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"Partitionstabellen för %s kunde inte skrivas. Starta om datorn och försök "
-"igen."
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"Partitionen %s kunde inte skapas. Installationen avbryts. Starta om datorn "
-"och försök igen."
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Logisk partition"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Utökad partition"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Okänd"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Redigera partition"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Redigera partition"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Enhet:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Formatera som:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Monteringspunkt:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Avbryt"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1227,49 +1234,49 @@ msgstr "Skapar partitioner på %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formaterar %(partition)s som %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Ställer in värdnamn"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Ställer in språk"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Ställer in värdnamn"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Ställer in tangentbordet"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Avlägsnar nutidskonfiguration (paket)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Installerar starthanterare"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Konfigurerar starthanteraren"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1277,15 +1284,15 @@ msgstr ""
 "VARNING: starthanteraren grub är felaktigt konfigurerad! Du måste "
 "konfigurera den manuellt."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Kontrollerar starthanteraren"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-sv.po
+++ b/po/live-installer-sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2020-03-10 19:38+0000\n"
 "Last-Translator: Jan-Olof Svensson <jan-olof.svensson@abc.se>\n"
 "Language-Team: Swedish <sv@li.org>\n"
@@ -24,8 +24,8 @@ msgid "Welcome to the 17g Installer."
 msgstr "Välkommen till installationsprogrammet för LMDE."
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 #, fuzzy
 msgid ""
 "This program will ask you some questions and set up system on your computer."
@@ -33,12 +33,12 @@ msgstr ""
 "Programmet kommer att ställa några frågor och installera LMDE i din dator."
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr "Tangentbordsmodell:"
 
@@ -48,10 +48,12 @@ msgid "Type here to test your keyboard"
 msgstr "Skriv här för att prova ditt tangentbordsupplägg"
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -60,13 +62,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Tidszon"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr "Automatisk installation"
 
@@ -76,12 +78,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr "Töm enheten och installera LMDE på den."
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr "Skiva:"
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Redigera partition"
@@ -92,42 +94,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr "Använd LVM (Logisk Volym-Hantering)"
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr "Kryptera operativsystemet"
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr "Lösenfras"
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr "Bekräfta lösenfrasen"
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr "Detta ger en extra säkerhet men kan ta flera timmar."
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr "Fyll enheten med slumpmässiga data"
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr "Manuell partitionering"
 
@@ -146,7 +148,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Avancerat läge"
@@ -156,144 +158,150 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 #, fuzzy
 msgid "Minimal installation"
 msgstr "Automatisk installation"
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Uppdatera"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Formatera som"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr "Installera GRUBs startmeny på:"
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Redigera partitioner"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr "Ditt namn:"
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr "Din dators namn:"
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr "Välj ett användarnamn:"
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr "Det namn som används när den pratar med andra datorer."
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr "Välj ett lösenord:"
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Logga in automatiskt"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr "Kräv mitt lösenord för att logga in"
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr "Kryptera min hemmapp"
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr "Bekräfta ditt lösenord:"
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 #, fuzzy
 msgid "Automated installation enabled!"
 msgstr "Automatisk installation på %s"
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr "Välkommen"
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -324,6 +332,745 @@ msgstr ""
 #, fuzzy
 msgid "Welcome to 17g"
 msgstr "Välkommen"
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "OK"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Nej"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Ja"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Tidszon"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, fuzzy, python-format
+msgid "Welcome to the %s Installer."
+msgstr "Välkommen till installationsprogrammet för LMDE."
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr "Vilket språk vill du använda?"
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Språk"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr "Var befinner du dig?"
+
+#: live-installer/frontend/tui_interface.py:57
+#, fuzzy
+msgid "What keyboard would you like to use?"
+msgstr "Vilket språk vill du använda?"
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Tangentbordsmodell:"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Installationstyp"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Typ"
+
+#: live-installer/frontend/tui_interface.py:80
+#, fuzzy
+msgid "Select a disk?"
+msgstr "Var god välj en enhet."
+
+#: live-installer/frontend/tui_interface.py:84
+#, fuzzy
+msgid "Disk"
+msgstr "Skiva:"
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, fuzzy, python-format
+msgid "Welcome to %s"
+msgstr "Välkommen"
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Land"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Utseende"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Variant"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Beräknar fil-index ..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr "Installationsprogram"
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Tangentbordsupplägg"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr "Vad har du för tangentbordsupplägg?"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr "Användarkonto"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr "Vem är du?"
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr "Installationstyp"
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Var vill du installera LMDE?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Partitionering"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Sammanfattning"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr "Installerar"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+#, fuzzy
+msgid "Automated Install"
+msgstr "Automatisk installation"
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Bakåt"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr "Framåt"
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr "Skriv här för att prova ditt tangentbordsupplägg"
+
+#: live-installer/frontend/gtk_interface.py:546
+#, fuzzy
+msgid "Erase a disk and install system on it."
+msgstr "Töm enheten och installera LMDE på den."
+
+#: live-installer/frontend/gtk_interface.py:559
+#, fuzzy
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+"Manuella val för att skapa, storleksändra eller välja partitioner för LMDE."
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Redigera partitioner"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Enhet"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Operativsystem"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Monteringspunkt"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Formatera som"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Storlek"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Ledigt utrymme"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr "Varning"
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr "Alla data på %s kommer att raderas. Är du säker?"
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Installera"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr "Var god välj en lösenfras för krypteringen."
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Dina lösenord stämmer inte överens."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Avsluta?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Är du säker på att du vill avsluta installationsprogrammet?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Var god välj ett språk"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Var god välj ett namn för datorn."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Var god ange ditt fullständiga namn."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Dina lösenord stämmer inte överens."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "EFI-partitionen är för liten. Den måste vara minst 35 MB."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Var god välj en rootpartition (/)."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, fuzzy, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+"Det krävs en root-partition för att installera Linux Mint.\n"
+"\n"
+" - Monteringspunkt: /\n"
+" - Rekommenderad storlek: 30 GB\n"
+" - Rekommenderat filsystem: ext4\n"
+"\n"
+"Tänk på: För att göra systemkopior i btrfs-format med Timeshift krävs:\n"
+" - en undervolym med monteringspunkten /@\n"
+" - btrfs som filsystem\n"
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+"EFI-partitionen är inte angiven som startenhet. Justera partitionsflaggorna."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "EFI-partitionen är för liten. Den måste vara minst 35 MB."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "EFI-partitionen måste vara formaterad som vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Var god välj en EFI-partition."
+
+#: live-installer/frontend/gtk_interface.py:1301
+#, fuzzy
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+"Det behövs en EFI-partition med följande egenskaper:\n"
+"\n"
+" - Monteringspunkt: (boot/efi\n"
+" - Partitionsflaggor: Bootable\n"
+" - Storlek: minst 35 MB (100 MB eller mer rekommenderas)\n"
+" - Formatering: vfat eller fat32\n"
+"\n"
+"För att säkerställa kompatibilitet med Windows rekommenderar vi att du "
+"använder enhetens första partition som EFI-partition.\n"
+" "
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr "Var god välj en enhet."
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Var god ange ett användarnamn."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Landsanpassning"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Språk: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Tidszon: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Tangentbordsupplägg: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Användarinställningar"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Namn: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Användarnamn: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Automatisk inloggning: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "aktiverad"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "inaktiverad"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Systeminställningar"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr "Datorns namn: "
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+#, fuzzy
+msgid "Install updates after installation"
+msgstr "Automatisk installation"
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Filsystemsåtgärder"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Installera starthanteraren på %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Installera inte starthanterare"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Använd redan-monterat /mål."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr "Automatisk installation på %s"
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Formatera %(path)s som %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Montera %(path)s som %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Montera %(path)s som %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr "LVM: "
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr "Skivkryptering: "
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Installationen är klar"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Installationen är färdig. Vill du starta om din dator för att använda det "
+"nya systemet?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Installationsfel"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Borttagbar:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Redigera"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Tilldela till /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"Partitionstabellen för %s kunde inte skrivas. Starta om datorn och försök "
+"igen."
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"Partitionen %s kunde inte skapas. Installationen avbryts. Starta om datorn "
+"och försök igen."
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Logisk partition"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Utökad partition"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Okänd"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Redigera partition"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Redigera partition"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Enhet:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Formatera som:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Monteringspunkt:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
+msgstr ""
 
 #: live-installer/validate.py:12
 msgid "Please provide a username."
@@ -433,10 +1180,6 @@ msgstr "Dina lösenord stämmer inte överens."
 msgid "Please provide a password for your user account."
 msgstr "Var god ange ett lösenord för ditt användarkonto."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -463,7 +1206,7 @@ msgstr "Lägger till en ny användare i systemet"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Skriver in filsystemets monteringsinformation i /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Monterar %(partition)s på %(mountpoint)s"
@@ -484,49 +1227,49 @@ msgstr "Skapar partitioner på %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Formaterar %(partition)s som %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Ställer in värdnamn"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Ställer in språk"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Ställer in värdnamn"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Ställer in tangentbordet"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Avlägsnar nutidskonfiguration (paket)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Installerar starthanterare"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Konfigurerar starthanteraren"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -534,674 +1277,17 @@ msgstr ""
 "VARNING: starthanteraren grub är felaktigt konfigurerad! Du måste "
 "konfigurera den manuellt."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Installationen är klar"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Kontrollerar starthanteraren"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Land"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Språk"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Utseende"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Variant"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Beräknar fil-index ..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr "Installationsprogram"
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr "Vilket språk vill du använda?"
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr "Var befinner du dig?"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Tangentbordsupplägg"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr "Vad har du för tangentbordsupplägg?"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr "Användarkonto"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr "Vem är du?"
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr "Installationstyp"
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Var vill du installera LMDE?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Partitionering"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Sammanfattning"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr "Installerar"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-#, fuzzy
-msgid "Automated install"
-msgstr "Automatisk installation"
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Bakåt"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr "Framåt"
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, fuzzy, python-format
-msgid "Welcome to the %s Installer."
-msgstr "Välkommen till installationsprogrammet för LMDE."
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr "Skriv här för att prova ditt tangentbordsupplägg"
-
-#: live-installer/frontend/gtk_interface.py:542
-#, fuzzy
-msgid "Erase a disk and install system on it."
-msgstr "Töm enheten och installera LMDE på den."
-
-#: live-installer/frontend/gtk_interface.py:555
-#, fuzzy
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-"Manuella val för att skapa, storleksändra eller välja partitioner för LMDE."
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Redigera partitioner"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Enhet"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Typ"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Operativsystem"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Monteringspunkt"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Formatera som"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Storlek"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Ledigt utrymme"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Installera"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr "Var god välj en lösenfras för krypteringen."
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Dina lösenord stämmer inte överens."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Avsluta?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Är du säker på att du vill avsluta installationsprogrammet?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Var god välj ett språk"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Var god välj ett namn för datorn."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Var god ange ditt fullständiga namn."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Dina lösenord stämmer inte överens."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "EFI-partitionen är för liten. Den måste vara minst 35 MB."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Var god välj en rootpartition (/)."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, fuzzy, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-"Det krävs en root-partition för att installera Linux Mint.\n"
-"\n"
-" - Monteringspunkt: /\n"
-" - Rekommenderad storlek: 30 GB\n"
-" - Rekommenderat filsystem: ext4\n"
-"\n"
-"Tänk på: För att göra systemkopior i btrfs-format med Timeshift krävs:\n"
-" - en undervolym med monteringspunkten /@\n"
-" - btrfs som filsystem\n"
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-"EFI-partitionen är inte angiven som startenhet. Justera partitionsflaggorna."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "EFI-partitionen är för liten. Den måste vara minst 35 MB."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "EFI-partitionen måste vara formaterad som vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Var god välj en EFI-partition."
-
-#: live-installer/frontend/gtk_interface.py:1226
-#, fuzzy
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-"Det behövs en EFI-partition med följande egenskaper:\n"
-"\n"
-" - Monteringspunkt: (boot/efi\n"
-" - Partitionsflaggor: Bootable\n"
-" - Storlek: minst 35 MB (100 MB eller mer rekommenderas)\n"
-" - Formatering: vfat eller fat32\n"
-"\n"
-"För att säkerställa kompatibilitet med Windows rekommenderar vi att du "
-"använder enhetens första partition som EFI-partition.\n"
-" "
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr "Var god välj en enhet."
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr "Varning"
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr "Alla data på %s kommer att raderas. Är du säker?"
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Var god ange ett användarnamn."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Landsanpassning"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Språk: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Tidszon: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Tangentbordsupplägg: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Användarinställningar"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Namn: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Användarnamn: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Automatisk inloggning: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "aktiverad"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "inaktiverad"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Systeminställningar"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr "Datorns namn: "
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-#, fuzzy
-msgid "Install updates after installation"
-msgstr "Automatisk installation"
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Filsystemsåtgärder"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Installera starthanteraren på %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Installera inte starthanterare"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Använd redan-monterat /mål."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr "Automatisk installation på %s"
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Formatera %(path)s som %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Montera %(path)s som %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr "LVM: "
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr "Skivkryptering: "
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Installationen är färdig. Vill du starta om din dator för att använda det "
-"nya systemet?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Installationsfel"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, fuzzy, python-format
-msgid "Welcome to %s"
-msgstr "Välkommen"
-
-#: live-installer/frontend/tui_interface.py:57
-#, fuzzy
-msgid "What keyboard would you like to use?"
-msgstr "Vilket språk vill du använda?"
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Tangentbordsmodell:"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Installationstyp"
-
-#: live-installer/frontend/tui_interface.py:80
-#, fuzzy
-msgid "Select a disk?"
-msgstr "Var god välj en enhet."
-
-#: live-installer/frontend/tui_interface.py:84
-#, fuzzy
-msgid "Disk"
-msgstr "Skiva:"
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Tidszon"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Borttagbar:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Redigera"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Tilldela till /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"Partitionstabellen för %s kunde inte skrivas. Starta om datorn och försök "
-"igen."
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"Partitionen %s kunde inte skapas. Installationen avbryts. Starta om datorn "
-"och försök igen."
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Logisk partition"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Utökad partition"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Okänd"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Redigera partition"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Redigera partition"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Enhet:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Formatera som:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Monteringspunkt:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Avbryt"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "OK"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Nej"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Ja"
 
 #~ msgid "Quit"
 #~ msgstr "Avsluta"

--- a/po/live-installer-ta.po
+++ b/po/live-installer-ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2016-10-28 12:59+0000\n"
 "Last-Translator: Kamala Kannan <Unknown>\n"
 "Language-Team: Tamil <ta@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "நேர மண்டலம்"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,140 +149,146 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "புதுப்பி"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 msgid "Edit Partitions"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -309,6 +317,702 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "நேர மண்டலம்"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "மொழி"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "விசைப்பலகை அமைப்பு"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "நிறுவல் பிழை"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "வகை"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "நாடு"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "தளவமைப்பு"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "விசைப்பலகை அமைப்பு"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "சுருக்கம்"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "சாதனம்"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "இயக்க அமைப்பு"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "ஏற்றப்புள்ளி"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "அளவு"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "மொழி: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "நேர மண்டலம்: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "விசைப்பலகை அமைப்பு: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "பயனர் பெயர்: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "ஏற்றுகிறது %(partition)s on %(mountpoint)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "நிறுவல் நிறைவுற்றது"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "நிறுவல் பிழை"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "சாதனம்:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -404,10 +1108,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -434,7 +1134,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "ஏற்றுகிறது %(partition)s on %(mountpoint)s"
@@ -454,676 +1154,62 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "புரவலன் பெயர் அமைப்பு"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "மொழி அமைப்பு"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "புரவலன் பெயர் அமைப்பு"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "நேரடி கட்டமைப்பு (தொகுப்புகள்) நீக்குகிறது"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "நிறுவல் நிறைவுற்றது"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "நாடு"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "மொழி"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "தளவமைப்பு"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "விசைப்பலகை அமைப்பு"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "சுருக்கம்"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "சாதனம்"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "வகை"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "இயக்க அமைப்பு"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "ஏற்றப்புள்ளி"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "அளவு"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "மொழி: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "நேர மண்டலம்: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "விசைப்பலகை அமைப்பு: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "பயனர் பெயர்: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "நிறுவல் பிழை"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "விசைப்பலகை அமைப்பு"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "நிறுவல் பிழை"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "நேர மண்டலம்"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "சாதனம்:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""

--- a/po/live-installer-ta.po
+++ b/po/live-installer-ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2016-10-28 12:59+0000\n"
 "Last-Translator: Kamala Kannan <Unknown>\n"
 "Language-Team: Tamil <ta@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -291,6 +291,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -321,8 +326,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -411,23 +416,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "நாடு"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "தளவமைப்பு"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -445,9 +521,102 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "சாதனம்:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "நாடு"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "தளவமைப்பு"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -562,18 +731,6 @@ msgstr ""
 msgid "Size"
 msgstr "அளவு"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -605,25 +762,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -858,7 +996,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "நிறுவல் நிறைவுற்றது"
 
@@ -877,138 +1015,6 @@ msgstr "நிறுவல் பிழை"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "சாதனம்:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1154,62 +1160,62 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "புரவலன் பெயர் அமைப்பு"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "மொழி அமைப்பு"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "புரவலன் பெயர் அமைப்பு"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "நேரடி கட்டமைப்பு (தொகுப்புகள்) நீக்குகிறது"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""

--- a/po/live-installer-te.po
+++ b/po/live-installer-te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2011-11-11 02:32+0000\n"
 "Last-Translator: Praveen Illa <mail2ipn@gmail.com>\n"
 "Language-Team: Telugu <te@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -292,6 +292,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -322,8 +327,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -411,23 +416,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "నమూనా"
-
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "చరరాశి"
-
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -445,9 +521,103 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "ఖాళీ స్థలం"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "వ్యవస్థ అమరికలు"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "నమూనా"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "చరరాశి"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -562,18 +732,6 @@ msgstr ""
 msgid "Size"
 msgstr "పరిమాణం"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "ఖాళీ స్థలం"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -605,25 +763,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -858,7 +997,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "స్థాపన ప్రక్రియ పూర్తిచేయబడింది"
 
@@ -877,139 +1016,6 @@ msgstr "స్థాపన ప్రక్రియ దోషము"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "వ్యవస్థ అమరికలు"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1155,63 +1161,63 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "హోస్టుపేరు అమర్చబడుతోంది"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "భాషను అమర్చుతున్నది"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "హోస్టుపేరు అమర్చబడుతోంది"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "కీ బోర్డు ఐచ్ఛికాలను అమర్చుతున్నది"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "ప్యాకేజిల  ప్రత్యక్ష కన్ఫిగరేషన్ తీసివేయబడుతోంది"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "బూట్ లోడర్ స్థాపించబడుతోంది"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "బూట్‌లోడర్‌ని స్వరూపిస్తున్నది"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr "హెచ్ఛరిక: grub బూట్‌లోడర్‌ సరిగా స్వరూపించబడలేదు! మీరు దానిని మానవీయంగా స్వరూపించాలి."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "బూట్‌లోడర్‌ని తనిఖీ చేస్తున్నది"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-te.po
+++ b/po/live-installer-te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2011-11-11 02:32+0000\n"
 "Last-Translator: Praveen Illa <mail2ipn@gmail.com>\n"
 "Language-Team: Telugu <te@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,141 +149,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "వ్యవస్థ అమరికలు"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -310,6 +318,702 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "కీ బోర్డు నమూనా: "
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "స్థాపన ప్రక్రియ దోషము"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "రకము"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "నమూనా"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "చరరాశి"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "పరికరము"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "నిర్వహణ వ్యవస్థ"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "మౌంట్ పాయింట్"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "పరిమాణం"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "ఖాళీ స్థలం"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "స్థానికీకరణ"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "భాష: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "సమయ క్షేత్రం: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "కీ బోర్డు నమూనా: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "వాడుకరి అమరికలు"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "అసలు పేరు: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "వాడుకరిపేరు: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "వ్యవస్థ అమరికలు"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "ఫైల్ వ్యవస్థ కార్యాలు"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "బూట్‌లోడర్‌ను స్థాపించవద్దు"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "%(partition)s లను %(mountpoint)s పై మౌంటుచేస్తున్నది"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "స్థాపన ప్రక్రియ పూర్తిచేయబడింది"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "స్థాపన ప్రక్రియ దోషము"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "వ్యవస్థ అమరికలు"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -405,10 +1109,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -435,7 +1135,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "%(partition)s లను %(mountpoint)s పై మౌంటుచేస్తున్నది"
@@ -455,678 +1155,64 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "హోస్టుపేరు అమర్చబడుతోంది"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "భాషను అమర్చుతున్నది"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "హోస్టుపేరు అమర్చబడుతోంది"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "కీ బోర్డు ఐచ్ఛికాలను అమర్చుతున్నది"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "ప్యాకేజిల  ప్రత్యక్ష కన్ఫిగరేషన్ తీసివేయబడుతోంది"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "బూట్ లోడర్ స్థాపించబడుతోంది"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "బూట్‌లోడర్‌ని స్వరూపిస్తున్నది"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr "హెచ్ఛరిక: grub బూట్‌లోడర్‌ సరిగా స్వరూపించబడలేదు! మీరు దానిని మానవీయంగా స్వరూపించాలి."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "స్థాపన ప్రక్రియ పూర్తిచేయబడింది"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "బూట్‌లోడర్‌ని తనిఖీ చేస్తున్నది"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "నమూనా"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "చరరాశి"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "పరికరము"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "రకము"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "నిర్వహణ వ్యవస్థ"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "మౌంట్ పాయింట్"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "పరిమాణం"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "ఖాళీ స్థలం"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "స్థానికీకరణ"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "భాష: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "సమయ క్షేత్రం: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "కీ బోర్డు నమూనా: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "వాడుకరి అమరికలు"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "అసలు పేరు: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "వాడుకరిపేరు: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "వ్యవస్థ అమరికలు"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "ఫైల్ వ్యవస్థ కార్యాలు"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "బూట్‌లోడర్‌ను స్థాపించవద్దు"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "స్థాపన ప్రక్రియ దోషము"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "కీ బోర్డు నమూనా: "
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "స్థాపన ప్రక్రియ దోషము"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "వ్యవస్థ అమరికలు"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-tg.po
+++ b/po/live-installer-tg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2014-02-06 22:35+0000\n"
 "Last-Translator: Victor Ibragimov <victor.ibragimov@gmail.com>\n"
 "Language-Team: Tajik <tg@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Минтақаи вақт"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,141 +149,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Танзимоти система"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -310,6 +318,710 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Минтақаи вақт"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Забон"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Тарҳбандии клавиатура"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Хатои насбкунӣ"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Навъ"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Тарҳбандӣ"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Вариант"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Тарҳбандии клавиатура"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Қисмбандӣ"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Хулоса"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Дастгоҳ"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Системаи омил"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Нуқтаи васл"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Андоза"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Фазои озод"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+"Қисми диски EFI боршаванда нест. Лутфан, байрақчаҳои қисмбандиро таҳрир "
+"кунед."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+"Қисми диски EFI боршаванда нест. Лутфан, байрақчаҳои қисмбандиро таҳрир "
+"кунед."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "Қисми диски EFI бояд ҳамчун vfat формат карда шавад."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "Қисми диски EFI бояд ҳамчун vfat формат карда шавад."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Тарҷумаҳои маҳаллӣ"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Забон: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Минтақаи вақт: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Тарҳбандии клавиатура: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Танзимоти корбар"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Номи ҳақиқӣ: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Номи корбар: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Танзимоти система"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Амалҳои системаи файлӣ"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Насб накардан худроҳандозӣ"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "%(partition)s дар %(mountpoint)s васл шуда истодааст"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Насбкунӣ ба анҷом расид"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Хатои насбкунӣ"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Танзимоти система"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -405,10 +1117,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -435,7 +1143,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "%(partition)s дар %(mountpoint)s васл шуда истодааст"
@@ -455,49 +1163,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Танзимкунии номи мизбон"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Танзимкунии хусусиятҳои забонӣ"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Танзимкунии номи мизбон"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Танзимкунии имконоти клавиатура"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Тозакунии танзимот аз системаи зинда (бастаҳо)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Насбкунии худроҳандозӣ"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Конфигуратсияи худроҳандозӣ"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -505,638 +1213,16 @@ msgstr ""
 "ОГОҲӢ: Худроҳандозии GRUB дуруст танзим нашудааст! Шумо бояд онро ба таври "
 "дастӣ танзим кунед."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Насбкунӣ ба анҷом расид"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Санҷиши худроҳандозӣ"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Забон"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Тарҳбандӣ"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Вариант"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Тарҳбандии клавиатура"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Қисмбандӣ"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Хулоса"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Дастгоҳ"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Навъ"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Системаи омил"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Нуқтаи васл"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Андоза"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Фазои озод"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-"Қисми диски EFI боршаванда нест. Лутфан, байрақчаҳои қисмбандиро таҳрир "
-"кунед."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-"Қисми диски EFI боршаванда нест. Лутфан, байрақчаҳои қисмбандиро таҳрир "
-"кунед."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "Қисми диски EFI бояд ҳамчун vfat формат карда шавад."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "Қисми диски EFI бояд ҳамчун vfat формат карда шавад."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Тарҷумаҳои маҳаллӣ"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Забон: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Минтақаи вақт: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Тарҳбандии клавиатура: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Танзимоти корбар"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Номи ҳақиқӣ: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Номи корбар: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Танзимоти система"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Амалҳои системаи файлӣ"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Насб накардан худроҳандозӣ"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Хатои насбкунӣ"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Тарҳбандии клавиатура"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Хатои насбкунӣ"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Минтақаи вақт"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Танзимоти система"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-tg.po
+++ b/po/live-installer-tg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2014-02-06 22:35+0000\n"
 "Last-Translator: Victor Ibragimov <victor.ibragimov@gmail.com>\n"
 "Language-Team: Tajik <tg@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -292,6 +292,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -322,8 +327,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -412,23 +417,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Тарҳбандӣ"
-
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Вариант"
-
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -446,9 +522,103 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Фазои озод"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Танзимоти система"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Тарҳбандӣ"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Вариант"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -563,18 +733,6 @@ msgstr ""
 msgid "Size"
 msgstr "Андоза"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Фазои озод"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -606,25 +764,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -866,7 +1005,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Насбкунӣ ба анҷом расид"
 
@@ -885,139 +1024,6 @@ msgstr "Хатои насбкунӣ"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Танзимоти система"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1163,49 +1169,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Танзимкунии номи мизбон"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Танзимкунии хусусиятҳои забонӣ"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Танзимкунии номи мизбон"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Танзимкунии имконоти клавиатура"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Тозакунии танзимот аз системаи зинда (бастаҳо)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Насбкунии худроҳандозӣ"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Конфигуратсияи худроҳандозӣ"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1213,15 +1219,15 @@ msgstr ""
 "ОГОҲӢ: Худроҳандозии GRUB дуруст танзим нашудааст! Шумо бояд онро ба таври "
 "дастӣ танзим кунед."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Санҷиши худроҳандозӣ"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-th.po
+++ b/po/live-installer-th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2016-03-05 11:31+0000\n"
 "Last-Translator: Rockworld <sumoisrock@gmail.com>\n"
 "Language-Team: Thai <th@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -189,9 +189,9 @@ msgid "Format"
 msgstr "ฟอร์แมตเป็น"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -295,6 +295,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "ฟอร์แมตเป็น"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -325,8 +331,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -415,23 +421,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "ประเทศ"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "ผัง"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "แบบย่อย"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "กำลังคำนวณดรรชนีแฟ้ม..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "สื่อถอดเสียบ:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "แก้ไข"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "ปรับใช้กับ /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -449,10 +526,104 @@ msgstr "กำลังคำนวณดรรชนีแฟ้ม..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "พื้นที่ว่าง"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "พาร์ติชันแบบลอจิคัล"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "พาร์ทิชันขยาย"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "ไม่รู้"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "แก้ไขพาร์ทิชัน"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "แก้ไขพาร์ทิชัน"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "อุปกรณ์:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "ฟอร์แมตเป็น:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "ตำแหน่งเมานท์:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "ประเทศ"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "ผัง"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "แบบย่อย"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "กำลังคำนวณดรรชนีแฟ้ม..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -567,18 +738,6 @@ msgstr "ฟอร์แมตเป็น"
 msgid "Size"
 msgstr "ขนาด"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "พื้นที่ว่าง"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -611,25 +770,6 @@ msgstr "ออกจากโปรแกรมหรือไม่?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "คุณแน่ใจหรือว่าคุณต้องการออกจากโปรแกรมติดตั้ง?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -869,7 +1009,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "การติดตั้งเสร็จสิ้น"
 
@@ -889,139 +1029,6 @@ msgstr "การติดตั้งเกิดความผิดพลา
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "สื่อถอดเสียบ:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "แก้ไข"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "ปรับใช้กับ /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "พาร์ติชันแบบลอจิคัล"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "พาร์ทิชันขยาย"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "ไม่รู้"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "แก้ไขพาร์ทิชัน"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "แก้ไขพาร์ทิชัน"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "อุปกรณ์:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "ฟอร์แมตเป็น:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "ตำแหน่งเมานท์:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1180,63 +1187,63 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "กำลังทำการฟอร์แมต %(partition)s เป็น %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "ตั้งค่าโฮสต์เนม"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "กำลังตั้งค่าตำแหน่งที่ตั้ง"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "ตั้งค่าโฮสต์เนม"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "กำลังตั้งค่าคีย์บอร์ด"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "กำลังลบการตั้งค่าแบบ live (แพคเกจ)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "กำลังติดตั้ง bootloader"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "ตั้งค่า bootloader"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr "คำเตือน : grub bootloader ไม่ได้ตั้งค่าอย่างถูกต้อง คุณต้องตั้งค่ามันด้วยตนเอง"
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "กำลังตรวจสอบ bootloader"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-th.po
+++ b/po/live-installer-th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2016-03-05 11:31+0000\n"
 "Last-Translator: Rockworld <sumoisrock@gmail.com>\n"
 "Language-Team: Thai <th@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "เขตเวลา"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "แก้ไขพาร์ทิชัน"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "โหมดผู้เชี่ยวชาญ"
@@ -149,142 +151,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "เรียกใหม่อีกครั้ง"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "ฟอร์แมตเป็น"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "แก้ไขข้อมูลพาร์ทิชัน"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "เข้าระบบอัตโนมัติ"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -313,6 +321,711 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "เขตเวลา"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "ภาษา"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "ผังแป้นพิมพ์"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "การติดตั้งหยุดชั่วคราว"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "ประเภท"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "ประเทศ"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "ผัง"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "แบบย่อย"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "กำลังคำนวณดรรชนีแฟ้ม..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "ผังแป้นพิมพ์"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "คุณแน่ใจหรือว่าคุณต้องการออกจากโปรแกรมติดตั้ง?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "การจัดพาร์ทิชัน"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "สรุป"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "แก้ไขข้อมูลพาร์ทิชัน"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "อุปกรณ์"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "ระบบปฏิบัติการ"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "จุดเมานท์"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "ฟอร์แมตเป็น"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "ขนาด"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "พื้นที่ว่าง"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "รหัสผ่านของคุณไม่ตรงกัน"
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "ออกจากโปรแกรมหรือไม่?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "คุณแน่ใจหรือว่าคุณต้องการออกจากโปรแกรมติดตั้ง?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "กรุณาเลือกภาษา"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "กรุณากรอกรหัสผ่านสำหรับบัญชีผู้ใช้ของคุณ"
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "กรุณากรอกชื่อจริงของคุณ"
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "รหัสผ่านของคุณไม่ตรงกัน"
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "พาร์ทิชัน EFI ใช้เริ่มระบบไม่ได้ กรุณาแก้ไขสถานะของพาร์ทิชัน"
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "กรุณาเลือกพาร์ทิชันรูท (/)"
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "พาร์ทิชัน EFI ใช้เริ่มระบบไม่ได้ กรุณาแก้ไขสถานะของพาร์ทิชัน"
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "พาร์ทิชัน EFI ต้องฟอร์แมตเป็น vfat"
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "พาร์ทิชัน EFI ต้องฟอร์แมตเป็น vfat"
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "กรุณาเลือกพาร์ทิชัน EFI"
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "กรุณากรอกชื่อผู้ใช้"
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "ความเป็นท้องถิ่น"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "ภาษา: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "เขตเวลา: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "แบบคีย์บอร์ด: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "การตั้งค่าผู้ใช้"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "ชื่อจริง: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "ชื่อผู้ใช้: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "เข้าระบบอัตโนมัติ: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "เปิดใช้งานแล้ว"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "ปิดใช้งานแล้ว"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "ตั้งค่าระบบ"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "การปฏิบัติการกับระบบไฟล์"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "ติดตั้งบูตโหลดเดอร์บน %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "อย่าติดตั้ง bootloader"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "ใช้ /target ที่เมานท์เรียบร้อยแล้ว"
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "ฟอร์แมต %(path)s เป็น %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "เมานท์ %(path)s เป็น %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "เมานท์ %(path)s เป็น %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "การติดตั้งเสร็จสิ้น"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"การติดตั้งเสร็จสมบูรณ์แล้ว คุณต้องการเริ่มการทำงานของคอมพิวเตอร์คุณใหม่เพื่อใช้ระบบใหม่หรือไม่?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "การติดตั้งเกิดความผิดพลาด"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "สื่อถอดเสียบ:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "แก้ไข"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "ปรับใช้กับ /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "พาร์ติชันแบบลอจิคัล"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "พาร์ทิชันขยาย"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "ไม่รู้"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "แก้ไขพาร์ทิชัน"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "แก้ไขพาร์ทิชัน"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "อุปกรณ์:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "ฟอร์แมตเป็น:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "ตำแหน่งเมานท์:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -421,10 +1134,6 @@ msgstr "รหัสผ่านของคุณไม่ตรงกัน"
 msgid "Please provide a password for your user account."
 msgstr "กรุณากรอกรหัสผ่านสำหรับบัญชีผู้ใช้ของคุณ"
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -451,7 +1160,7 @@ msgstr "กำลังทำการเพิ่มผู้ใช้คนใ
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "เขียนข้อมูลเมานท์ระบบแฟ้มไปที่ /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "กำลังเมานท์ %(partition)s บน %(mountpoint)s"
@@ -471,687 +1180,64 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "กำลังทำการฟอร์แมต %(partition)s เป็น %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "ตั้งค่าโฮสต์เนม"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "กำลังตั้งค่าตำแหน่งที่ตั้ง"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "ตั้งค่าโฮสต์เนม"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "กำลังตั้งค่าคีย์บอร์ด"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "กำลังลบการตั้งค่าแบบ live (แพคเกจ)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "กำลังติดตั้ง bootloader"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "ตั้งค่า bootloader"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr "คำเตือน : grub bootloader ไม่ได้ตั้งค่าอย่างถูกต้อง คุณต้องตั้งค่ามันด้วยตนเอง"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "การติดตั้งเสร็จสิ้น"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "กำลังตรวจสอบ bootloader"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "ประเทศ"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "ภาษา"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "ผัง"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "แบบย่อย"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "กำลังคำนวณดรรชนีแฟ้ม..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "ผังแป้นพิมพ์"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "คุณแน่ใจหรือว่าคุณต้องการออกจากโปรแกรมติดตั้ง?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "การจัดพาร์ทิชัน"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "สรุป"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "แก้ไขข้อมูลพาร์ทิชัน"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "อุปกรณ์"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "ประเภท"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "ระบบปฏิบัติการ"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "จุดเมานท์"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "ฟอร์แมตเป็น"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "ขนาด"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "พื้นที่ว่าง"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "รหัสผ่านของคุณไม่ตรงกัน"
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "ออกจากโปรแกรมหรือไม่?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "คุณแน่ใจหรือว่าคุณต้องการออกจากโปรแกรมติดตั้ง?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "กรุณาเลือกภาษา"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "กรุณากรอกรหัสผ่านสำหรับบัญชีผู้ใช้ของคุณ"
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "กรุณากรอกชื่อจริงของคุณ"
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "รหัสผ่านของคุณไม่ตรงกัน"
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "พาร์ทิชัน EFI ใช้เริ่มระบบไม่ได้ กรุณาแก้ไขสถานะของพาร์ทิชัน"
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "กรุณาเลือกพาร์ทิชันรูท (/)"
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "พาร์ทิชัน EFI ใช้เริ่มระบบไม่ได้ กรุณาแก้ไขสถานะของพาร์ทิชัน"
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "พาร์ทิชัน EFI ต้องฟอร์แมตเป็น vfat"
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "พาร์ทิชัน EFI ต้องฟอร์แมตเป็น vfat"
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "กรุณาเลือกพาร์ทิชัน EFI"
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "กรุณากรอกชื่อผู้ใช้"
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "ความเป็นท้องถิ่น"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "ภาษา: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "เขตเวลา: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "แบบคีย์บอร์ด: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "การตั้งค่าผู้ใช้"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "ชื่อจริง: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "ชื่อผู้ใช้: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "เข้าระบบอัตโนมัติ: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "เปิดใช้งานแล้ว"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "ปิดใช้งานแล้ว"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "ตั้งค่าระบบ"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "การปฏิบัติการกับระบบไฟล์"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "ติดตั้งบูตโหลดเดอร์บน %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "อย่าติดตั้ง bootloader"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "ใช้ /target ที่เมานท์เรียบร้อยแล้ว"
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "ฟอร์แมต %(path)s เป็น %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "เมานท์ %(path)s เป็น %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"การติดตั้งเสร็จสมบูรณ์แล้ว คุณต้องการเริ่มการทำงานของคอมพิวเตอร์คุณใหม่เพื่อใช้ระบบใหม่หรือไม่?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "การติดตั้งเกิดความผิดพลาด"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "ผังแป้นพิมพ์"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "การติดตั้งหยุดชั่วคราว"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "เขตเวลา"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "สื่อถอดเสียบ:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "แก้ไข"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "ปรับใช้กับ /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "พาร์ติชันแบบลอจิคัล"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "พาร์ทิชันขยาย"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "ไม่รู้"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "แก้ไขพาร์ทิชัน"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "แก้ไขพาร์ทิชัน"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "อุปกรณ์:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "ฟอร์แมตเป็น:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "ตำแหน่งเมานท์:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-tl.po
+++ b/po/live-installer-tl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2015-02-26 14:34+0000\n"
 "Last-Translator: Ueliton <Unknown>\n"
 "Language-Team: Tagalog <tl@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -187,9 +187,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -293,6 +293,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -323,8 +328,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -413,23 +418,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Bansa"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Ayos"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Baryante"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -447,9 +523,103 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Bakanteng espasyo."
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Hindi alam"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Pamatnugutan partition"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Pamatnugutan partition"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Aparato:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Mount point:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Bansa"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Ayos"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Baryante"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -564,18 +734,6 @@ msgstr ""
 msgid "Size"
 msgstr "Laki"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Bakanteng espasyo."
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -607,25 +765,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -860,7 +999,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Natapos na ang pag-iinstall"
 
@@ -879,139 +1018,6 @@ msgstr "May pagkakamali sa pag-iinstall"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Hindi alam"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Pamatnugutan partition"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Pamatnugutan partition"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Aparato:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Mount point:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1157,49 +1163,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Pag-format ng %(partition)s sa %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Itinatakda ang hostname"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Hanay ng lokasyon"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Itinatakda ang hostname"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Itinatakda ang mga option para sa keyboard"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Tinatanggal ang live configuration (packages)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Iniinstall ang bootloader"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Inaayos ang bootloader"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1207,15 +1213,15 @@ msgstr ""
 "BABALA: grub bootloader ay hindi naisaayos nang tama! Kailangan mo upang "
 "mano-manong i-configure ito."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Sinusuri bootloader"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-tl.po
+++ b/po/live-installer-tl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2015-02-26 14:34+0000\n"
 "Last-Translator: Ueliton <Unknown>\n"
 "Language-Team: Tagalog <tl@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Sona ng oras"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Pamatnugutan partition"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -148,141 +150,147 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Pamatnugutan partition"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -311,6 +319,703 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Sona ng oras"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Wika"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Pagkakalatag ng tipaan"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "May pagkakamali sa pag-iinstall"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Uri"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Bansa"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Ayos"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Baryante"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Pagkakalatag ng tipaan"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Paghahati"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Buod"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Aparato"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Operating system"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Mount point"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Laki"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Bakanteng espasyo."
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Lokalisasyon"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Wika: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Ang iyong Timezone: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Layout ng keyboard: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Mga setting para sa user"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Tunay na pangalan: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Username: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Mga setting para sa system"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Mga operasyon ng filesystem"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Huwag i-install ang bootloader"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Ikinakabit ang %(partition)s sa %(mountpoint)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Natapos na ang pag-iinstall"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "May pagkakamali sa pag-iinstall"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Hindi alam"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Pamatnugutan partition"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Pamatnugutan partition"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Aparato:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Mount point:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -406,10 +1111,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -436,7 +1137,7 @@ msgstr "Ang pagdaragdag ng bagong user sa system"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Ikinakabit ang %(partition)s sa %(mountpoint)s"
@@ -456,49 +1157,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Pag-format ng %(partition)s sa %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Itinatakda ang hostname"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Hanay ng lokasyon"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Itinatakda ang hostname"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Itinatakda ang mga option para sa keyboard"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Tinatanggal ang live configuration (packages)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Iniinstall ang bootloader"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Inaayos ang bootloader"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -506,631 +1207,16 @@ msgstr ""
 "BABALA: grub bootloader ay hindi naisaayos nang tama! Kailangan mo upang "
 "mano-manong i-configure ito."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Natapos na ang pag-iinstall"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Sinusuri bootloader"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Bansa"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Wika"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Ayos"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Baryante"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Pagkakalatag ng tipaan"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Paghahati"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Buod"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Aparato"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Uri"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Operating system"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Mount point"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Laki"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Bakanteng espasyo."
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Lokalisasyon"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Wika: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Ang iyong Timezone: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Layout ng keyboard: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Mga setting para sa user"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Tunay na pangalan: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Username: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Mga setting para sa system"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Mga operasyon ng filesystem"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Huwag i-install ang bootloader"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "May pagkakamali sa pag-iinstall"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Pagkakalatag ng tipaan"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "May pagkakamali sa pag-iinstall"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Sona ng oras"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Hindi alam"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Pamatnugutan partition"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Pamatnugutan partition"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Aparato:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Mount point:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-tr.po
+++ b/po/live-installer-tr.po
@@ -9,15 +9,15 @@ msgstr ""
 "Project-Id-Version: unnamed project\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-05-06 19:10+0300\n"
-"PO-Revision-Date: 2023-08-29 18:48+0300\n"
+"PO-Revision-Date: 2024-05-06 19:21+0300\n"
 "Last-Translator: Fatih Altun <fatih.altun@pardus.org.tr>\n"
 "Language-Team: Turkish <dev@pardus.org.tr>\n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0\n"
-"X-Generator: Gtranslator 3.38.0\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 3.2.2\n"
 
 #: live-installer/resources/interface.ui:71
 msgid "Welcome to the 17g Installer."
@@ -293,13 +293,12 @@ msgstr "salt okur"
 
 #: live-installer/resources/interface.ui:2518
 msgid "Use default Btrfs subvolumes"
-msgstr ""
+msgstr "Varsayılan Btrfs altbölümlerini kullan"
 
 #: live-installer/resources/interface.ui:2678
 #: live-installer/frontend/partitioning.py:888
-#, fuzzy
 msgid "Format subvolume"
-msgstr "Biçimlendirme türü"
+msgstr "Altbölümü biçimlendir"
 
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
@@ -456,11 +455,11 @@ msgstr "Taşınabilir:"
 #: live-installer/frontend/gtk_interface.py:977
 #: live-installer/frontend/gtk_interface.py:1006
 msgid "btrfs subvolume"
-msgstr ""
+msgstr "btrfs altbölümü"
 
 #: live-installer/frontend/partitioning.py:195
 msgid "Edit Subvolume"
-msgstr ""
+msgstr "Altbölümü düzenle"
 
 #: live-installer/frontend/partitioning.py:213
 #: live-installer/frontend/gtk_interface.py:598
@@ -469,11 +468,11 @@ msgstr "Salt okunur"
 
 #: live-installer/frontend/partitioning.py:241
 msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
+msgstr "Bir altbölümün adı eğik çizgi ile başlayamaz veya bitemez"
 
 #: live-installer/frontend/partitioning.py:245
 msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
+msgstr "Bir altbölümün adı boş olamaz ya da boşluk içeremez"
 
 #: live-installer/frontend/partitioning.py:249
 msgid "The mount point of a subvolume must not contain a space"
@@ -482,13 +481,13 @@ msgstr ""
 #: live-installer/frontend/partitioning.py:256
 #, python-format
 msgid "Subvolume with name '%s' already exists"
-msgstr ""
+msgstr "'%s' ismine sahip bir altbölüm halihazırda mevcut"
 
 #: live-installer/frontend/partitioning.py:291
 #: live-installer/frontend/gtk_interface.py:984
 #: live-installer/frontend/gtk_interface.py:992
 msgid "Create a subvolume"
-msgstr ""
+msgstr "Bir altbölüm oluştur"
 
 #: live-installer/frontend/partitioning.py:345
 msgid "Edit"
@@ -505,7 +504,7 @@ msgstr "%s olarak ata"
 
 #: live-installer/frontend/partitioning.py:391
 msgid "Create btrfs subvolume"
-msgstr ""
+msgstr "btrfs altbölümü oluştur"
 
 #: live-installer/frontend/partitioning.py:446
 #: live-installer/frontend/partitioning.py:529
@@ -607,11 +606,11 @@ msgstr "İptal"
 
 #: live-installer/frontend/partitioning.py:874
 msgid "Create Subvolume"
-msgstr ""
+msgstr "Altbölüm oluştur"
 
 #: live-installer/frontend/partitioning.py:881
 msgid "Name:"
-msgstr ""
+msgstr "isim:"
 
 #: live-installer/frontend/gtk_interface.py:109
 #: live-installer/frontend/gtk_interface.py:514
@@ -791,9 +790,8 @@ msgid "New partition will created at {}"
 msgstr "{}'de yeni bölüm oluşturulacak"
 
 #: live-installer/frontend/gtk_interface.py:1009
-#, fuzzy
 msgid "subvolume {} will removed from {}."
-msgstr "{} bölümü {} içerisinden silinecek"
+msgstr "{} altbölümü {} içerisinden silinecek."
 
 #: live-installer/frontend/gtk_interface.py:1026
 msgid "Partition {} will removed from {}."
@@ -1016,12 +1014,12 @@ msgstr "%(path)s yolunu %(mount)s olarak bağla"
 #: live-installer/frontend/gtk_interface.py:1554
 #, python-format
 msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
-msgstr ""
+msgstr " %(parentPath)s altına %(path)s altbölümünü oluştur"
 
 #: live-installer/frontend/gtk_interface.py:1558
-#, fuzzy, python-format
+#, python-format
 msgid "Mount %(path)s subvolume as %(mount)s"
-msgstr "%(path)s yolunu %(mount)s olarak bağla"
+msgstr "%(path)s altbölümünü %(mount)s olarak bağla"
 
 #: live-installer/frontend/gtk_interface.py:1563
 msgid "LVM: "

--- a/po/live-installer-tr.po
+++ b/po/live-installer-tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: unnamed project\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2023-08-29 18:48+0300\n"
 "Last-Translator: Fatih Altun <fatih.altun@pardus.org.tr>\n"
 "Language-Team: Turkish <dev@pardus.org.tr>\n"
@@ -24,20 +24,20 @@ msgid "Welcome to the 17g Installer."
 msgstr "17g Kurucuya Hoş Geldiniz."
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 "Bu uygulama size bazı sorular soracak ve bilgisayarınıza sistemi kuracaktır."
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr "Lisans Sözleşmesi'nin şartlarını kabul ediyorum"
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr "Klavye Modeli:"
 
@@ -46,10 +46,12 @@ msgid "Type here to test your keyboard"
 msgstr "Klavyenizi test etmek için buraya yazın"
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr "etiket"
 
@@ -58,13 +60,13 @@ msgid "Continent"
 msgstr "Bölge"
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Zaman dilimi"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr "Otomatik Kurulum"
 
@@ -73,12 +75,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr "Diski sil ve sistemi üstüne kur."
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr "Disk:"
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr "Takas alanı oluştur"
 
@@ -88,42 +90,42 @@ msgstr "1"
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr "LVM kullan (Mantıksal Bölüm Yönetimi)"
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr "İşletim sistemini şifrele"
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr "Parola"
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr "Parolayı doğrula"
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr "Bu fazladan güvenlik sağlar fakat uzun sürebilir."
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr "Diski rastgele veri ile doldur"
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr "Elle bölümlendirme"
 
@@ -142,7 +144,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr "Mevcut Windowsu sil ve yerine yükle."
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr "Uzman modu"
 
@@ -151,141 +153,147 @@ msgid "The setup tool will not do partitioning."
 msgstr "Kurulum aracı bölümlendirme yapmayacak."
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr "Minimal kurulum"
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr "Sadece minimal masaüstü ile tarayıcı ve temel araçlar kurulacak."
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr "Sistemi güncellemeler ile birlikte yükle"
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr "İnternete bağlanırsanız, güncellemeler yüklenir."
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Yenile"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr "Sil"
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr "Biçimlendir"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr "Oluştur"
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr "GRUB önyükleyiciyi buraya kur:"
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 msgid "Edit Partitions"
 msgstr "Bölümleri Düzenle"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr "Adınız:"
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr "Bilgisayarınızın adı:"
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr "Bir kullanıcı adı seçin:"
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr "Diğer bilgisayarlarla konuşurken kullandığı ad."
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr "Bir parola seçin:"
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Otomatik giriş"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr "Giriş için parola gerektir"
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr "Ev dizinimi şifrele"
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr "Parolanızı doğrulayın:"
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr "Minimum 8 karakter uzunluğunda olmalı"
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr "Otomatik kurulum etkin!"
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr "0.0"
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr "Yükleme işlemi sırasında lütfen bilgisayarınızı kapatmayın."
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr "17g takımı"
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr "Hoş geldiniz"
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr "/dev/sda1"
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
 msgstr "salt okur"
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
+msgstr ""
 
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
@@ -315,6 +323,734 @@ msgstr ""
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
 msgstr "Hoş geldiniz"
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "Tamam"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Hayır"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Evet"
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr "Zaman dilimi seçin"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr "%s Kurucuya Hoş Geldiniz."
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr "Hangi dili kullanmak istiyorsunuz?"
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Dil"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr "Neredesiniz?"
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr "Hangi dili kullanmak istiyorsunuz?"
+
+#: live-installer/frontend/tui_interface.py:64
+msgid "Keyboard Model"
+msgstr "Klavye modeli"
+
+#: live-installer/frontend/tui_interface.py:73
+msgid "Installation type?"
+msgstr "Kurulum türü?"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Tür"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr "Lütfen bir disk seçin?"
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr "Disk"
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr "%s dene"
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr "Şu anda %s canlı ortamdan çalışıyor."
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+"Şimdi %s yükleyebilirsiniz, veya Daha sonra uygulama menüsünden \"diske "
+"yükle\" seçebilirsiniz."
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr "Hoş geldiniz %s"
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Ülke"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Düzen"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Değişken"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Dosya indexleri hesaplanıyor ..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr "Kurucu"
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr "Lisans Sözleşmesi"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Klavye düzeni"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr "Klavye düzeniniz nedir?"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr "Kullanıcı hesabı"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr "Kimsiniz?"
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr "Kurulum türü"
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr "Sistemi nereye kurmak istiyorsunuz?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Bölümlendirme"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Özet"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr "Her şeyin doğru olduğunu gözden geçirin"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr "Yükleniyor"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr "Lütfen bekleyin..."
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr "Otomatik Kurulum"
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Geri"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr "İleri"
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr "Klavyenizi test etmek için buraya yazın"
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr "Diski sil ve sistemi üstüne kur."
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+"Sistem için disk bölümlerini elle oluşturun, yeniden boyutlandırın veya "
+"seçin."
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr "Kurulum aracı bölümlendirme yapmayacak"
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr "Windowsu sil ve yerine yükle"
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr "Mevcut Windowsu sil ve yerine yükle."
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Bölümleri düzenle"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Donanım"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "İşletim sistemi"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Bağlama noktası"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Biçimlendirme türü"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Boyut"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Boş alan"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr "Salt okunur"
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr "Uyarı"
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr "%s üzerindeki tüm veriler silinecek. Emin misiniz?"
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Yükle"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr "Lütfen şifreleme için parola belirleyin."
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Parolalar uyuşmuyor."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Çıkış?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Kurulumdan çıkmak istediğinizden emin misiniz?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr "Emin misiniz?"
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr "{}'de yeni bölüm oluşturulacak"
+
+#: live-installer/frontend/gtk_interface.py:1009
+#, fuzzy
+msgid "subvolume {} will removed from {}."
+msgstr "{} bölümü {} içerisinden silinecek"
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr "{} bölümü {} içerisinden silinecek"
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr "{} bölümü {} içerisinden formatlanacak."
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Lütfen bir dil seçin"
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Lütfen bir klavye düzeni belirleyin."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Lütfen bir isim belirleyin."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr "Parolanız zayıf."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+"Kök dosya sistemi seçilmedi. Kurulum biçimlendirme olmadan devam edecek."
+"Devam etmek istiyor musunuz?"
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+"Kök bölümü çok küçük. En az 16GB olmalıdır. Devam etmek istiyor musunuz?"
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Lütfen kök (/) bölümü seçin."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+"%s yüklemek için bir kök bölüm gerekir.\n"
+"\n"
+" - Bağlama noktası: /\n"
+" - Önerilen boyut: 30 GB\n"
+" - Önerilen dosya sistemi: ext4\n"
+"\n"
+"Not: Timeshift uygulamasının btrfs anlık görüntü alma özelliğini kullanma "
+"için gereklilikler:\n"
+" - altbölüm Bağlama-noktası /@\n"
+" - dosya sistemi formatı olarak btrfs\n"
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "EFI bölümü önyüklenebilir değil. Önyükleme bayrağı ayarlansın mı?"
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "EFI bölümü çok küçük. En az 35MB olmalıdır."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "EFI bölümü vfat olarak biçimlendirilmelidir."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Lütfen bir EFI bölümü seçin."
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+"Aşağıdaki gereksinimlere sahip bir EFI sistem bölümü gereklidir:\n"
+"\n"
+"  - Bağlantı noktası: /boot/efi\n"
+"  - Bölüm bayrakları: Önyüklenebilir\n"
+"  - Boyut: en az 35MB (100MB veya daha fazlası önerilir)\n"
+"  - Biçim: vfat veya fat32\n"
+"\n"
+"Windows ile uyumluluğu sağlamak için diskin ilk bölümünü EFI sistem bölümü "
+"olarak kullanmanızı öneririz. "
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr "Lütfen bir disk seçin."
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr "Lütfen grub için bir disk belirleyin."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Yerelleştirme"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Dil "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Zaman dilimi "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Klavye düzeni "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Kullanıcı ayarları"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Gerçek isim "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Kullanıcı adı "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr "Parola: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Otomatik giriş "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "etkin"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "devre dışı"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Sistem ayarları"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr "Bilgisayar adı "
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr "Bios türü: "
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr "Kurulumdan sonra güncellemeleri yükle"
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Dosya sistemi işlemleri"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Önyükleyiciyi %s içine kur"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Ön yükleyici kurma"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "/target zaten bağlı."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr " (%s GB takas ile)"
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr "%s üzerine otomatik kurulum"
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "%(path)s yolunu %(filesystem)s olarak biçimlendir"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "%(path)s yolunu %(mount)s olarak bağla"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "%(path)s yolunu %(mount)s olarak bağla"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr "LVM: "
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr "Disk şifreleme: "
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Kurulum tamamlandı"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Kurulum tamamlandı. Yeni sistemi kullanmak için bilgisayarınızı yeniden "
+"başlatmak istiyor musunuz?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Kurulum hatası"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr "Hata"
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Taşınabilir:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Düzenle"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr "%s olarak ata"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+"Disk: {} bölümlendirme tablosu bozuk veya mevcut değil. Yeni bölüm tablosu "
+"oluşturmak istiyor musunuz?"
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"Bölüm tablosu %s için yazılamadı. Bilgisayarı yeniden başlatın ve tekrar "
+"deneyin."
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"%s bölümü oluşturulamadı. Kurulum duracaktır. Bilgisayarı yeniden başlatın "
+"ve tekrar deneyin."
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Mantıksal bölüm"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Genişletilmiş bölüm"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Bilinmeyen"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr "önyükleyici/kurtarma"
+
+#: live-installer/frontend/partitioning.py:742
+msgid "EFI System Partition"
+msgstr "EFI Sistem Bölümü"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Bölümleri düzenle"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Donanım:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Biçimleme türü:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Bağlama noktası:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "İptal"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
+msgstr "Root olmalısınız!"
 
 #: live-installer/validate.py:12
 msgid "Please provide a username."
@@ -411,10 +1147,6 @@ msgstr "Parolanız sayı içermelidir"
 msgid "Please provide a password for your user account."
 msgstr "Lütfen kullanıcı hesabınız için parola belirleyin."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr "Root olmalısınız!"
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -441,7 +1173,7 @@ msgstr "Sisteme yeni kullanıcı ekleniyor"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Dosya sistemi bağlama bilgisi /etc/fstab içine yazılıyor"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "%(partition)s bölümü %(mountpoint)s bağlanma noktasına bağlanıyor"
@@ -463,47 +1195,47 @@ msgstr "%s üzerine bölümler oluşturuluyor"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "%(partition)s bölümü %(format)s biçiminde biçimlendiriliyor..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Bilgisayar adı ayarlanıyor"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Dil ayarlanıyor"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 msgid "Setting timezone"
 msgstr "Zaman dilimi ayarlanıyor"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Klavye ayarlanıyor"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 msgid "Removing extra packages"
 msgstr "Ekstra paketler siliniyor"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr "Paket yöneticisi temizleniyor"
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr "Initramfs oluşturuluyor"
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr "Ön yükleyici kurulumu hazırlanıyor"
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Önyükleyici kuruluyor"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Önyükleyici yapılandırılıyor"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -511,662 +1243,17 @@ msgstr ""
 "UYARI: Grub önyükleyicisi düzgün ayarlanamadı! Elle ayarlamanız "
 "gerekmektedir."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr "Güncellemeler yapılmaya çalışıyor"
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Kurulum tamamlandı"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Önyükleyici denetleniyor"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr "Komut ile çalıştırılamadı. ({} ile çıktı.)"
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Ülke"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Dil"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Düzen"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Değişken"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Dosya indexleri hesaplanıyor ..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr "Kurucu"
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr "Lisans Sözleşmesi"
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr "Hangi dili kullanmak istiyorsunuz?"
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr "Neredesiniz?"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Klavye düzeni"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr "Klavye düzeniniz nedir?"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr "Kullanıcı hesabı"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr "Kimsiniz?"
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr "Kurulum türü"
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr "Sistemi nereye kurmak istiyorsunuz?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Bölümlendirme"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Özet"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr "Her şeyin doğru olduğunu gözden geçirin"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr "Yükleniyor"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr "Lütfen bekleyin..."
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated Install"
-msgstr "Otomatik Kurulum"
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Geri"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr "İleri"
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr "%s Kurucuya Hoş Geldiniz."
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr "Klavyenizi test etmek için buraya yazın"
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr "Diski sil ve sistemi üstüne kur."
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-"Sistem için disk bölümlerini elle oluşturun, yeniden boyutlandırın veya "
-"seçin."
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr "Kurulum aracı bölümlendirme yapmayacak"
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr "Windowsu sil ve yerine yükle"
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr "Mevcut Windowsu sil ve yerine yükle."
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Bölümleri düzenle"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Donanım"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Tür"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "İşletim sistemi"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Bağlama noktası"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Biçimlendirme türü"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Boyut"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Boş alan"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr "Salt okunur"
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Yükle"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr "Lütfen şifreleme için parola belirleyin."
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Parolalar uyuşmuyor."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Çıkış?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Kurulumdan çıkmak istediğinizden emin misiniz?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr "Emin misiniz?"
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr "{}'de yeni bölüm oluşturulacak"
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr "{} bölümü {} içerisinden silinecek"
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr "{} bölümü {} içerisinden formatlanacak."
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Lütfen bir dil seçin"
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Lütfen bir klavye düzeni belirleyin."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Lütfen bir isim belirleyin."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr "Parolanız zayıf."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-"Kök dosya sistemi seçilmedi. Kurulum biçimlendirme olmadan devam edecek."
-"Devam etmek istiyor musunuz?"
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-"Kök bölümü çok küçük. En az 16GB olmalıdır. Devam etmek istiyor musunuz?"
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Lütfen kök (/) bölümü seçin."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-"%s yüklemek için bir kök bölüm gerekir.\n"
-"\n"
-" - Bağlama noktası: /\n"
-" - Önerilen boyut: 30 GB\n"
-" - Önerilen dosya sistemi: ext4\n"
-"\n"
-"Not: Timeshift uygulamasının btrfs anlık görüntü alma özelliğini kullanma "
-"için gereklilikler:\n"
-" - altbölüm Bağlama-noktası /@\n"
-" - dosya sistemi formatı olarak btrfs\n"
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "EFI bölümü önyüklenebilir değil. Önyükleme bayrağı ayarlansın mı?"
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "EFI bölümü çok küçük. En az 35MB olmalıdır."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "EFI bölümü vfat olarak biçimlendirilmelidir."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Lütfen bir EFI bölümü seçin."
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-"Aşağıdaki gereksinimlere sahip bir EFI sistem bölümü gereklidir:\n"
-"\n"
-"  - Bağlantı noktası: /boot/efi\n"
-"  - Bölüm bayrakları: Önyüklenebilir\n"
-"  - Boyut: en az 35MB (100MB veya daha fazlası önerilir)\n"
-"  - Biçim: vfat veya fat32\n"
-"\n"
-"Windows ile uyumluluğu sağlamak için diskin ilk bölümünü EFI sistem bölümü "
-"olarak kullanmanızı öneririz. "
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr "Lütfen bir disk seçin."
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr "Uyarı"
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr "%s üzerindeki tüm veriler silinecek. Emin misiniz?"
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr "Lütfen grub için bir disk belirleyin."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Yerelleştirme"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Dil "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Zaman dilimi "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Klavye düzeni "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Kullanıcı ayarları"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Gerçek isim "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Kullanıcı adı "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr "Parola: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Otomatik giriş "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "etkin"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "devre dışı"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Sistem ayarları"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr "Bilgisayar adı "
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr "Bios türü: "
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr "Kurulumdan sonra güncellemeleri yükle"
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Dosya sistemi işlemleri"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Önyükleyiciyi %s içine kur"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Ön yükleyici kurma"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "/target zaten bağlı."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr " (%s GB takas ile)"
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr "%s üzerine otomatik kurulum"
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "%(path)s yolunu %(filesystem)s olarak biçimlendir"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "%(path)s yolunu %(mount)s olarak bağla"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr "LVM: "
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr "Disk şifreleme: "
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Kurulum tamamlandı. Yeni sistemi kullanmak için bilgisayarınızı yeniden "
-"başlatmak istiyor musunuz?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Kurulum hatası"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr "Hata"
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr "%s dene"
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr "Şu anda %s canlı ortamdan çalışıyor."
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-"Şimdi %s yükleyebilirsiniz, veya Daha sonra uygulama menüsünden \"diske "
-"yükle\" seçebilirsiniz."
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr "Hoş geldiniz %s"
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr "Hangi dili kullanmak istiyorsunuz?"
-
-#: live-installer/frontend/tui_interface.py:64
-msgid "Keyboard Model"
-msgstr "Klavye modeli"
-
-#: live-installer/frontend/tui_interface.py:73
-msgid "Installation type?"
-msgstr "Kurulum türü?"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr "Lütfen bir disk seçin?"
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr "Disk"
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr "Zaman dilimi seçin"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Taşınabilir:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Düzenle"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr "%s olarak ata"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-"Disk: {} bölümlendirme tablosu bozuk veya mevcut değil. Yeni bölüm tablosu "
-"oluşturmak istiyor musunuz?"
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"Bölüm tablosu %s için yazılamadı. Bilgisayarı yeniden başlatın ve tekrar "
-"deneyin."
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"%s bölümü oluşturulamadı. Kurulum duracaktır. Bilgisayarı yeniden başlatın "
-"ve tekrar deneyin."
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Mantıksal bölüm"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Genişletilmiş bölüm"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Bilinmeyen"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr "önyükleyici/kurtarma"
-
-#: live-installer/frontend/partitioning.py:582
-msgid "EFI System Partition"
-msgstr "EFI Sistem Bölümü"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Bölümleri düzenle"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Donanım:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Biçimleme türü:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Bağlama noktası:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "İptal"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "Tamam"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Hayır"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Evet"
 
 #~ msgid "Quit"
 #~ msgstr "Çıkış"

--- a/po/live-installer-tr.po
+++ b/po/live-installer-tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: unnamed project\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2023-08-29 18:48+0300\n"
 "Last-Translator: Fatih Altun <fatih.altun@pardus.org.tr>\n"
 "Language-Team: Turkish <dev@pardus.org.tr>\n"
@@ -90,7 +90,7 @@ msgstr "1"
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -190,9 +190,9 @@ msgid "Format"
 msgstr "Biçimlendir"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr "Oluştur"
 
@@ -295,6 +295,12 @@ msgstr "salt okur"
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Biçimlendirme türü"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr "%s dene"
@@ -326,8 +332,8 @@ msgstr "Hoş geldiniz"
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "Tamam"
 
@@ -415,23 +421,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr "Hoş geldiniz %s"
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Ülke"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Düzen"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Değişken"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Dosya indexleri hesaplanıyor ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Taşınabilir:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr "Salt okunur"
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Düzenle"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr "%s olarak ata"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -449,10 +526,109 @@ msgstr "Dosya indexleri hesaplanıyor ..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr "Kurucu"
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+"Disk: {} bölümlendirme tablosu bozuk veya mevcut değil. Yeni bölüm tablosu "
+"oluşturmak istiyor musunuz?"
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Boş alan"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"Bölüm tablosu %s için yazılamadı. Bilgisayarı yeniden başlatın ve tekrar "
+"deneyin."
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"%s bölümü oluşturulamadı. Kurulum duracaktır. Bilgisayarı yeniden başlatın "
+"ve tekrar deneyin."
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Mantıksal bölüm"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Genişletilmiş bölüm"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Bilinmeyen"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr "önyükleyici/kurtarma"
+
+#: live-installer/frontend/partitioning.py:754
+msgid "EFI System Partition"
+msgstr "EFI Sistem Bölümü"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Bölümleri düzenle"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Donanım:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Biçimleme türü:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Bağlama noktası:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "İptal"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Ülke"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Düzen"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Değişken"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Dosya indexleri hesaplanıyor ..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -568,18 +744,6 @@ msgstr "Biçimlendirme türü"
 msgid "Size"
 msgstr "Boyut"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Boş alan"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr "Salt okunur"
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -612,25 +776,6 @@ msgstr "Çıkış?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Kurulumdan çıkmak istediğinizden emin misiniz?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -887,7 +1032,7 @@ msgid "Disk Encryption: "
 msgstr "Disk şifreleme: "
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Kurulum tamamlandı"
 
@@ -909,144 +1054,6 @@ msgstr "Kurulum hatası"
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
 msgstr "Hata"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Taşınabilir:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Düzenle"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr "%s olarak ata"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-"Disk: {} bölümlendirme tablosu bozuk veya mevcut değil. Yeni bölüm tablosu "
-"oluşturmak istiyor musunuz?"
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"Bölüm tablosu %s için yazılamadı. Bilgisayarı yeniden başlatın ve tekrar "
-"deneyin."
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"%s bölümü oluşturulamadı. Kurulum duracaktır. Bilgisayarı yeniden başlatın "
-"ve tekrar deneyin."
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Mantıksal bölüm"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Genişletilmiş bölüm"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Bilinmeyen"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr "önyükleyici/kurtarma"
-
-#: live-installer/frontend/partitioning.py:742
-msgid "EFI System Partition"
-msgstr "EFI Sistem Bölümü"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Bölümleri düzenle"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Donanım:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Biçimleme türü:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Bağlama noktası:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "İptal"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
-msgstr ""
 
 #: live-installer/main.py:38
 msgid "You must be root!"
@@ -1195,47 +1202,47 @@ msgstr "%s üzerine bölümler oluşturuluyor"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "%(partition)s bölümü %(format)s biçiminde biçimlendiriliyor..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Bilgisayar adı ayarlanıyor"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Dil ayarlanıyor"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 msgid "Setting timezone"
 msgstr "Zaman dilimi ayarlanıyor"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Klavye ayarlanıyor"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 msgid "Removing extra packages"
 msgstr "Ekstra paketler siliniyor"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr "Paket yöneticisi temizleniyor"
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr "Initramfs oluşturuluyor"
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr "Ön yükleyici kurulumu hazırlanıyor"
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Önyükleyici kuruluyor"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Önyükleyici yapılandırılıyor"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1243,15 +1250,15 @@ msgstr ""
 "UYARI: Grub önyükleyicisi düzgün ayarlanamadı! Elle ayarlamanız "
 "gerekmektedir."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr "Güncellemeler yapılmaya çalışıyor"
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Önyükleyici denetleniyor"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr "Komut ile çalıştırılamadı. ({} ile çıktı.)"
 

--- a/po/live-installer-tt.po
+++ b/po/live-installer-tt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2017-01-29 15:16+0000\n"
 "Last-Translator: myname <rezonans.89@mail.ru>\n"
 "Language-Team: Tatar <tt@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -291,6 +291,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -321,8 +326,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -409,23 +414,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -443,9 +519,102 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -560,18 +729,6 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -603,25 +760,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -856,7 +994,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Кую тәмам"
 
@@ -875,138 +1013,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1152,62 +1158,62 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Хост исемен көйләү"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Хост исемен көйләү"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Локализация пакетлары"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""

--- a/po/live-installer-tt.po
+++ b/po/live-installer-tt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2017-01-29 15:16+0000\n"
 "Last-Translator: myname <rezonans.89@mail.ru>\n"
 "Language-Team: Tatar <tt@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,140 +149,146 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 msgid "Edit Partitions"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -309,6 +317,700 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+msgid "Keyboard Model"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Кую тәмам"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Кую тәмам"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -404,10 +1106,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -434,7 +1132,7 @@ msgstr "Яңа кулланучыны системага өстәү"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr ""
@@ -454,674 +1152,62 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Хост исемен көйләү"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Хост исемен көйләү"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Локализация пакетлары"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Кую тәмам"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-msgid "Keyboard Model"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Кую тәмам"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""

--- a/po/live-installer-uk.po
+++ b/po/live-installer-uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2020-03-10 07:48+0000\n"
 "Last-Translator: Jon900 <Stuartlittle1970@gmail.com>\n"
 "Language-Team: Ukrainian <uk@li.org>\n"
@@ -24,20 +24,20 @@ msgid "Welcome to the 17g Installer."
 msgstr "Ласкаво просимо до інсталятора 17G."
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 #, fuzzy
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr "Ця програма задасть вам кілька запитань і налаштує 17G на комп'ютері."
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr "Модель клавіатури:"
 
@@ -47,10 +47,12 @@ msgid "Type here to test your keyboard"
 msgstr "Введіть тут, щоб перевірити розкладку клавіатури"
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -59,13 +61,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Часовий пояс"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr "Автоматична установка"
 
@@ -75,12 +77,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr "Стерти диск та встановити на нього 17G."
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr "Диск:"
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Змінити розділ"
@@ -91,42 +93,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "ҐБ"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr "Використання УЛР (Управління Логічними Розділами)"
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr "Шифрування операційної системи"
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr "Пароль"
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr "Підтвердіть пароль"
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr "Це забезпечує додаткову безпеку, але може потребувати декількох годин."
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr "Заповнити диск випадковими даними"
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr "Ручне розділення"
 
@@ -144,7 +146,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Режим фахівця"
@@ -154,144 +156,150 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 #, fuzzy
 msgid "Minimal installation"
 msgstr "Автоматична установка"
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Оновити"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Форматувати як"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr "Встановлення меню завантаження GRUB на:"
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Редагувати розділи"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr "Ваше ім'я:"
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr "Назва Вашого комп'ютера:"
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr "Вкажіть ім'я користувача:"
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr "Назва, яка використовується для зв'язку з іншими комп'ютерами."
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr "Виберіть пароль:"
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Входити автоматично"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr "Для входу потрібен пароль"
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr "Зашифрувати мій домашній каталог"
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr "Підтвердження паролю:"
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 #, fuzzy
 msgid "Automated installation enabled!"
 msgstr "Автоматична установка на %s"
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr "Вітаємо!"
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -322,6 +330,744 @@ msgstr ""
 #, fuzzy
 msgid "Welcome to 17g"
 msgstr "Вітаємо!"
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "Так"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Ні"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Так"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Часовий пояс"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, fuzzy, python-format
+msgid "Welcome to the %s Installer."
+msgstr "Ласкаво просимо до інсталятора 17G."
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr "Якою мовою ви б хотіли користуватися?"
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Мова"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr "Ваше місце знаходження?"
+
+#: live-installer/frontend/tui_interface.py:57
+#, fuzzy
+msgid "What keyboard would you like to use?"
+msgstr "Якою мовою ви б хотіли користуватися?"
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Модель клавіатури:"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Тип установки"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Тип"
+
+#: live-installer/frontend/tui_interface.py:80
+#, fuzzy
+msgid "Select a disk?"
+msgstr "Виберіть диск."
+
+#: live-installer/frontend/tui_interface.py:84
+#, fuzzy
+msgid "Disk"
+msgstr "Диск:"
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, fuzzy, python-format
+msgid "Welcome to %s"
+msgstr "Вітаємо!"
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Країна"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Розкладка"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Варіант"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Обчислення індексів файлів"
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr "Встановлювач"
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Розкладка клавіатури"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr "Яка розкладка клавіатури?"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr "Профіль користувача"
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr "Хто ви?"
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr "Тип установки"
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Де ви хочете встановити 17G?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Розбиття на розділи"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Підсумок"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr "Триває інсталяція"
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+#, fuzzy
+msgid "Automated Install"
+msgstr "Автоматична установка"
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Назад"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr "Наступне"
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr "Введіть тут, щоб перевірити розкладку клавіатури"
+
+#: live-installer/frontend/gtk_interface.py:546
+#, fuzzy
+msgid "Erase a disk and install system on it."
+msgstr "Стерти диск та встановити на нього 17G."
+
+#: live-installer/frontend/gtk_interface.py:559
+#, fuzzy
+msgid "Manually create, resize or choose partitions for system."
+msgstr "Вручну створити, змінити розмір або вибрати розділи для 17G."
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Редагувати розділи"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Пристрій"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Операційна система"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Точка монтування"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Форматувати як"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Розмір"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Вільне місце"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr "Застереження"
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr "Це видалить усі дані на %s. Ви впевнені?"
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Встановити"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr "Введіть пароль для шифрування."
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Ваші паролі не збігаються."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Вийти?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Ви впевнені, що бажаєте вийти з встановлення ?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Будь ласка, оберіть мову"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Вкажіть ім’я для свого комп’ютера."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Будь ласка, вкажіть своє повне ім'я."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Ваші паролі не збігаються."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "Розділ EFI занадто малий. Він повинен бути не менше 35 Мб."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Будь ласка, виберіть кореневий розділ (/)."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, fuzzy, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+"Для встановлення Linux Mint потрібен кореневий розділ.\n"
+"\n"
+" - Міце монтування: /\n"
+" - Рекомендований розмір: 30GB\n"
+" - Рекомендоване форматування: ext4\n"
+"\n"
+"Примітка: Функція резервного копіювання btrfs вимагає використання:\n"
+" - підрозділ місця монтування /@\n"
+" - форматування btrfs\n"
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+"Розділ EFI не є завантажувальним. Будь ласка, відредагуйте прапорці розділів."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "Розділ EFI занадто малий. Він повинен бути не менше 35 Мб."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "Розділ EFI повинен бути відформатований як vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Будь ласка, виберіть розділ EFI."
+
+#: live-installer/frontend/gtk_interface.py:1301
+#, fuzzy
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+"Потрібен системний розділ EFI із наступними вимогами:\n"
+"\n"
+" - Міце монтування: /boot/efi\n"
+" - Прапорець розділу: Bootable\n"
+" - Розмір: мінімум 35MB (100MB або більше рекомендується)\n"
+" - Форматування: vfat або fat32\n"
+"\n"
+"Для забезпечення сумісності з Windows рекомендується використовувати перший "
+"розділ диска як системний розділ EFI.\n"
+" "
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr "Виберіть диск."
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Будь ласка, вкажіть ім'я користувача."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Локалізація"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Мова: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Часовий пояс: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Розкладка клавіатури: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Налаштування користувача"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Справжнє ім'я "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Ім'я користувача: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Автоматичний вхід у систему: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "увімкнено"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "вимкнено"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Налаштування системи"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr "Ім'я комп’ютера: "
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+#, fuzzy
+msgid "Install updates after installation"
+msgstr "Автоматична установка"
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Операції з файловою системою"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Встановити завантажувач на %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Не встановлювати завантажувач"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Використовувати вже встановлений /target."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr "Автоматична установка на %s"
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Форматувати %(path)s як %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Монтувати %(path)s як %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Монтувати %(path)s як %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr "LVM: "
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr "Шифрування диску: "
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Встановлення завершено"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Встановлення завершено. Ви бажаєте перезавантажити комп'ютер, щоб "
+"скористатися новою системою?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Помилка під час встановлення"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "Б"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "кб"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "Мб"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "Тб"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Знімний:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Редагувати"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Призначити /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"Не вдалося записати таблицю розділів для %s. Перезавантажте комп’ютер і "
+"повторіть спробу."
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"Розділ %s не вдалося створити. Встановлення припиниться. Перезавантажте "
+"комп’ютер і повторіть спробу."
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Логічний розділ"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Розширений розділ"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Невідомий"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Змінити розділ"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Змінити розділ"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Пристрій:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Форматувати як:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Точка монтування:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Скасувати"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
+msgstr ""
 
 #: live-installer/validate.py:12
 msgid "Please provide a username."
@@ -431,10 +1177,6 @@ msgstr "Ваші паролі не збігаються."
 msgid "Please provide a password for your user account."
 msgstr "Будь ласка, вкажіть пароль для облікового запису користувача."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -461,7 +1203,7 @@ msgstr "Додавання нового користувача у систему
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Запис інформації про монтування файлової системи у /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Монтування %(partition)s на %(mountpoint)s"
@@ -483,49 +1225,49 @@ msgstr "Створення розділів на %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Форматування %(partition)s як %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Налаштування назви хосту"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Налаштування мови"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Налаштування назви хосту"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Налаштування параметрів клавіатури"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Вилучення тимчасових налаштувань (пакунків)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Встановлення завантажувача"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Налаштування завантажувача"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -533,673 +1275,17 @@ msgstr ""
 "УВАГА! Завантажувач GRUB не був налаштований правильно! Вам треба "
 "наташтувати його вручну."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Встановлення завершено"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Перевірка завантажувача"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Країна"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Мова"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Розкладка"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Варіант"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Обчислення індексів файлів"
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr "Встановлювач"
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr "Якою мовою ви б хотіли користуватися?"
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr "Ваше місце знаходження?"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Розкладка клавіатури"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr "Яка розкладка клавіатури?"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr "Профіль користувача"
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr "Хто ви?"
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr "Тип установки"
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Де ви хочете встановити 17G?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Розбиття на розділи"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Підсумок"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr "Триває інсталяція"
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-#, fuzzy
-msgid "Automated install"
-msgstr "Автоматична установка"
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Назад"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr "Наступне"
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, fuzzy, python-format
-msgid "Welcome to the %s Installer."
-msgstr "Ласкаво просимо до інсталятора 17G."
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr "Введіть тут, щоб перевірити розкладку клавіатури"
-
-#: live-installer/frontend/gtk_interface.py:542
-#, fuzzy
-msgid "Erase a disk and install system on it."
-msgstr "Стерти диск та встановити на нього 17G."
-
-#: live-installer/frontend/gtk_interface.py:555
-#, fuzzy
-msgid "Manually create, resize or choose partitions for system."
-msgstr "Вручну створити, змінити розмір або вибрати розділи для 17G."
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Редагувати розділи"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Пристрій"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Тип"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Операційна система"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Точка монтування"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Форматувати як"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Розмір"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Вільне місце"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Встановити"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr "Введіть пароль для шифрування."
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Ваші паролі не збігаються."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Вийти?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Ви впевнені, що бажаєте вийти з встановлення ?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Будь ласка, оберіть мову"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Вкажіть ім’я для свого комп’ютера."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Будь ласка, вкажіть своє повне ім'я."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Ваші паролі не збігаються."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "Розділ EFI занадто малий. Він повинен бути не менше 35 Мб."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Будь ласка, виберіть кореневий розділ (/)."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, fuzzy, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-"Для встановлення Linux Mint потрібен кореневий розділ.\n"
-"\n"
-" - Міце монтування: /\n"
-" - Рекомендований розмір: 30GB\n"
-" - Рекомендоване форматування: ext4\n"
-"\n"
-"Примітка: Функція резервного копіювання btrfs вимагає використання:\n"
-" - підрозділ місця монтування /@\n"
-" - форматування btrfs\n"
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-"Розділ EFI не є завантажувальним. Будь ласка, відредагуйте прапорці розділів."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "Розділ EFI занадто малий. Він повинен бути не менше 35 Мб."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "Розділ EFI повинен бути відформатований як vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Будь ласка, виберіть розділ EFI."
-
-#: live-installer/frontend/gtk_interface.py:1226
-#, fuzzy
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-"Потрібен системний розділ EFI із наступними вимогами:\n"
-"\n"
-" - Міце монтування: /boot/efi\n"
-" - Прапорець розділу: Bootable\n"
-" - Розмір: мінімум 35MB (100MB або більше рекомендується)\n"
-" - Форматування: vfat або fat32\n"
-"\n"
-"Для забезпечення сумісності з Windows рекомендується використовувати перший "
-"розділ диска як системний розділ EFI.\n"
-" "
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr "Виберіть диск."
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr "Застереження"
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr "Це видалить усі дані на %s. Ви впевнені?"
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Будь ласка, вкажіть ім'я користувача."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Локалізація"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Мова: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Часовий пояс: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Розкладка клавіатури: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Налаштування користувача"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Справжнє ім'я "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Ім'я користувача: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Автоматичний вхід у систему: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "увімкнено"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "вимкнено"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Налаштування системи"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr "Ім'я комп’ютера: "
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-#, fuzzy
-msgid "Install updates after installation"
-msgstr "Автоматична установка"
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Операції з файловою системою"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Встановити завантажувач на %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Не встановлювати завантажувач"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Використовувати вже встановлений /target."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr "Автоматична установка на %s"
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Форматувати %(path)s як %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Монтувати %(path)s як %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr "LVM: "
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr "Шифрування диску: "
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Встановлення завершено. Ви бажаєте перезавантажити комп'ютер, щоб "
-"скористатися новою системою?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Помилка під час встановлення"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, fuzzy, python-format
-msgid "Welcome to %s"
-msgstr "Вітаємо!"
-
-#: live-installer/frontend/tui_interface.py:57
-#, fuzzy
-msgid "What keyboard would you like to use?"
-msgstr "Якою мовою ви б хотіли користуватися?"
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Модель клавіатури:"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Тип установки"
-
-#: live-installer/frontend/tui_interface.py:80
-#, fuzzy
-msgid "Select a disk?"
-msgstr "Виберіть диск."
-
-#: live-installer/frontend/tui_interface.py:84
-#, fuzzy
-msgid "Disk"
-msgstr "Диск:"
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Часовий пояс"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "Б"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "кб"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "Мб"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "Тб"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Знімний:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Редагувати"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Призначити /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"Не вдалося записати таблицю розділів для %s. Перезавантажте комп’ютер і "
-"повторіть спробу."
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"Розділ %s не вдалося створити. Встановлення припиниться. Перезавантажте "
-"комп’ютер і повторіть спробу."
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Логічний розділ"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Розширений розділ"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Невідомий"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Змінити розділ"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Змінити розділ"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Пристрій:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Форматувати як:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Точка монтування:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Скасувати"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "Так"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Ні"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Так"
 
 #~ msgid "Quit"
 #~ msgstr "Вийти"

--- a/po/live-installer-uk.po
+++ b/po/live-installer-uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2020-03-10 07:48+0000\n"
 "Last-Translator: Jon900 <Stuartlittle1970@gmail.com>\n"
 "Language-Team: Ukrainian <uk@li.org>\n"
@@ -93,7 +93,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "ҐБ"
 
@@ -195,9 +195,9 @@ msgid "Format"
 msgstr "Форматувати як"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -302,6 +302,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Форматувати як"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -333,8 +339,8 @@ msgstr "Вітаємо!"
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "Так"
 
@@ -426,23 +432,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr "Вітаємо!"
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Країна"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "Б"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Розкладка"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "кб"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Варіант"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "Мб"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Обчислення індексів файлів"
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "Тб"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Знімний:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Редагувати"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Призначити /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -460,10 +537,108 @@ msgstr "Обчислення індексів файлів"
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr "Встановлювач"
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Вільне місце"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+"Не вдалося записати таблицю розділів для %s. Перезавантажте комп’ютер і "
+"повторіть спробу."
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+"Розділ %s не вдалося створити. Встановлення припиниться. Перезавантажте "
+"комп’ютер і повторіть спробу."
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Логічний розділ"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Розширений розділ"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Невідомий"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Змінити розділ"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Змінити розділ"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Пристрій:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Форматувати як:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Точка монтування:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Скасувати"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Країна"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Розкладка"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Варіант"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Обчислення індексів файлів"
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -581,18 +756,6 @@ msgstr "Форматувати як"
 msgid "Size"
 msgstr "Розмір"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Вільне місце"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -625,25 +788,6 @@ msgstr "Вийти?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Ви впевнені, що бажаєте вийти з встановлення ?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -905,7 +1049,7 @@ msgid "Disk Encryption: "
 msgstr "Шифрування диску: "
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Встановлення завершено"
 
@@ -926,143 +1070,6 @@ msgstr "Помилка під час встановлення"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "Б"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "кб"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "Мб"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "Тб"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Знімний:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Редагувати"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Призначити /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-"Не вдалося записати таблицю розділів для %s. Перезавантажте комп’ютер і "
-"повторіть спробу."
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-"Розділ %s не вдалося створити. Встановлення припиниться. Перезавантажте "
-"комп’ютер і повторіть спробу."
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Логічний розділ"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Розширений розділ"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Невідомий"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Змінити розділ"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Змінити розділ"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Пристрій:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Форматувати як:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Точка монтування:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Скасувати"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1225,49 +1232,49 @@ msgstr "Створення розділів на %s"
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Форматування %(partition)s як %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Налаштування назви хосту"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Налаштування мови"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Налаштування назви хосту"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Налаштування параметрів клавіатури"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Вилучення тимчасових налаштувань (пакунків)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Встановлення завантажувача"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Налаштування завантажувача"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1275,15 +1282,15 @@ msgstr ""
 "УВАГА! Завантажувач GRUB не був налаштований правильно! Вам треба "
 "наташтувати його вручну."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Перевірка завантажувача"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-ur.po
+++ b/po/live-installer-ur.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2016-12-06 13:44+0000\n"
 "Last-Translator: Waqar Ahmed <waqar.17a@gmail.com>\n"
 "Language-Team: Urdu <ur@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "علاقہ وقت"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "پارٹیشن کی ترمیم"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "گ.ب"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "ماہر موڈ"
@@ -149,142 +151,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "تازہ کریں"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "فارمیٹ کریں بطور"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "پارٹیشن میں ترمیم"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "خودکار لاگ ان کر دیں"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -313,6 +321,714 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "علاقہ وقت"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "زبان"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "کیبورڈ خاکہ"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "انسٹالیشن موقوف کردہ"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "قسم"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "ملک"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "وضع کاری"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "مختلف"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "کیبورڈ خاکہ"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "کیا آپ واقعی بند کرنا چاہتے ہیں؟"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "پارٹیشن کر رہا ہے"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "خلاصہ"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "پارٹیشن میں ترمیم"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "ڈیوائس"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "آپریٹینگ سسٹم"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "ماؤنٹ پوائنٹ"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "فارمیٹ کریں بطور"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "سائز"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "خالی جگہ"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "پاس ورڈ آپس میں مل نہیں رہے"
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "بند کر دیں؟"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "کیا آپ واقعی بند کرنا چاہتے ہیں؟"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "برائے مہربانی زبان منتخب کریں"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "اپنے کھاتے کے لیے پاس ورڈ فراہم کریں۔"
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "اپنا پورا نام فراہم کریں۔"
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "پاس ورڈ آپس میں مل نہیں رہے"
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+"EFI پارٹیشن بوٹ ہو نے کے قابل نہیں ہے۔ برائے مہربانی پارٹیشن فلیگ کی ترمیم "
+"کریں۔"
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+"EFI پارٹیشن بوٹ ہو نے کے قابل نہیں ہے۔ برائے مہربانی پارٹیشن فلیگ کی ترمیم "
+"کریں۔"
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "EFI پارٹیشن بطور vfat فارمیٹ ہونی چاہیے۔"
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "EFI پارٹیشن بطور vfat فارمیٹ ہونی چاہیے۔"
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "برائے مہربانی ایک EFI پارٹیشن منتخب کریں۔"
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "اپنا اسم صارف(username) فراہم کریں۔"
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "مقامیانہ"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "زبان: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "علاقہ وقت: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "کیبورڈ خاکہ: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "صارف کی ترتیبات"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "اصل نام: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "اسمِ صارف: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "خودکار لاگ ان: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "فعال کردہ"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "غیر فعال کردہ"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "سسٹم کی ترتیبات"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "فائل سسٹم آپریشن"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "بوٹ لوڈر کو %s پہ انسٹال کر دیں"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "بوٹ لوڈر مت انسٹال کریں"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "انسٹالیشن مکمل ہوئی"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr "انسٹالیشن مکمل ہو گئی۔ کیا آپ اب کمپیوٹر کو ری۔سٹارٹ کرنا چاہیں گے؟"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "انسٹالیشن میں مسئلہ"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "ب"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "ک.ب"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "م.ب"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "ٹ.ب"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "قابلِ علیحدگی:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "ترمیم"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "نا معلوم"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "پارٹیشن کی ترمیم"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "پارٹیشن کی ترمیم"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "آلہ:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "فارمیٹ کریں بطور:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "ماؤنٹ پوائنٹ"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -421,10 +1137,6 @@ msgstr "پاس ورڈ آپس میں مل نہیں رہے"
 msgid "Please provide a password for your user account."
 msgstr "اپنے کھاتے کے لیے پاس ورڈ فراہم کریں۔"
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -451,7 +1163,7 @@ msgstr "سسٹم میں نیا صارف شامل کر رہا ہے"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr ""
@@ -471,49 +1183,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "ھوسٹ کا نام سیٹ کر رہا ہے"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "لوکیل سیٹ کیا جا رہا ہے"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "ھوسٹ کا نام سیٹ کر رہا ہے"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "کیی بورڈ کے اختیارات سیٹ کیے جا رہے ہیں"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "والی ترتیب مٹا رہا ہے CD (packages)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "بوٹ لوڈر نصب کیا جا رہا ہے"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "بوٹ لوڈر ترتیب دیا جا رہا ہے"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -521,642 +1233,16 @@ msgstr ""
 "انتباہ: گرب بوٹ لوڈر کو صحیح سے تشکیل نہیں دیا جا سکا۔ آپ کو اس کو دستی "
 "طریقے سے تشکیل دینا ہو گا۔"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "انسٹالیشن مکمل ہوئی"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "بوٹ لوڈر کو چیک کیا جا رہا ہے"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "ملک"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "زبان"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "وضع کاری"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "مختلف"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "کیبورڈ خاکہ"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "کیا آپ واقعی بند کرنا چاہتے ہیں؟"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "پارٹیشن کر رہا ہے"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "خلاصہ"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "پارٹیشن میں ترمیم"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "ڈیوائس"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "قسم"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "آپریٹینگ سسٹم"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "ماؤنٹ پوائنٹ"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "فارمیٹ کریں بطور"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "سائز"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "خالی جگہ"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "پاس ورڈ آپس میں مل نہیں رہے"
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "بند کر دیں؟"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "کیا آپ واقعی بند کرنا چاہتے ہیں؟"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "برائے مہربانی زبان منتخب کریں"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "اپنے کھاتے کے لیے پاس ورڈ فراہم کریں۔"
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "اپنا پورا نام فراہم کریں۔"
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "پاس ورڈ آپس میں مل نہیں رہے"
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-"EFI پارٹیشن بوٹ ہو نے کے قابل نہیں ہے۔ برائے مہربانی پارٹیشن فلیگ کی ترمیم "
-"کریں۔"
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-"EFI پارٹیشن بوٹ ہو نے کے قابل نہیں ہے۔ برائے مہربانی پارٹیشن فلیگ کی ترمیم "
-"کریں۔"
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "EFI پارٹیشن بطور vfat فارمیٹ ہونی چاہیے۔"
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "EFI پارٹیشن بطور vfat فارمیٹ ہونی چاہیے۔"
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "برائے مہربانی ایک EFI پارٹیشن منتخب کریں۔"
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "اپنا اسم صارف(username) فراہم کریں۔"
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "مقامیانہ"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "زبان: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "علاقہ وقت: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "کیبورڈ خاکہ: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "صارف کی ترتیبات"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "اصل نام: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "اسمِ صارف: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "خودکار لاگ ان: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "فعال کردہ"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "غیر فعال کردہ"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "سسٹم کی ترتیبات"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "فائل سسٹم آپریشن"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "بوٹ لوڈر کو %s پہ انسٹال کر دیں"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "بوٹ لوڈر مت انسٹال کریں"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr "انسٹالیشن مکمل ہو گئی۔ کیا آپ اب کمپیوٹر کو ری۔سٹارٹ کرنا چاہیں گے؟"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "انسٹالیشن میں مسئلہ"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "کیبورڈ خاکہ"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "انسٹالیشن موقوف کردہ"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "علاقہ وقت"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "ب"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "ک.ب"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "م.ب"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "ٹ.ب"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "قابلِ علیحدگی:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "ترمیم"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "نا معلوم"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "پارٹیشن کی ترمیم"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "پارٹیشن کی ترمیم"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "آلہ:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "فارمیٹ کریں بطور:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "ماؤنٹ پوائنٹ"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-ur.po
+++ b/po/live-installer-ur.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2016-12-06 13:44+0000\n"
 "Last-Translator: Waqar Ahmed <waqar.17a@gmail.com>\n"
 "Language-Team: Urdu <ur@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "گ.ب"
 
@@ -189,9 +189,9 @@ msgid "Format"
 msgstr "فارمیٹ کریں بطور"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -295,6 +295,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "فارمیٹ کریں بطور"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -325,8 +331,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -415,23 +421,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "ملک"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "ب"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "وضع کاری"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "ک.ب"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "مختلف"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "م.ب"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "ٹ.ب"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "قابلِ علیحدگی:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "ترمیم"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -449,9 +526,103 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "خالی جگہ"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "نا معلوم"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "پارٹیشن کی ترمیم"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "پارٹیشن کی ترمیم"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "آلہ:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "فارمیٹ کریں بطور:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "ماؤنٹ پوائنٹ"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "ملک"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "وضع کاری"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "مختلف"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -567,18 +738,6 @@ msgstr "فارمیٹ کریں بطور"
 msgid "Size"
 msgstr "سائز"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "خالی جگہ"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -611,25 +770,6 @@ msgstr "بند کر دیں؟"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "کیا آپ واقعی بند کرنا چاہتے ہیں؟"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -873,7 +1013,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "انسٹالیشن مکمل ہوئی"
 
@@ -892,139 +1032,6 @@ msgstr "انسٹالیشن میں مسئلہ"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "ب"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "ک.ب"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "م.ب"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "ٹ.ب"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "قابلِ علیحدگی:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "ترمیم"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "نا معلوم"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "پارٹیشن کی ترمیم"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "پارٹیشن کی ترمیم"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "آلہ:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "فارمیٹ کریں بطور:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "ماؤنٹ پوائنٹ"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1183,49 +1190,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "ھوسٹ کا نام سیٹ کر رہا ہے"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "لوکیل سیٹ کیا جا رہا ہے"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "ھوسٹ کا نام سیٹ کر رہا ہے"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "کیی بورڈ کے اختیارات سیٹ کیے جا رہے ہیں"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "والی ترتیب مٹا رہا ہے CD (packages)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "بوٹ لوڈر نصب کیا جا رہا ہے"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "بوٹ لوڈر ترتیب دیا جا رہا ہے"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1233,15 +1240,15 @@ msgstr ""
 "انتباہ: گرب بوٹ لوڈر کو صحیح سے تشکیل نہیں دیا جا سکا۔ آپ کو اس کو دستی "
 "طریقے سے تشکیل دینا ہو گا۔"
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "بوٹ لوڈر کو چیک کیا جا رہا ہے"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-uz.po
+++ b/po/live-installer-uz.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2020-01-05 18:53+0000\n"
 "Last-Translator: Umidjon Almasov <Unknown>\n"
 "Language-Team: Uzbek <uz@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "ГБ"
 
@@ -189,9 +189,9 @@ msgid "Format"
 msgstr "Форматлаш тури"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -295,6 +295,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Форматлаш тури"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -325,8 +331,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "OK"
 
@@ -415,23 +421,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Мамлакат"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "Б"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Шаблон"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "кБ"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Вариант"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "МБ"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Файл индексларини ҳисоблаш ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "ТБ"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Олиб ташлаш мумкин:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Таҳрирлаш"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "/ га тайинлаш"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -449,10 +526,104 @@ msgstr "Файл индексларини ҳисоблаш ..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Бўш жой"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Мантиқий қисм (Logical partition)"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Дискнинг кенгайтирилган қисми"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Номаълум"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Диск қисмини таҳрирлаш"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Диск қисмини таҳрирлаш"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Қўрилма:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Формат тури:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Улаш нуқтаси:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "Bekor qilish"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Мамлакат"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Шаблон"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Вариант"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Файл индексларини ҳисоблаш ..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -567,18 +738,6 @@ msgstr "Форматлаш тури"
 msgid "Size"
 msgstr "Ўлчам"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Бўш жой"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -611,25 +770,6 @@ msgstr "Чиқиб кетмоқчимисиз?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Ўрнатувчи дастурни тўхтатмоқчимисиз?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -869,7 +1009,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Операцион тизимни ўрнатиш якунланди"
 
@@ -890,139 +1030,6 @@ msgstr "Ўрнатиш пайтида хато содир бўлди"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "Б"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "кБ"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "МБ"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "ТБ"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Олиб ташлаш мумкин:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Таҳрирлаш"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "/ га тайинлаш"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Мантиқий қисм (Logical partition)"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Дискнинг кенгайтирилган қисми"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Номаълум"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Диск қисмини таҳрирлаш"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Диск қисмини таҳрирлаш"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Қўрилма:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Формат тури:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Улаш нуқтаси:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "Bekor qilish"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1181,50 +1188,50 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "%(partition)s ларни %(format)s каби форматлаш..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Компьютер номини ўрнатиш"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Маҳаллик тилни ўрнатиш"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Компьютер номини ўрнатиш"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Клавиатура параметрларини ўрнатиш"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr ""
 "Тизимга ўрнатиш пайтида зарур бўлган вақтинчалик пакетларни олиб ташлаш"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Операцион тизимни юкловчи дастурни (bootloader) ўрнатиш"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Операцион тизимни юкловчи дастур (bootloader) ни созлаш"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1232,15 +1239,15 @@ msgstr ""
 "ОГОҲЛАНТИРИШ: grub юклагич (bootloader) тўлиғича созланмади! Уни қўлда "
 "созлашингиз керак."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Операцион тизимни юкловчи дастур (bootloader) ни текшириш"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-uz.po
+++ b/po/live-installer-uz.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2020-01-05 18:53+0000\n"
 "Last-Translator: Umidjon Almasov <Unknown>\n"
 "Language-Team: Uzbek <uz@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Вақт зонаси"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Диск қисмини таҳрирлаш"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "ГБ"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Эксперт режими"
@@ -149,142 +151,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Янгилаш"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Форматлаш тури"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Диск қисаларини таҳрирлаш"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Тизимга автоматик кириш"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -313,6 +321,712 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "OK"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "Yo‘q"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "Ha"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Вақт зонаси"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Тил"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Клавиатура тили"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Ўрнатиш вақтинчалик тўхтатилди"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Тури"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Мамлакат"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Шаблон"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Вариант"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Файл индексларини ҳисоблаш ..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Клавиатура тили"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Ўрнатувчи дастурни тўхтатмоқчимисиз?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Дискни бўлиш"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Ҳисобот"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "Orqaga"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Диск қисаларини таҳрирлаш"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Қурилма"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Операцион тизим"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Улаш нуқтаси"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Форматлаш тури"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Ўлчам"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Бўш жой"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "Oʻrnatish"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Пароллар мос тушмаяпти"
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Чиқиб кетмоқчимисиз?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Ўрнатувчи дастурни тўхтатмоқчимисиз?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Тилни танланг"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Аккаунтингиз учун парол яратинг"
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Тўлиқ номингизни киритинг."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Пароллар мос тушмаяпти"
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "EFI қисм юкланувчи эмас. Қисм барйроқчаларини таҳрирланг."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "root (/) қисмни танланг."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "EFI қисм юкланувчи эмас. Қисм барйроқчаларини таҳрирланг."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "EFI қисм vfat турда форматланиши зарур."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "EFI қисм vfat турда форматланиши зарур."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "EFI қисмни танланг."
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Фойдаланувчи номини киритинг"
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Локализация"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Тил: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Вақи зонаси: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Клавиатура шаблони: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Фойдаланувчи созламалари"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Реал ном: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Фойдаланувчи номи: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Тизимга автоматик кириш: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "ёқилган"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "ўчирилган"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Тизим мосламалари"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Файл тизимида мумкин бўлган амаллар"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Юкловчи дастур (bootloader) ни  %s га ўрнатиш"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Юкловчи дастур (bootloader) тизимга ўрнатилмасин"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Аллақачон уланган /target ни ишлатиш"
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "%(path)s ни %(filesystem)s каби форматлаш"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "%(path)s  ни %(mount)s каби улаш"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "%(path)s  ни %(mount)s каби улаш"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Операцион тизимни ўрнатиш якунланди"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Ўрнатиш жараёни якунланди. Янги тизимни ишлатиш учун компьютерни ўчириб-"
+"ёқасизми?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Ўрнатиш пайтида хато содир бўлди"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "Б"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "кБ"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "МБ"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "ТБ"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Олиб ташлаш мумкин:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Таҳрирлаш"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "/ га тайинлаш"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Мантиқий қисм (Logical partition)"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Дискнинг кенгайтирилган қисми"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Номаълум"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Диск қисмини таҳрирлаш"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Диск қисмини таҳрирлаш"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Қўрилма:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Формат тури:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Улаш нуқтаси:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "Bekor qilish"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -421,10 +1135,6 @@ msgstr "Пароллар мос тушмаяпти"
 msgid "Please provide a password for your user account."
 msgstr "Аккаунтингиз учун парол яратинг"
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -451,7 +1161,7 @@ msgstr "Тизимга янги фойдаланувчи қўшиш"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Файл тизимини улаш ҳақидаги маълумотни /etc/fstab га ёзиш"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "%(partition)s ни %(mountpoint)s га улаш"
@@ -471,50 +1181,50 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "%(partition)s ларни %(format)s каби форматлаш..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Компьютер номини ўрнатиш"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Маҳаллик тилни ўрнатиш"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Компьютер номини ўрнатиш"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Клавиатура параметрларини ўрнатиш"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr ""
 "Тизимга ўрнатиш пайтида зарур бўлган вақтинчалик пакетларни олиб ташлаш"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Операцион тизимни юкловчи дастурни (bootloader) ўрнатиш"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Операцион тизимни юкловчи дастур (bootloader) ни созлаш"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -522,641 +1232,17 @@ msgstr ""
 "ОГОҲЛАНТИРИШ: grub юклагич (bootloader) тўлиғича созланмади! Уни қўлда "
 "созлашингиз керак."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Операцион тизимни ўрнатиш якунланди"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Операцион тизимни юкловчи дастур (bootloader) ни текшириш"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Мамлакат"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Тил"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Шаблон"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Вариант"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Файл индексларини ҳисоблаш ..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Клавиатура тили"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Ўрнатувчи дастурни тўхтатмоқчимисиз?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Дискни бўлиш"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Ҳисобот"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "Orqaga"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Диск қисаларини таҳрирлаш"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Қурилма"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Тури"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Операцион тизим"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Улаш нуқтаси"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Форматлаш тури"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Ўлчам"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Бўш жой"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "Oʻrnatish"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Пароллар мос тушмаяпти"
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Чиқиб кетмоқчимисиз?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Ўрнатувчи дастурни тўхтатмоқчимисиз?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Тилни танланг"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Аккаунтингиз учун парол яратинг"
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Тўлиқ номингизни киритинг."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Пароллар мос тушмаяпти"
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "EFI қисм юкланувчи эмас. Қисм барйроқчаларини таҳрирланг."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "root (/) қисмни танланг."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "EFI қисм юкланувчи эмас. Қисм барйроқчаларини таҳрирланг."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "EFI қисм vfat турда форматланиши зарур."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "EFI қисм vfat турда форматланиши зарур."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "EFI қисмни танланг."
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Фойдаланувчи номини киритинг"
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Локализация"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Тил: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Вақи зонаси: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Клавиатура шаблони: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Фойдаланувчи созламалари"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Реал ном: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Фойдаланувчи номи: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Тизимга автоматик кириш: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "ёқилган"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "ўчирилган"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Тизим мосламалари"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Файл тизимида мумкин бўлган амаллар"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Юкловчи дастур (bootloader) ни  %s га ўрнатиш"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Юкловчи дастур (bootloader) тизимга ўрнатилмасин"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Аллақачон уланган /target ни ишлатиш"
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "%(path)s ни %(filesystem)s каби форматлаш"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "%(path)s  ни %(mount)s каби улаш"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Ўрнатиш жараёни якунланди. Янги тизимни ишлатиш учун компьютерни ўчириб-"
-"ёқасизми?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Ўрнатиш пайтида хато содир бўлди"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Клавиатура тили"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Ўрнатиш вақтинчалик тўхтатилди"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Вақт зонаси"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "Б"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "кБ"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "МБ"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "ТБ"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Олиб ташлаш мумкин:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Таҳрирлаш"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "/ га тайинлаш"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Мантиқий қисм (Logical partition)"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Дискнинг кенгайтирилган қисми"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Номаълум"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Диск қисмини таҳрирлаш"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Диск қисмини таҳрирлаш"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Қўрилма:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Формат тури:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Улаш нуқтаси:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "Bekor qilish"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "OK"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "Yo‘q"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "Ha"
 
 #~ msgid "Quit"
 #~ msgstr "Tizimdan chiqish"

--- a/po/live-installer-vi.po
+++ b/po/live-installer-vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2015-02-25 07:57+0000\n"
 "Last-Translator: Saki <Unknown>\n"
 "Language-Team: Vietnamese <vi@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "Múi giờ"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "Sửa phân vùng"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "Chế độ chuyên gia"
@@ -149,142 +151,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "Làm mới"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "Định dạng như"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "Chỉnh sửa phân vùng"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "Đăng nhập tự động"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -313,6 +321,712 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "Múi giờ"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "Ngôn ngữ"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "Bố trí bàn phím"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "Cài đặt tạm dừng"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "Kiểu"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Quốc gia"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Bố trí"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Biến thể"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Đang tính toán chỉ mục tập tin..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "Bố trí bàn phím"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "Bạn có chắc chắn muốn thoát trình cài đặt không ?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "Đang phân vùng"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "Tóm tắt"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "Chỉnh sửa phân vùng"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "Thiết bị"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "Hệ điều hành"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "Điểm gắn kết"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "Định dạng như"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "Kích cỡ"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "Không gian trống"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "Mật khẩu không khớp."
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "Thoát ?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "Bạn có chắc chắn muốn thoát trình cài đặt không ?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "Vui lòng chọn ngôn ngữ"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "Vui lòng cung cấp mật khẩu cho tài khoản người dùng."
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "Vui lòng cung cấp họ tên đầy đủ."
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "Mật khẩu không khớp."
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "Phân vùng EFI không khởi động được. Vui lòng chỉnh sửa cờ phân vùng."
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "Vui lòng chọn phân vùng gốc (/)."
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "Phân vùng EFI không khởi động được. Vui lòng chỉnh sửa cờ phân vùng."
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "Phân vùng EFI phải được định dạng kiểu vfat."
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "Phân vùng EFI phải được định dạng kiểu vfat."
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "Vui lòng chọn phân vùng EFI."
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "Vui lòng cung cấp tên người dùng."
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "Bản địa hóa"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "Ngôn ngữ: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "Múi giờ: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "Bố trí bàn phím: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "Thiết lập người dùng"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "Tên thật: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "Tên người dùng: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "Tự động đăng nhập: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "bật"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "tắt"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "Thiết lập hệ thống"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "Thao tác hệ thống tập tin"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "Cài đặt trình nạp khởi động vào %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "Không cài đặt trình nạp khởi động"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "Dùng /target đã gắn kết."
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "Định dạng %(path)s thành %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "Gắn kết %(path)s vào %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "Gắn kết %(path)s vào %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "Cài đặt hoàn tất"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+"Quá trình cài đặt giờ đã hoàn tất. Bạn có muốn khởi động lại máy để dùng hệ "
+"thống mới không ?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "Lỗi cài đặt"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Tháo lắp được:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "Chỉnh sửa"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Gán vào /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "Phân vùng luận lý"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "Phân vùng mở rộng"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "Không rõ"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Sửa phân vùng"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "Sửa phân vùng"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "Thiết bị:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "Định dạng thành:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "Điểm gắn kết:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -421,10 +1135,6 @@ msgstr "Mật khẩu không khớp."
 msgid "Please provide a password for your user account."
 msgstr "Vui lòng cung cấp mật khẩu cho tài khoản người dùng."
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -451,7 +1161,7 @@ msgstr "Đang thêm người dùng mới vào hệ thống"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "Đang viết thông tin gắn kết hệ thống tập tin vào /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "Đang gắn kết phân vùng %(partition)s đến %(mountpoint)s"
@@ -471,49 +1181,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Đang định dạng %(partition)s thành %(format)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "Đang thiết lập tên máy"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "Đang thiết lập locale ngôn ngữ"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Đang thiết lập tên máy"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "Đang thiếp lập tùy chọn bàn phím"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Đang gõ bỏ cấu hình live (các gói)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "Đang cài đặt trình nạp khởi động"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "Đang cấu hình trình nạp khởi động"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -521,640 +1231,16 @@ msgstr ""
 "CẢNH BÁO: Trình nạp khởi động Grub không được cấu hình đúng đắn. Bạn cần "
 "phải cấu hình thủ công."
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "Cài đặt hoàn tất"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "Đang kiểm tra trình nạp khởi động"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "Quốc gia"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "Ngôn ngữ"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "Bố trí"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "Biến thể"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "Đang tính toán chỉ mục tập tin..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "Bố trí bàn phím"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "Bạn có chắc chắn muốn thoát trình cài đặt không ?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "Đang phân vùng"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "Tóm tắt"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "Chỉnh sửa phân vùng"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "Thiết bị"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "Kiểu"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "Hệ điều hành"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "Điểm gắn kết"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "Định dạng như"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "Kích cỡ"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "Không gian trống"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "Mật khẩu không khớp."
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "Thoát ?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "Bạn có chắc chắn muốn thoát trình cài đặt không ?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "Vui lòng chọn ngôn ngữ"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "Vui lòng cung cấp mật khẩu cho tài khoản người dùng."
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "Vui lòng cung cấp họ tên đầy đủ."
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "Mật khẩu không khớp."
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "Phân vùng EFI không khởi động được. Vui lòng chỉnh sửa cờ phân vùng."
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "Vui lòng chọn phân vùng gốc (/)."
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "Phân vùng EFI không khởi động được. Vui lòng chỉnh sửa cờ phân vùng."
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "Phân vùng EFI phải được định dạng kiểu vfat."
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "Phân vùng EFI phải được định dạng kiểu vfat."
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "Vui lòng chọn phân vùng EFI."
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "Vui lòng cung cấp tên người dùng."
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "Bản địa hóa"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "Ngôn ngữ: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "Múi giờ: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "Bố trí bàn phím: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "Thiết lập người dùng"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "Tên thật: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "Tên người dùng: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "Tự động đăng nhập: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "bật"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "tắt"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "Thiết lập hệ thống"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "Thao tác hệ thống tập tin"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "Cài đặt trình nạp khởi động vào %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "Không cài đặt trình nạp khởi động"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "Dùng /target đã gắn kết."
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "Định dạng %(path)s thành %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "Gắn kết %(path)s vào %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-"Quá trình cài đặt giờ đã hoàn tất. Bạn có muốn khởi động lại máy để dùng hệ "
-"thống mới không ?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "Lỗi cài đặt"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "Bố trí bàn phím"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "Cài đặt tạm dừng"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "Múi giờ"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Tháo lắp được:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "Chỉnh sửa"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Gán vào /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "Phân vùng luận lý"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "Phân vùng mở rộng"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "Không rõ"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Sửa phân vùng"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "Sửa phân vùng"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "Thiết bị:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "Định dạng thành:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "Điểm gắn kết:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-vi.po
+++ b/po/live-installer-vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2015-02-25 07:57+0000\n"
 "Last-Translator: Saki <Unknown>\n"
 "Language-Team: Vietnamese <vi@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -189,9 +189,9 @@ msgid "Format"
 msgstr "Định dạng như"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -295,6 +295,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "Định dạng như"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -325,8 +331,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -415,23 +421,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "Quốc gia"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "Bố trí"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "Biến thể"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "Đang tính toán chỉ mục tập tin..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "Tháo lắp được:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "Chỉnh sửa"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "Gán vào /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -449,10 +526,104 @@ msgstr "Đang tính toán chỉ mục tập tin..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "Không gian trống"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "Phân vùng luận lý"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "Phân vùng mở rộng"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "Không rõ"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "Sửa phân vùng"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "Sửa phân vùng"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "Thiết bị:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "Định dạng thành:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "Điểm gắn kết:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "Quốc gia"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "Bố trí"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "Biến thể"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "Đang tính toán chỉ mục tập tin..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -567,18 +738,6 @@ msgstr "Định dạng như"
 msgid "Size"
 msgstr "Kích cỡ"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "Không gian trống"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -611,25 +770,6 @@ msgstr "Thoát ?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "Bạn có chắc chắn muốn thoát trình cài đặt không ?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -869,7 +1009,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "Cài đặt hoàn tất"
 
@@ -890,139 +1030,6 @@ msgstr "Lỗi cài đặt"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "Tháo lắp được:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "Chỉnh sửa"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "Gán vào /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "Phân vùng luận lý"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "Phân vùng mở rộng"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "Không rõ"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "Sửa phân vùng"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "Sửa phân vùng"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "Thiết bị:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "Định dạng thành:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "Điểm gắn kết:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1181,49 +1188,49 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "Đang định dạng %(partition)s thành %(format)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "Đang thiết lập tên máy"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "Đang thiết lập locale ngôn ngữ"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "Đang thiết lập tên máy"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "Đang thiếp lập tùy chọn bàn phím"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "Đang gõ bỏ cấu hình live (các gói)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "Đang cài đặt trình nạp khởi động"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "Đang cấu hình trình nạp khởi động"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
@@ -1231,15 +1238,15 @@ msgstr ""
 "CẢNH BÁO: Trình nạp khởi động Grub không được cấu hình đúng đắn. Bạn cần "
 "phải cấu hình thủ công."
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "Đang kiểm tra trình nạp khởi động"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-yi.po
+++ b/po/live-installer-yi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2012-02-25 23:52+0000\n"
 "Last-Translator: John smith <Unknown>\n"
 "Language-Team: Yiddish <yi@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr ""
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 msgid "Create swap partition"
 msgstr ""
 
@@ -86,42 +88,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr ""
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -138,7 +140,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 msgid "Expert Mode"
 msgstr ""
 
@@ -147,140 +149,146 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 msgid "Edit Partitions"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -308,6 +316,699 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+msgid "Select timezone"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+msgid "Keyboard Model"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:73
+msgid "Installation type?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Where do you want to install system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1199
+msgid "Please provide a kayboard layout for your computer."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Your passwords is not strong."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1285
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+msgid "Please provide a device to install grub."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -403,10 +1104,6 @@ msgstr ""
 msgid "Please provide a password for your user account."
 msgstr ""
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -433,7 +1130,7 @@ msgstr ""
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr ""
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr ""
@@ -453,672 +1150,61 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "רעמאָווינג לעבן קאַנפיגיעריישאַן (פּאַקאַדזשאַז)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr ""
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Where do you want to install system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1138
-msgid "Please provide a kayboard layout for your computer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Your passwords is not strong."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1210
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-msgid "Please provide a device to install grub."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-msgid "Keyboard Model"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:73
-msgid "Installation type?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-msgid "Select timezone"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""

--- a/po/live-installer-yi.po
+++ b/po/live-installer-yi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2012-02-25 23:52+0000\n"
 "Last-Translator: John smith <Unknown>\n"
 "Language-Team: Yiddish <yi@li.org>\n"
@@ -88,7 +88,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr ""
 
@@ -186,9 +186,9 @@ msgid "Format"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -291,6 +291,11 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+msgid "Format subvolume"
+msgstr ""
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -320,8 +325,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -407,23 +412,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
 msgstr ""
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, python-format
+msgid "Assign to %s"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -441,9 +517,102 @@ msgstr ""
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+msgid "EFI System Partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:480
@@ -558,18 +727,6 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -601,25 +758,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
@@ -854,7 +992,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr ""
 
@@ -873,138 +1011,6 @@ msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, python-format
-msgid "Assign to %s"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-msgid "EFI System Partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1150,61 +1156,61 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr ""
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr ""
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr ""
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 msgid "Setting timezone"
 msgstr ""
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr ""
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "רעמאָווינג לעבן קאַנפיגיעריישאַן (פּאַקאַדזשאַז)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr ""
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr ""
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr ""
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr ""
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""

--- a/po/live-installer-zh_CN.po
+++ b/po/live-installer-zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2018-08-10 04:22+0000\n"
 "Last-Translator: AlephAlpha <alephalpha911@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <zh_CN@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -189,9 +189,9 @@ msgid "Format"
 msgstr "格式化为"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -295,6 +295,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "格式化为"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -325,8 +331,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "确定"
 
@@ -415,23 +421,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "国家/地区"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "布局"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "kB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "多样"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "正在计算文件索引..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "可移动的:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "编辑"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "分配到 /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -449,10 +526,104 @@ msgstr "正在计算文件索引..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "剩余空间"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "逻辑分区"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "扩展分区"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "未知"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "编辑分区"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "编辑分区"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "设备："
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "格式化为："
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "挂载点："
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "取消"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "国家/地区"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "布局"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "多样"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "正在计算文件索引..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -567,18 +738,6 @@ msgstr "格式化为"
 msgid "Size"
 msgstr "大小"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "剩余空间"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -611,25 +770,6 @@ msgstr "是否退出？"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "您确定要退出安装程序吗？"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -869,7 +1009,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "安装完成"
 
@@ -888,139 +1028,6 @@ msgstr "安装错误"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "可移动的:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "编辑"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "分配到 /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "逻辑分区"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "扩展分区"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "未知"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "编辑分区"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "编辑分区"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "设备："
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "格式化为："
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "挂载点："
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "取消"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1179,63 +1186,63 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "正在将 %(partition)s 格式化为 %(format)s"
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "正在设置主机名"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "正在设置区域"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "正在设置主机名"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "正在设置键盘选项"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "正在移除 live 配置(包)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "正在安装启动引导程序"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "正在配置启动引导程序"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr "警告：grub 启动引导程序配置不正确！您需要手动配置它。"
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "正在检查启动引导程序"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-zh_CN.po
+++ b/po/live-installer-zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2018-08-10 04:22+0000\n"
 "Last-Translator: AlephAlpha <alephalpha911@gmail.com>\n"
 "Language-Team: Chinese (Simplified) <zh_CN@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "时区"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "编辑分区"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "专家模式"
@@ -149,142 +151,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "刷新"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "格式化为"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "编辑分区"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "自动登录"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -313,6 +321,710 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "确定"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "否"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "是"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "时区"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "语言"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "键盘布局"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "安装暂停"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "类型"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "国家/地区"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "布局"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "多样"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "正在计算文件索引..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "键盘布局"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "您确定要退出安装程序吗？"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "正在进行分区"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "摘要"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "后退"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "编辑分区"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "设备"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "操作系统"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "挂载点"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "格式化为"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "大小"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "剩余空间"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "安装"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "您的密码不匹配。"
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "是否退出？"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "您确定要退出安装程序吗？"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "请选择一种语言"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "请为您的帐号输入一个密码。"
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "请输入您的全名。"
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "您的密码不匹配。"
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "EFI 分区无法开机启动。请编辑分区表。"
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "请选择一个根(/)分区"
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "EFI 分区无法开机启动。请编辑分区表。"
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "EFI 分区必须被格式化成 vfat。"
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "EFI 分区必须被格式化成 vfat。"
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "请选择一个 EFI 分区。"
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "请输入一个用户名。"
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "本地化"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "语言： "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "时区： "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "键盘布局： "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "用户设置"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "真实姓名： "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "用户名： "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "自动登录： "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "启用"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "禁用"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "系统设置"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "文件系统操作"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "将启动引导程序安装至 %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "不安装启动引导程序"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "使用已经挂载的 /target"
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "将 %(path)s 格式化为 %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "将 %(path)s 挂载到 %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "将 %(path)s 挂载到 %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "安装完成"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr "安装完成。您要重启您的电脑以使用新系统吗？"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "安装错误"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "kB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "可移动的:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "编辑"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "分配到 /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "逻辑分区"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "扩展分区"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "未知"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "编辑分区"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "编辑分区"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "设备："
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "格式化为："
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "挂载点："
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "取消"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -421,10 +1133,6 @@ msgstr "您的密码不匹配。"
 msgid "Please provide a password for your user account."
 msgstr "请为您的帐号输入一个密码。"
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -451,7 +1159,7 @@ msgstr "正在将新用户添加到系统..."
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "正在将文件系统挂载信息写入 /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "正在将 %(partition)s 挂载到 %(mountpoint)s"
@@ -471,687 +1179,65 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "正在将 %(partition)s 格式化为 %(format)s"
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "正在设置主机名"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "正在设置区域"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "正在设置主机名"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "正在设置键盘选项"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "正在移除 live 配置(包)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "正在安装启动引导程序"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "正在配置启动引导程序"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr "警告：grub 启动引导程序配置不正确！您需要手动配置它。"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "安装完成"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "正在检查启动引导程序"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "国家/地区"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "语言"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "布局"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "多样"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "正在计算文件索引..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "键盘布局"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "您确定要退出安装程序吗？"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "正在进行分区"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "摘要"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "后退"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "编辑分区"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "设备"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "类型"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "操作系统"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "挂载点"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "格式化为"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "大小"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "剩余空间"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "安装"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "您的密码不匹配。"
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "是否退出？"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "您确定要退出安装程序吗？"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "请选择一种语言"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "请为您的帐号输入一个密码。"
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "请输入您的全名。"
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "您的密码不匹配。"
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "EFI 分区无法开机启动。请编辑分区表。"
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "请选择一个根(/)分区"
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "EFI 分区无法开机启动。请编辑分区表。"
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "EFI 分区必须被格式化成 vfat。"
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "EFI 分区必须被格式化成 vfat。"
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "请选择一个 EFI 分区。"
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "请输入一个用户名。"
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "本地化"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "语言： "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "时区： "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "键盘布局： "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "用户设置"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "真实姓名： "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "用户名： "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "自动登录： "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "启用"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "禁用"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "系统设置"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "文件系统操作"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "将启动引导程序安装至 %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "不安装启动引导程序"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "使用已经挂载的 /target"
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "将 %(path)s 格式化为 %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "将 %(path)s 挂载到 %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr "安装完成。您要重启您的电脑以使用新系统吗？"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "安装错误"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "键盘布局"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "安装暂停"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "时区"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "kB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "可移动的:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "编辑"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "分配到 /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "逻辑分区"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "扩展分区"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "未知"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "编辑分区"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "编辑分区"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "设备："
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "格式化为："
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "挂载点："
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "取消"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "确定"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "否"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "是"
 
 #~ msgid "Quit"
 #~ msgstr "退出"

--- a/po/live-installer-zh_HK.po
+++ b/po/live-installer-zh_HK.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2016-07-13 11:30+0000\n"
 "Last-Translator: tomoe_musashi <hkg.musashi@gmail.com>\n"
 "Language-Team: Chinese (Hong Kong) <zh_HK@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -189,9 +189,9 @@ msgid "Format"
 msgstr "格式化為"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -295,6 +295,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "格式化為"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -325,8 +331,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr ""
 
@@ -415,23 +421,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "國家"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "佈局"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "KB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "變體"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "正在計算檔案索引..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "可移除式："
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "編輯"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "指派至 /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -449,10 +526,104 @@ msgstr "正在計算檔案索引..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "可用空間"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "邏輯磁碟分割"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "延伸磁碟分割"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "未知"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "編輯磁碟分割"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "編輯磁碟分割"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "裝置："
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "格式化為："
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "掛載點："
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "國家"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "佈局"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "變體"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "正在計算檔案索引..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -567,18 +738,6 @@ msgstr "格式化為"
 msgid "Size"
 msgstr "大小"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "可用空間"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -611,25 +770,6 @@ msgstr "退出？"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "你是否確定要退出安裝程式？"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -869,7 +1009,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "安裝完成"
 
@@ -888,139 +1028,6 @@ msgstr "安裝發生錯誤"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "KB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "可移除式："
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "編輯"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "指派至 /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "邏輯磁碟分割"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "延伸磁碟分割"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "未知"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "編輯磁碟分割"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "編輯磁碟分割"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "裝置："
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "格式化為："
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "掛載點："
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1179,63 +1186,63 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "正在以 %(format)s 格式化 %(partition)s ..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "正在設定主機名稱"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "正在設定語系"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "正在設定主機名稱"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "正在設定鍵盤選項"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "正在移除 live 組態 (套件)"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "正在安裝 bootloader"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "正在配置 bootloader"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr "警告：grub 啟動程式組態不正確！你需要進行手動配置。"
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "正在檢查 bootloader"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 

--- a/po/live-installer-zh_HK.po
+++ b/po/live-installer-zh_HK.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2016-07-13 11:30+0000\n"
 "Last-Translator: tomoe_musashi <hkg.musashi@gmail.com>\n"
 "Language-Team: Chinese (Hong Kong) <zh_HK@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "時區"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "編輯磁碟分割"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "專家模式"
@@ -149,142 +151,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "重新整理"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "格式化為"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "編輯磁碟分割"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "自動登入"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -313,6 +321,710 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr ""
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "時區"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "語言"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "鍵盤佈局"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "安裝已暫停"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "類型"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "國家"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "佈局"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "變體"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "正在計算檔案索引..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "鍵盤佈局"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "你是否確定要退出安裝程式？"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "分割中"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "總覽"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "編輯磁碟分割"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "裝置"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "操作系统"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "掛載點"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "格式化為"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "大小"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "可用空間"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "你的密碼不相符。"
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "退出？"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "你是否確定要退出安裝程式？"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "請選擇語言"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "請提供密碼給你的使用者帳號。"
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "請提供你的全名。"
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "你的密碼不相符。"
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "EFI 磁碟分割無法用於開機。請編輯磁碟分割旗標。"
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "請選擇 root (/) 磁碟分割。"
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "EFI 磁碟分割無法用於開機。請編輯磁碟分割旗標。"
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "EFI 磁碟分割必須被格式化為 vfat。"
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "EFI 磁碟分割必須被格式化為 vfat。"
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "請選擇 EFI 磁碟分割。"
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "請提供使用者名稱。"
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "本地化"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "語言： "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "時區： "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "鍵盤佈局： "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "使用者設定"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "真實姓名： "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "使用者名稱： "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "自動登入： "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "啟用"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "停用"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "系統設定"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "檔案系統操作"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "安裝 bootloader 於 %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "不要安裝 bootloader"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "使用已掛載 /target。"
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "格式化 %(path)s 為 %(filesystem)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "掛載 %(path)s 為 %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "掛載 %(path)s 為 %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "安裝完成"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr "安裝現已完成。你想要重新啟動你的電腦以使用新系統嗎？"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "安裝發生錯誤"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "KB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "可移除式："
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "編輯"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "指派至 /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "邏輯磁碟分割"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "延伸磁碟分割"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "未知"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "編輯磁碟分割"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "編輯磁碟分割"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "裝置："
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "格式化為："
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "掛載點："
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -421,10 +1133,6 @@ msgstr "你的密碼不相符。"
 msgid "Please provide a password for your user account."
 msgstr "請提供密碼給你的使用者帳號。"
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -451,7 +1159,7 @@ msgstr "新增新使用者至系統"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "正在寫入檔案系統掛載資訊至 /etc/fstab"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "正在將 %(partition)s 掛載於 %(mountpoint)s"
@@ -471,686 +1179,64 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "正在以 %(format)s 格式化 %(partition)s ..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "正在設定主機名稱"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "正在設定語系"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "正在設定主機名稱"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "正在設定鍵盤選項"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "正在移除 live 組態 (套件)"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "正在安裝 bootloader"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "正在配置 bootloader"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr "警告：grub 啟動程式組態不正確！你需要進行手動配置。"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "安裝完成"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "正在檢查 bootloader"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "國家"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "語言"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "佈局"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "變體"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "正在計算檔案索引..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "鍵盤佈局"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "你是否確定要退出安裝程式？"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "分割中"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "總覽"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "編輯磁碟分割"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "裝置"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "類型"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "操作系统"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "掛載點"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "格式化為"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "大小"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "可用空間"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "你的密碼不相符。"
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "退出？"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "你是否確定要退出安裝程式？"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "請選擇語言"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "請提供密碼給你的使用者帳號。"
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "請提供你的全名。"
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "你的密碼不相符。"
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "EFI 磁碟分割無法用於開機。請編輯磁碟分割旗標。"
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "請選擇 root (/) 磁碟分割。"
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "EFI 磁碟分割無法用於開機。請編輯磁碟分割旗標。"
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "EFI 磁碟分割必須被格式化為 vfat。"
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "EFI 磁碟分割必須被格式化為 vfat。"
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "請選擇 EFI 磁碟分割。"
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "請提供使用者名稱。"
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "本地化"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "語言： "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "時區： "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "鍵盤佈局： "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "使用者設定"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "真實姓名： "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "使用者名稱： "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "自動登入： "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "啟用"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "停用"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "系統設定"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "檔案系統操作"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "安裝 bootloader 於 %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "不要安裝 bootloader"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "使用已掛載 /target。"
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "格式化 %(path)s 為 %(filesystem)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "掛載 %(path)s 為 %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr "安裝現已完成。你想要重新啟動你的電腦以使用新系統嗎？"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "安裝發生錯誤"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "鍵盤佈局"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "安裝已暫停"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "時區"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "KB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "可移除式："
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "編輯"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "指派至 /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "邏輯磁碟分割"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "延伸磁碟分割"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "未知"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "編輯磁碟分割"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "編輯磁碟分割"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "裝置："
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "格式化為："
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "掛載點："
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr ""
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
 msgstr ""
 
 #~ msgid "Installation Tool"

--- a/po/live-installer-zh_TW.po
+++ b/po/live-installer-zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-31 16:00+0300\n"
+"POT-Creation-Date: 2024-04-28 17:00+0300\n"
 "PO-Revision-Date: 2019-07-15 01:03+0000\n"
 "Last-Translator: Li,ChengYang <Unknown>\n"
 "Language-Team: Chinese (Traditional) <zh_TW@li.org>\n"
@@ -23,19 +23,19 @@ msgid "Welcome to the 17g Installer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:88
-#: live-installer/frontend/gtk_interface.py:503
 #: live-installer/frontend/tui_interface.py:36
+#: live-installer/frontend/gtk_interface.py:507
 msgid ""
 "This program will ask you some questions and set up system on your computer."
 msgstr ""
 
 #: live-installer/resources/interface.ui:143
-#: live-installer/frontend/gtk_interface.py:505
+#: live-installer/frontend/gtk_interface.py:509
 msgid "I accept the terms of the License Agreement"
 msgstr ""
 
 #: live-installer/resources/interface.ui:214
-#: live-installer/frontend/gtk_interface.py:514
+#: live-installer/frontend/gtk_interface.py:518
 msgid "Keyboard Model:"
 msgstr ""
 
@@ -44,10 +44,12 @@ msgid "Type here to test your keyboard"
 msgstr ""
 
 #: live-installer/resources/interface.ui:377
-#: live-installer/resources/interface.ui:1964
-#: live-installer/resources/interface.ui:2416
-#: live-installer/resources/interface.ui:2428
-#: live-installer/resources/interface.ui:2440
+#: live-installer/resources/interface.ui:1965
+#: live-installer/resources/interface.ui:2417
+#: live-installer/resources/interface.ui:2429
+#: live-installer/resources/interface.ui:2441
+#: live-installer/resources/interface.ui:2622
+#: live-installer/resources/interface.ui:2634
 msgid "label"
 msgstr ""
 
@@ -56,13 +58,13 @@ msgid "Continent"
 msgstr ""
 
 #: live-installer/resources/interface.ui:426
-#: live-installer/frontend/gtk_interface.py:480
 #: live-installer/frontend/tui_interface.py:53
+#: live-installer/frontend/gtk_interface.py:484
 msgid "Timezone"
 msgstr "時區"
 
 #: live-installer/resources/interface.ui:484
-#: live-installer/frontend/gtk_interface.py:540
+#: live-installer/frontend/gtk_interface.py:544
 msgid "Automated Installation"
 msgstr ""
 
@@ -71,12 +73,12 @@ msgid "Erase a disk and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:528
-#: live-installer/frontend/gtk_interface.py:543
+#: live-installer/frontend/gtk_interface.py:547
 msgid "Disk:"
 msgstr ""
 
 #: live-installer/resources/interface.ui:573
-#: live-installer/frontend/gtk_interface.py:570
+#: live-installer/frontend/gtk_interface.py:574
 #, fuzzy
 msgid "Create swap partition"
 msgstr "編輯磁碟分割"
@@ -87,42 +89,42 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:443
+#: live-installer/frontend/partitioning.py:592
 msgid "GB"
 msgstr "GB"
 
 #: live-installer/resources/interface.ui:658
-#: live-installer/frontend/gtk_interface.py:551
+#: live-installer/frontend/gtk_interface.py:555
 msgid "Use LVM (Logical Volume Management)"
 msgstr ""
 
 #: live-installer/resources/interface.ui:705
-#: live-installer/frontend/gtk_interface.py:545
+#: live-installer/frontend/gtk_interface.py:549
 msgid "Encrypt the operating system"
 msgstr ""
 
 #: live-installer/resources/interface.ui:735
-#: live-installer/frontend/gtk_interface.py:547
+#: live-installer/frontend/gtk_interface.py:551
 msgid "Passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:751
-#: live-installer/frontend/gtk_interface.py:549
+#: live-installer/frontend/gtk_interface.py:553
 msgid "Confirm passphrase"
 msgstr ""
 
 #: live-installer/resources/interface.ui:785
-#: live-installer/frontend/gtk_interface.py:568
+#: live-installer/frontend/gtk_interface.py:572
 msgid "This provides extra security but it can take hours."
 msgstr ""
 
 #: live-installer/resources/interface.ui:799
-#: live-installer/frontend/gtk_interface.py:566
+#: live-installer/frontend/gtk_interface.py:570
 msgid "Fill the disk with random data"
 msgstr ""
 
 #: live-installer/resources/interface.ui:884
-#: live-installer/frontend/gtk_interface.py:553
+#: live-installer/frontend/gtk_interface.py:557
 msgid "Manual Partitioning"
 msgstr ""
 
@@ -139,7 +141,7 @@ msgid "Remove existsing windows and install LMDE on it."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1033
-#: live-installer/frontend/gtk_interface.py:557
+#: live-installer/frontend/gtk_interface.py:561
 #, fuzzy
 msgid "Expert Mode"
 msgstr "專家模式"
@@ -149,142 +151,148 @@ msgid "The setup tool will not do partitioning."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1111
-#: live-installer/frontend/gtk_interface.py:602
+#: live-installer/frontend/gtk_interface.py:606
 msgid "Minimal installation"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1127
-#: live-installer/frontend/gtk_interface.py:603
+#: live-installer/frontend/gtk_interface.py:607
 msgid ""
 "This will only install a minimal desktop environment with a browser and "
 "utilities."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1160
-#: live-installer/frontend/gtk_interface.py:600
+#: live-installer/frontend/gtk_interface.py:604
 msgid "Install system with updates"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1176
-#: live-installer/frontend/gtk_interface.py:601
+#: live-installer/frontend/gtk_interface.py:605
 msgid "If you connect internet, updates will install."
 msgstr ""
 
 #: live-installer/resources/interface.ui:1278
-#: live-installer/frontend/gtk_interface.py:574
+#: live-installer/frontend/gtk_interface.py:578
 msgid "Refresh"
 msgstr "重新整理"
 
 #: live-installer/resources/interface.ui:1325
-#: live-installer/frontend/gtk_interface.py:576
+#: live-installer/frontend/gtk_interface.py:580
 msgid "Delete"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1372
-#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:581
 #, fuzzy
 msgid "Format"
 msgstr "格式化為"
 
 #: live-installer/resources/interface.ui:1419
-#: live-installer/frontend/gtk_interface.py:578
+#: live-installer/frontend/gtk_interface.py:582
+#: live-installer/frontend/gtk_interface.py:966
+#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
 #: live-installer/resources/interface.ui:1455
-#: live-installer/frontend/gtk_interface.py:591
+#: live-installer/frontend/gtk_interface.py:595
 msgid "Install the GRUB boot menu on:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1528
+#: live-installer/resources/interface.ui:1529
 #, fuzzy
 msgid "Edit Partitions"
 msgstr "編輯磁碟分割"
 
-#: live-installer/resources/interface.ui:1552
+#: live-installer/resources/interface.ui:1553
 msgid "Legacy"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1610
-#: live-installer/frontend/gtk_interface.py:519
+#: live-installer/resources/interface.ui:1611
+#: live-installer/frontend/gtk_interface.py:523
 msgid "Your name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1653
-#: live-installer/frontend/gtk_interface.py:521
+#: live-installer/resources/interface.ui:1654
+#: live-installer/frontend/gtk_interface.py:525
 msgid "Your computer's name:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1668
-#: live-installer/frontend/gtk_interface.py:525
+#: live-installer/resources/interface.ui:1669
+#: live-installer/frontend/gtk_interface.py:529
 msgid "Pick a username:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1681
-#: live-installer/frontend/gtk_interface.py:523
+#: live-installer/resources/interface.ui:1682
+#: live-installer/frontend/gtk_interface.py:527
 msgid "The name it uses when it talks to other computers."
 msgstr ""
 
-#: live-installer/resources/interface.ui:1714
-#: live-installer/frontend/gtk_interface.py:527
+#: live-installer/resources/interface.ui:1715
+#: live-installer/frontend/gtk_interface.py:531
 msgid "Choose a password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1758
-#: live-installer/frontend/gtk_interface.py:532
+#: live-installer/resources/interface.ui:1759
+#: live-installer/frontend/gtk_interface.py:536
 msgid "Log in automatically"
 msgstr "自動登入"
 
-#: live-installer/resources/interface.ui:1773
-#: live-installer/frontend/gtk_interface.py:534
+#: live-installer/resources/interface.ui:1774
+#: live-installer/frontend/gtk_interface.py:538
 msgid "Require my password to log in"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1788
-#: live-installer/frontend/gtk_interface.py:536
+#: live-installer/resources/interface.ui:1789
+#: live-installer/frontend/gtk_interface.py:540
 msgid "Encrypt my home folder"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1812
-#: live-installer/frontend/gtk_interface.py:529
+#: live-installer/resources/interface.ui:1813
+#: live-installer/frontend/gtk_interface.py:533
 msgid "Confirm your password:"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1841
+#: live-installer/resources/interface.ui:1842
 msgid "Length must be minimum 8 characters"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1914
-#: live-installer/frontend/gtk_interface.py:608
+#: live-installer/resources/interface.ui:1915
+#: live-installer/frontend/gtk_interface.py:612
 msgid "Automated installation enabled!"
 msgstr ""
 
-#: live-installer/resources/interface.ui:1983
+#: live-installer/resources/interface.ui:1984
 msgid "0.0"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2015
-#: live-installer/frontend/gtk_interface.py:604
+#: live-installer/resources/interface.ui:2016
+#: live-installer/frontend/gtk_interface.py:608
 msgid "Please do not turn off your computer during the installation process."
 msgstr ""
 
-#: live-installer/resources/interface.ui:2084
+#: live-installer/resources/interface.ui:2085
 #: live-installer/resources/welcome.ui:206
 msgid "17g team"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2288
-#: live-installer/resources/interface.ui:2328
-#: live-installer/frontend/gtk_interface.py:474
+#: live-installer/resources/interface.ui:2289
+#: live-installer/resources/interface.ui:2329
+#: live-installer/frontend/gtk_interface.py:478
 msgid "Welcome"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2452
+#: live-installer/resources/interface.ui:2453
 msgid "/dev/sda1"
 msgstr ""
 
-#: live-installer/resources/interface.ui:2504
+#: live-installer/resources/interface.ui:2505
 msgid "read only"
+msgstr ""
+
+#: live-installer/resources/interface.ui:2518
+msgid "Use default Btrfs subvolumes"
 msgstr ""
 
 #: live-installer/resources/welcome.ui:61
@@ -313,6 +321,710 @@ msgstr ""
 
 #: live-installer/resources/welcome.ui:228
 msgid "Welcome to 17g"
+msgstr ""
+
+#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
+#: live-installer/frontend/dialogs.py:54
+#: live-installer/frontend/partitioning.py:785
+#: live-installer/frontend/partitioning.py:872
+msgid "OK"
+msgstr "確定"
+
+#: live-installer/frontend/dialogs.py:41
+msgid "No"
+msgstr "否"
+
+#: live-installer/frontend/dialogs.py:42
+msgid "Yes"
+msgstr "是"
+
+#: live-installer/frontend/timezones.py:140
+#, fuzzy
+msgid "Select timezone"
+msgstr "時區"
+
+#: live-installer/frontend/tui_interface.py:34
+#: live-installer/frontend/gtk_interface.py:505
+#, python-format
+msgid "Welcome to the %s Installer."
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:40
+#: live-installer/frontend/gtk_interface.py:482
+msgid "What language would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:45
+#: live-installer/frontend/gtk_interface.py:118
+#: live-installer/frontend/gtk_interface.py:482
+#: live-installer/frontend/gtk_interface.py:513
+msgid "Language"
+msgstr "語言"
+
+#: live-installer/frontend/tui_interface.py:49
+#: live-installer/frontend/gtk_interface.py:484
+msgid "Where are you?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:57
+msgid "What keyboard would you like to use?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:64
+#, fuzzy
+msgid "Keyboard Model"
+msgstr "鍵盤配置"
+
+#: live-installer/frontend/tui_interface.py:73
+#, fuzzy
+msgid "Installation type?"
+msgstr "安裝已暫停"
+
+#: live-installer/frontend/tui_interface.py:77
+#: live-installer/frontend/gtk_interface.py:585
+msgid "Type"
+msgstr "類型"
+
+#: live-installer/frontend/tui_interface.py:80
+msgid "Select a disk?"
+msgstr ""
+
+#: live-installer/frontend/tui_interface.py:84
+msgid "Disk"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:32
+#, python-format
+msgid "Try %s"
+msgstr ""
+
+#: live-installer/frontend/welcome.py:36
+#, python-format
+msgid "You are currently running %s from live media."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:38
+#, python-format
+msgid ""
+"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
+"Menu later."
+msgstr ""
+
+#: live-installer/frontend/welcome.py:39
+#, python-format
+msgid "Welcome to %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "國家"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "配置"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "變體"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "計算檔案索引中..."
+
+#: live-installer/frontend/gtk_interface.py:467
+#: live-installer/frontend/gtk_interface.py:470
+#: live-installer/frontend/gtk_interface.py:1173
+#: live-installer/frontend/gtk_interface.py:1198
+#: live-installer/frontend/gtk_interface.py:1221
+#: live-installer/frontend/gtk_interface.py:1241
+#: live-installer/frontend/gtk_interface.py:1245
+#: live-installer/frontend/gtk_interface.py:1255
+#: live-installer/frontend/gtk_interface.py:1259
+#: live-installer/frontend/gtk_interface.py:1264
+#: live-installer/frontend/gtk_interface.py:1278
+#: live-installer/frontend/gtk_interface.py:1284
+#: live-installer/frontend/gtk_interface.py:1290
+#: live-installer/frontend/gtk_interface.py:1295
+#: live-installer/frontend/gtk_interface.py:1300
+#: live-installer/frontend/gtk_interface.py:1365
+#: live-installer/frontend/gtk_interface.py:1444
+#: live-installer/frontend/partitioning.py:434
+#: live-installer/frontend/partitioning.py:517
+msgid "Installer"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:480
+msgid "License Agreement"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "Keyboard layout"
+msgstr "鍵盤配置"
+
+#: live-installer/frontend/gtk_interface.py:486
+msgid "What is your keyboard layout?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "User account"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:488
+msgid "Who are you?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+msgid "Installation Type"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:490
+#: live-installer/frontend/gtk_interface.py:492
+#, fuzzy
+msgid "Where do you want to install system?"
+msgstr "您是否確定要退出安裝程式?"
+
+#: live-installer/frontend/gtk_interface.py:492
+msgid "Partitioning"
+msgstr "磁碟分割中"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Summary"
+msgstr "總覽"
+
+#: live-installer/frontend/gtk_interface.py:494
+msgid "Check that everything is correct"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Installing"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:496
+msgid "Please wait..."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:499
+#: live-installer/frontend/gtk_interface.py:613
+msgid "Automated Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:500
+msgid "Back"
+msgstr "向後"
+
+#: live-installer/frontend/gtk_interface.py:501
+#: live-installer/frontend/gtk_interface.py:1306
+msgid "Next"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:520
+msgid "Type here to test your keyboard layout"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:546
+msgid "Erase a disk and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:559
+msgid "Manually create, resize or choose partitions for system."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:563
+msgid "The setup tool will not do partitioning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:565
+msgid "Remove Windows & Install"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:567
+msgid "Remove existsing windows and install system on it."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:577
+#: live-installer/frontend/gtk_interface.py:579
+msgid "Edit partitions"
+msgstr "編輯磁碟分割"
+
+#: live-installer/frontend/gtk_interface.py:584
+msgid "Device"
+msgstr "裝置"
+
+#: live-installer/frontend/gtk_interface.py:586
+msgid "Operating system"
+msgstr "作業系統"
+
+#: live-installer/frontend/gtk_interface.py:587
+msgid "Mount point"
+msgstr "掛載點"
+
+#: live-installer/frontend/gtk_interface.py:588
+msgid "Format as"
+msgstr "格式化為"
+
+#: live-installer/frontend/gtk_interface.py:589
+msgid "Size"
+msgstr "尺寸"
+
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+#: live-installer/frontend/partitioning.py:457
+#: live-installer/frontend/partitioning.py:675
+msgid "Free space"
+msgstr "可用空間"
+
+#: live-installer/frontend/gtk_interface.py:598
+#: live-installer/frontend/partitioning.py:209
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:626
+#: live-installer/frontend/gtk_interface.py:1367
+msgid "Warning"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:627
+#: live-installer/frontend/gtk_interface.py:1368
+#, python-format
+msgid "This will delete all the data on %s. Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:652
+#: live-installer/frontend/gtk_interface.py:1228
+msgid "Install"
+msgstr "安裝"
+
+#: live-installer/frontend/gtk_interface.py:785
+msgid "Please provide a passphrase for the encryption."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:787
+#: live-installer/frontend/gtk_interface.py:1214
+msgid "Your passwords do not match."
+msgstr "您的密碼不符。"
+
+#: live-installer/frontend/gtk_interface.py:792
+msgid "Quit?"
+msgstr "退出?"
+
+#: live-installer/frontend/gtk_interface.py:793
+msgid "Are you sure you want to quit the installer?"
+msgstr "您是否確定要退出安裝程式?"
+
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:197
+#: live-installer/frontend/partitioning.py:248
+#: live-installer/frontend/partitioning.py:268
+#: live-installer/frontend/partitioning.py:328
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:344
+#: live-installer/frontend/partitioning.py:764
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+#: live-installer/frontend/partitioning.py:281
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:994
+#: live-installer/frontend/gtk_interface.py:1008
+#: live-installer/frontend/gtk_interface.py:1025
+#: live-installer/frontend/gtk_interface.py:1040
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+msgid "Are you sure?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:995
+msgid "New partition will created at {}"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1009
+msgid "subvolume {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1026
+msgid "Partition {} will removed from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1041
+msgid "Partition {} will formated from {}."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1174
+msgid "Please choose a language"
+msgstr "請選擇語言"
+
+#: live-installer/frontend/gtk_interface.py:1199
+#, fuzzy
+msgid "Please provide a kayboard layout for your computer."
+msgstr "請提供密碼給您的使用者帳號。"
+
+#: live-installer/frontend/gtk_interface.py:1219
+msgid "Please provide your full name."
+msgstr "請提供您的全名。"
+
+#: live-installer/frontend/gtk_interface.py:1224
+#: live-installer/frontend/gtk_interface.py:1362
+#, fuzzy
+msgid "Your passwords is not strong."
+msgstr "您的密碼不符。"
+
+#: live-installer/frontend/gtk_interface.py:1242
+#: live-installer/frontend/gtk_interface.py:1256
+msgid ""
+"Root filesystem type not specified. Installation will continue without disk "
+"formatting. Do you want to continue?"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1246
+#: live-installer/frontend/gtk_interface.py:1260
+#, fuzzy
+msgid ""
+"The root partition is too small. It should be at least 16GB. Do you want to "
+"continue?"
+msgstr "EFI 磁碟分割無法用於開機。請編輯磁碟分割旗標。"
+
+#: live-installer/frontend/gtk_interface.py:1264
+msgid "Please select a root (/) partition."
+msgstr "請選擇根 (/) 磁碟分割。"
+
+#: live-installer/frontend/gtk_interface.py:1265
+#, python-format
+msgid ""
+"A root partition is needed to install %s on.\n"
+"\n"
+" - Mount point: /\n"
+" - Recommended size: 30GB\n"
+" - Recommended filesystem format: ext4\n"
+"\n"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1279
+#, fuzzy
+msgid "The EFI partition is not bootable. Do you want to set boot flag?"
+msgstr "EFI 磁碟分割無法用於開機。請編輯磁碟分割旗標。"
+
+#: live-installer/frontend/gtk_interface.py:1285
+#, fuzzy
+msgid "The EFI partition is too small. It must be at least 100MB."
+msgstr "EFI 磁碟分割必須被格式化為 vfat。"
+
+#: live-installer/frontend/gtk_interface.py:1291
+#: live-installer/frontend/gtk_interface.py:1296
+msgid "The EFI partition must be formatted as vfat."
+msgstr "EFI 磁碟分割必須被格式化為 vfat。"
+
+#: live-installer/frontend/gtk_interface.py:1300
+msgid "Please select an EFI partition."
+msgstr "請選擇 EFI 磁碟分割。"
+
+#: live-installer/frontend/gtk_interface.py:1301
+msgid ""
+"An EFI system partition is needed with the following requirements:\n"
+"\n"
+" - Mount point: /boot/efi\n"
+" - Partition flags: Bootable\n"
+" - Size: at least 100MB \n"
+" - Format: vfat or fat32\n"
+"\n"
+"To ensure compatibility with Windows we recommend you use the first "
+"partition of the disk as the EFI system partition.\n"
+" "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1356
+msgid "Please select a disk."
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1445
+#, fuzzy
+msgid "Please provide a device to install grub."
+msgstr "請提供使用者名稱。"
+
+#: live-installer/frontend/gtk_interface.py:1493
+msgid "Localization"
+msgstr "在地化"
+
+#: live-installer/frontend/gtk_interface.py:1494
+msgid "Language: "
+msgstr "語言: "
+
+#: live-installer/frontend/gtk_interface.py:1495
+msgid "Timezone: "
+msgstr "時區: "
+
+#: live-installer/frontend/gtk_interface.py:1496
+msgid "Keyboard layout: "
+msgstr "鍵盤配置: "
+
+#: live-installer/frontend/gtk_interface.py:1500
+msgid "User settings"
+msgstr "使用者設定"
+
+#: live-installer/frontend/gtk_interface.py:1504
+msgid "Real name: "
+msgstr "真實名稱: "
+
+#: live-installer/frontend/gtk_interface.py:1505
+msgid "Username: "
+msgstr "使用者名稱: "
+
+#: live-installer/frontend/gtk_interface.py:1508
+#: live-installer/frontend/gtk_interface.py:1511
+msgid "Password: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1513
+msgid "Automatic login: "
+msgstr "自動登入: "
+
+#: live-installer/frontend/gtk_interface.py:1513
+#: live-installer/frontend/gtk_interface.py:1563
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "enabled"
+msgstr "啟用"
+
+#: live-installer/frontend/gtk_interface.py:1514
+#: live-installer/frontend/gtk_interface.py:1564
+#: live-installer/frontend/gtk_interface.py:1567
+msgid "disabled"
+msgstr "停用"
+
+#: live-installer/frontend/gtk_interface.py:1515
+msgid "System settings"
+msgstr "系統設定"
+
+#: live-installer/frontend/gtk_interface.py:1517
+msgid "Computer's name: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1520
+#: live-installer/frontend/gtk_interface.py:1522
+msgid "Bios type: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1524
+msgid "Install updates after installation"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1525
+msgid "Filesystem operations"
+msgstr "檔案系統操作"
+
+#: live-installer/frontend/gtk_interface.py:1526
+#, python-format
+msgid "Install bootloader on %s"
+msgstr "安裝開機載入器於 %s"
+
+#: live-installer/frontend/gtk_interface.py:1527
+msgid "Do not install bootloader"
+msgstr "不安裝開機載入器"
+
+#: live-installer/frontend/gtk_interface.py:1529
+msgid "Use already-mounted /target."
+msgstr "使用已掛載 /target。"
+
+#: live-installer/frontend/gtk_interface.py:1537
+#, python-format
+msgid " (with %s GB swap)"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1541
+#, python-format
+msgid "Automated installation on %s"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1545
+#, python-format
+msgid "Format %(path)s as %(filesystem)s"
+msgstr "以 %(filesystem)s 格式化 %(path)s"
+
+#: live-installer/frontend/gtk_interface.py:1549
+#, python-format
+msgid "Mount %(path)s as %(mount)s"
+msgstr "將 %(path)s 掛載為 %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1554
+#, python-format
+msgid "Create btrfs subvolume %(path)s under %(parentPath)s "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1558
+#, fuzzy, python-format
+msgid "Mount %(path)s subvolume as %(mount)s"
+msgstr "將 %(path)s 掛載為 %(mount)s"
+
+#: live-installer/frontend/gtk_interface.py:1563
+msgid "LVM: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1566
+msgid "Disk Encryption: "
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:1578
+#: live-installer/installer.py:878
+msgid "Installation finished"
+msgstr "完成安裝"
+
+#: live-installer/frontend/gtk_interface.py:1579
+msgid ""
+"The installation is now complete. Do you want to restart your computer to "
+"use the new system?"
+msgstr "安裝完成。您是否要重新啟動您的電腦以使用新系統?"
+
+#: live-installer/frontend/gtk_interface.py:1611
+#: live-installer/frontend/gtk_interface.py:1615
+#: live-installer/frontend/gtk_interface.py:1624
+#: live-installer/frontend/gtk_interface.py:1633
+msgid "Installation error"
+msgstr "安裝發生錯誤"
+
+#: live-installer/frontend/gtk_interface.py:1647
+msgid "Error"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "kB"
+msgstr "KB"
+
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:591
+msgid "MB"
+msgstr "MB"
+
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:592
+msgid "TB"
+msgstr "TB"
+
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "可移除:"
+
+#: live-installer/frontend/partitioning.py:194
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:226
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:230
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:234
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:239
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:333
+msgid "Edit"
+msgstr "編輯"
+
+#: live-installer/frontend/partitioning.py:345
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:363
+#: live-installer/frontend/partitioning.py:372
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "指定至 /"
+
+#: live-installer/frontend/partitioning.py:379
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:435
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:533
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:578
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:673
+msgid "Logical partition"
+msgstr "邏輯磁碟分割"
+
+#: live-installer/frontend/partitioning.py:674
+msgid "Extended partition"
+msgstr "延伸磁碟分割"
+
+#: live-installer/frontend/partitioning.py:678
+#: live-installer/frontend/partitioning.py:811
+msgid "Unknown"
+msgstr "未知"
+
+#: live-installer/frontend/partitioning.py:729
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:742
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "編輯磁碟分割"
+
+#: live-installer/frontend/partitioning.py:777
+msgid "Edit partition"
+msgstr "編輯磁碟分割"
+
+#: live-installer/frontend/partitioning.py:779
+msgid "Device:"
+msgstr "裝置:"
+
+#: live-installer/frontend/partitioning.py:781
+msgid "Format as:"
+msgstr "格式化為:"
+
+#: live-installer/frontend/partitioning.py:783
+#: live-installer/frontend/partitioning.py:870
+msgid "Mount point:"
+msgstr "掛載點:"
+
+#: live-installer/frontend/partitioning.py:784
+#: live-installer/frontend/partitioning.py:871
+msgid "Cancel"
+msgstr "取消"
+
+#: live-installer/frontend/partitioning.py:861
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:868
+msgid "Name:"
+msgstr ""
+
+#: live-installer/main.py:38
+msgid "You must be root!"
 msgstr ""
 
 #: live-installer/validate.py:12
@@ -421,10 +1133,6 @@ msgstr "您的密碼不符。"
 msgid "Please provide a password for your user account."
 msgstr "請提供密碼給您的使用者帳號。"
 
-#: live-installer/main.py:38
-msgid "You must be root!"
-msgstr ""
-
 #: live-installer/installer.py:139 live-installer/installer.py:160
 #, python-format
 msgid "Copying /%s"
@@ -451,7 +1159,7 @@ msgstr "加入新使用者至系統"
 msgid "Writing filesystem mount information to /etc/fstab"
 msgstr "寫入檔案系統掛載資訊至 /etc/fstab 中"
 
-#: live-installer/installer.py:257 live-installer/installer.py:413
+#: live-installer/installer.py:257 live-installer/installer.py:404
 #, python-format
 msgid "Mounting %(partition)s on %(mountpoint)s"
 msgstr "將 %(partition)s 掛載於 %(mountpoint)s 中"
@@ -471,687 +1179,65 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "以 %(format)s 格式化 %(partition)s 中..."
 
-#: live-installer/installer.py:577
+#: live-installer/installer.py:591
 msgid "Setting hostname"
 msgstr "設定主機名稱中"
 
-#: live-installer/installer.py:602
+#: live-installer/installer.py:616
 msgid "Setting locale"
 msgstr "設定語系中"
 
-#: live-installer/installer.py:642
+#: live-installer/installer.py:656
 #, fuzzy
 msgid "Setting timezone"
 msgstr "設定主機名稱中"
 
-#: live-installer/installer.py:677
+#: live-installer/installer.py:691
 msgid "Setting keyboard options"
 msgstr "設定鍵盤選項中"
 
-#: live-installer/installer.py:754
+#: live-installer/installer.py:768
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "移除 live 組態中（軟體包）"
 
-#: live-installer/installer.py:760
+#: live-installer/installer.py:774
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:779
+#: live-installer/installer.py:793
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:784
+#: live-installer/installer.py:798
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:804
+#: live-installer/installer.py:818
 msgid "Installing bootloader"
 msgstr "安裝開機載入器中"
 
-#: live-installer/installer.py:816
+#: live-installer/installer.py:830
 msgid "Configuring bootloader"
 msgstr "設定開機載入器組態中"
 
-#: live-installer/installer.py:824
+#: live-installer/installer.py:838
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr "警示: grub 開機載入器組態未正常設定! 您需要為其手動設定組態。"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:851
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:863
-#: live-installer/frontend/gtk_interface.py:1496
-msgid "Installation finished"
-msgstr "完成安裝"
-
-#: live-installer/installer.py:889
+#: live-installer/installer.py:904
 msgid "Checking bootloader"
 msgstr "檢查開機載入器中"
 
-#: live-installer/installer.py:926
+#: live-installer/installer.py:941
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:510
-msgid "Country"
-msgstr "國家"
-
-#: live-installer/frontend/gtk_interface.py:118
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/gtk_interface.py:509
-#: live-installer/frontend/tui_interface.py:45
-msgid "Language"
-msgstr "語言"
-
-#: live-installer/frontend/gtk_interface.py:289
-msgid "Layout"
-msgstr "配置"
-
-#: live-installer/frontend/gtk_interface.py:297
-msgid "Variant"
-msgstr "變體"
-
-#: live-installer/frontend/gtk_interface.py:315
-msgid "Calculating file indexes ..."
-msgstr "計算檔案索引中..."
-
-#: live-installer/frontend/gtk_interface.py:463
-#: live-installer/frontend/gtk_interface.py:466
-#: live-installer/frontend/gtk_interface.py:1112
-#: live-installer/frontend/gtk_interface.py:1137
-#: live-installer/frontend/gtk_interface.py:1160
-#: live-installer/frontend/gtk_interface.py:1180
-#: live-installer/frontend/gtk_interface.py:1184
-#: live-installer/frontend/gtk_interface.py:1189
-#: live-installer/frontend/gtk_interface.py:1203
-#: live-installer/frontend/gtk_interface.py:1209
-#: live-installer/frontend/gtk_interface.py:1215
-#: live-installer/frontend/gtk_interface.py:1220
-#: live-installer/frontend/gtk_interface.py:1225
-#: live-installer/frontend/gtk_interface.py:1291
-#: live-installer/frontend/gtk_interface.py:1372
-#: live-installer/frontend/partitioning.py:301
-#: live-installer/frontend/partitioning.py:368
-msgid "Installer"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:476
-msgid "License Agreement"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:478
-#: live-installer/frontend/tui_interface.py:40
-msgid "What language would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:480
-#: live-installer/frontend/tui_interface.py:49
-msgid "Where are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "Keyboard layout"
-msgstr "鍵盤配置"
-
-#: live-installer/frontend/gtk_interface.py:482
-msgid "What is your keyboard layout?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "User account"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:484
-msgid "Who are you?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-msgid "Installation Type"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:486
-#: live-installer/frontend/gtk_interface.py:488
-#, fuzzy
-msgid "Where do you want to install system?"
-msgstr "您是否確定要退出安裝程式?"
-
-#: live-installer/frontend/gtk_interface.py:488
-msgid "Partitioning"
-msgstr "磁碟分割中"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Summary"
-msgstr "總覽"
-
-#: live-installer/frontend/gtk_interface.py:490
-msgid "Check that everything is correct"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Installing"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:492
-msgid "Please wait..."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:495
-#: live-installer/frontend/gtk_interface.py:609
-msgid "Automated install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:496
-msgid "Back"
-msgstr "向後"
-
-#: live-installer/frontend/gtk_interface.py:497
-#: live-installer/frontend/gtk_interface.py:1231
-msgid "Next"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:501
-#: live-installer/frontend/tui_interface.py:34
-#, python-format
-msgid "Welcome to the %s Installer."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:516
-msgid "Type here to test your keyboard layout"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:542
-msgid "Erase a disk and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:555
-msgid "Manually create, resize or choose partitions for system."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:559
-msgid "The setup tool will not do partitioning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:561
-msgid "Remove Windows & Install"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:563
-msgid "Remove existsing windows and install system on it."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:573
-#: live-installer/frontend/gtk_interface.py:575
-msgid "Edit partitions"
-msgstr "編輯磁碟分割"
-
-#: live-installer/frontend/gtk_interface.py:580
-msgid "Device"
-msgstr "裝置"
-
-#: live-installer/frontend/gtk_interface.py:581
-#: live-installer/frontend/tui_interface.py:77
-msgid "Type"
-msgstr "類型"
-
-#: live-installer/frontend/gtk_interface.py:582
-msgid "Operating system"
-msgstr "作業系統"
-
-#: live-installer/frontend/gtk_interface.py:583
-msgid "Mount point"
-msgstr "掛載點"
-
-#: live-installer/frontend/gtk_interface.py:584
-msgid "Format as"
-msgstr "格式化為"
-
-#: live-installer/frontend/gtk_interface.py:585
-msgid "Size"
-msgstr "尺寸"
-
-#: live-installer/frontend/gtk_interface.py:586
-#: live-installer/frontend/gtk_interface.py:927
-#: live-installer/frontend/partitioning.py:324
-#: live-installer/frontend/partitioning.py:515
-msgid "Free space"
-msgstr "可用空間"
-
-#: live-installer/frontend/gtk_interface.py:594
-#: live-installer/frontend/partitioning.py:180
-msgid "Read only"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:629
-#: live-installer/frontend/gtk_interface.py:1167
-msgid "Install"
-msgstr "安裝"
-
-#: live-installer/frontend/gtk_interface.py:735
-msgid "Please provide a passphrase for the encryption."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:737
-#: live-installer/frontend/gtk_interface.py:1153
-msgid "Your passwords do not match."
-msgstr "您的密碼不符。"
-
-#: live-installer/frontend/gtk_interface.py:742
-msgid "Quit?"
-msgstr "退出?"
-
-#: live-installer/frontend/gtk_interface.py:743
-msgid "Are you sure you want to quit the installer?"
-msgstr "您是否確定要退出安裝程式?"
-
-#: live-installer/frontend/gtk_interface.py:937
-#: live-installer/frontend/gtk_interface.py:952
-#: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-msgid "Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:938
-msgid "New partition will created at {}"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:953
-msgid "Partition {} will removed from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:967
-msgid "Partition {} will formated from {}."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1113
-msgid "Please choose a language"
-msgstr "請選擇語言"
-
-#: live-installer/frontend/gtk_interface.py:1138
-#, fuzzy
-msgid "Please provide a kayboard layout for your computer."
-msgstr "請提供密碼給您的使用者帳號。"
-
-#: live-installer/frontend/gtk_interface.py:1158
-msgid "Please provide your full name."
-msgstr "請提供您的全名。"
-
-#: live-installer/frontend/gtk_interface.py:1163
-#: live-installer/frontend/gtk_interface.py:1288
-#, fuzzy
-msgid "Your passwords is not strong."
-msgstr "您的密碼不符。"
-
-#: live-installer/frontend/gtk_interface.py:1181
-msgid ""
-"Root filesystem type not specified. Installation will continue without disk "
-"formatting. Do you want to continue?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1185
-#, fuzzy
-msgid ""
-"The root partition is too small. It should be at least 16GB. Do you want to "
-"continue?"
-msgstr "EFI 磁碟分割無法用於開機。請編輯磁碟分割旗標。"
-
-#: live-installer/frontend/gtk_interface.py:1189
-msgid "Please select a root (/) partition."
-msgstr "請選擇根 (/) 磁碟分割。"
-
-#: live-installer/frontend/gtk_interface.py:1190
-#, python-format
-msgid ""
-"A root partition is needed to install %s on.\n"
-"\n"
-" - Mount point: /\n"
-" - Recommended size: 30GB\n"
-" - Recommended filesystem format: ext4\n"
-"\n"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1204
-#, fuzzy
-msgid "The EFI partition is not bootable. Do you want to set boot flag?"
-msgstr "EFI 磁碟分割無法用於開機。請編輯磁碟分割旗標。"
-
-#: live-installer/frontend/gtk_interface.py:1210
-#, fuzzy
-msgid "The EFI partition is too small. It must be at least 100MB."
-msgstr "EFI 磁碟分割必須被格式化為 vfat。"
-
-#: live-installer/frontend/gtk_interface.py:1216
-#: live-installer/frontend/gtk_interface.py:1221
-msgid "The EFI partition must be formatted as vfat."
-msgstr "EFI 磁碟分割必須被格式化為 vfat。"
-
-#: live-installer/frontend/gtk_interface.py:1225
-msgid "Please select an EFI partition."
-msgstr "請選擇 EFI 磁碟分割。"
-
-#: live-installer/frontend/gtk_interface.py:1226
-msgid ""
-"An EFI system partition is needed with the following requirements:\n"
-"\n"
-" - Mount point: /boot/efi\n"
-" - Partition flags: Bootable\n"
-" - Size: at least 100MB \n"
-" - Format: vfat or fat32\n"
-"\n"
-"To ensure compatibility with Windows we recommend you use the first "
-"partition of the disk as the EFI system partition.\n"
-" "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1281
-msgid "Please select a disk."
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1293
-msgid "Warning"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1294
-#, python-format
-msgid "This will delete all the data on %s. Are you sure?"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1373
-#, fuzzy
-msgid "Please provide a device to install grub."
-msgstr "請提供使用者名稱。"
-
-#: live-installer/frontend/gtk_interface.py:1420
-msgid "Localization"
-msgstr "在地化"
-
-#: live-installer/frontend/gtk_interface.py:1421
-msgid "Language: "
-msgstr "語言: "
-
-#: live-installer/frontend/gtk_interface.py:1422
-msgid "Timezone: "
-msgstr "時區: "
-
-#: live-installer/frontend/gtk_interface.py:1423
-msgid "Keyboard layout: "
-msgstr "鍵盤配置: "
-
-#: live-installer/frontend/gtk_interface.py:1427
-msgid "User settings"
-msgstr "使用者設定"
-
-#: live-installer/frontend/gtk_interface.py:1431
-msgid "Real name: "
-msgstr "真實名稱: "
-
-#: live-installer/frontend/gtk_interface.py:1432
-msgid "Username: "
-msgstr "使用者名稱: "
-
-#: live-installer/frontend/gtk_interface.py:1435
-#: live-installer/frontend/gtk_interface.py:1438
-msgid "Password: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1440
-msgid "Automatic login: "
-msgstr "自動登入: "
-
-#: live-installer/frontend/gtk_interface.py:1440
-#: live-installer/frontend/gtk_interface.py:1481
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "enabled"
-msgstr "啟用"
-
-#: live-installer/frontend/gtk_interface.py:1441
-#: live-installer/frontend/gtk_interface.py:1482
-#: live-installer/frontend/gtk_interface.py:1485
-msgid "disabled"
-msgstr "停用"
-
-#: live-installer/frontend/gtk_interface.py:1442
-msgid "System settings"
-msgstr "系統設定"
-
-#: live-installer/frontend/gtk_interface.py:1444
-msgid "Computer's name: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1447
-#: live-installer/frontend/gtk_interface.py:1449
-msgid "Bios type: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1451
-msgid "Install updates after installation"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1452
-msgid "Filesystem operations"
-msgstr "檔案系統操作"
-
-#: live-installer/frontend/gtk_interface.py:1453
-#, python-format
-msgid "Install bootloader on %s"
-msgstr "安裝開機載入器於 %s"
-
-#: live-installer/frontend/gtk_interface.py:1454
-msgid "Do not install bootloader"
-msgstr "不安裝開機載入器"
-
-#: live-installer/frontend/gtk_interface.py:1456
-msgid "Use already-mounted /target."
-msgstr "使用已掛載 /target。"
-
-#: live-installer/frontend/gtk_interface.py:1464
-#, python-format
-msgid " (with %s GB swap)"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1468
-#, python-format
-msgid "Automated installation on %s"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1472
-#, python-format
-msgid "Format %(path)s as %(filesystem)s"
-msgstr "以 %(filesystem)s 格式化 %(path)s"
-
-#: live-installer/frontend/gtk_interface.py:1476
-#, python-format
-msgid "Mount %(path)s as %(mount)s"
-msgstr "將 %(path)s 掛載為 %(mount)s"
-
-#: live-installer/frontend/gtk_interface.py:1481
-msgid "LVM: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1484
-msgid "Disk Encryption: "
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:1497
-msgid ""
-"The installation is now complete. Do you want to restart your computer to "
-"use the new system?"
-msgstr "安裝完成。您是否要重新啟動您的電腦以使用新系統?"
-
-#: live-installer/frontend/gtk_interface.py:1529
-#: live-installer/frontend/gtk_interface.py:1533
-#: live-installer/frontend/gtk_interface.py:1542
-#: live-installer/frontend/gtk_interface.py:1551
-msgid "Installation error"
-msgstr "安裝發生錯誤"
-
-#: live-installer/frontend/gtk_interface.py:1565
-msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:32
-#, python-format
-msgid "Try %s"
-msgstr ""
-
-#: live-installer/frontend/welcome.py:36
-#, python-format
-msgid "You are currently running %s from live media."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:38
-#, python-format
-msgid ""
-"You can install %s now, or chose \"Install to Hard Drive\" in the Appication "
-"Menu later."
-msgstr ""
-
-#: live-installer/frontend/welcome.py:39
-#, python-format
-msgid "Welcome to %s"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:57
-msgid "What keyboard would you like to use?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:64
-#, fuzzy
-msgid "Keyboard Model"
-msgstr "鍵盤配置"
-
-#: live-installer/frontend/tui_interface.py:73
-#, fuzzy
-msgid "Installation type?"
-msgstr "安裝已暫停"
-
-#: live-installer/frontend/tui_interface.py:80
-msgid "Select a disk?"
-msgstr ""
-
-#: live-installer/frontend/tui_interface.py:84
-msgid "Disk"
-msgstr ""
-
-#: live-installer/frontend/timezones.py:140
-#, fuzzy
-msgid "Select timezone"
-msgstr "時區"
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "kB"
-msgstr "KB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:442
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:443
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "可移除:"
-
-#: live-installer/frontend/partitioning.py:221
-msgid "Edit"
-msgstr "編輯"
-
-#: live-installer/frontend/partitioning.py:226
-#: live-installer/frontend/partitioning.py:230
-#: live-installer/frontend/partitioning.py:237
-#: live-installer/frontend/partitioning.py:246
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "指定至 /"
-
-#: live-installer/frontend/partitioning.py:302
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:384
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:429
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:513
-msgid "Logical partition"
-msgstr "邏輯磁碟分割"
-
-#: live-installer/frontend/partitioning.py:514
-msgid "Extended partition"
-msgstr "延伸磁碟分割"
-
-#: live-installer/frontend/partitioning.py:518
-msgid "Unknown"
-msgstr "未知"
-
-#: live-installer/frontend/partitioning.py:569
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:582
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "編輯磁碟分割"
-
-#: live-installer/frontend/partitioning.py:607
-msgid "Edit partition"
-msgstr "編輯磁碟分割"
-
-#: live-installer/frontend/partitioning.py:609
-msgid "Device:"
-msgstr "裝置:"
-
-#: live-installer/frontend/partitioning.py:611
-msgid "Format as:"
-msgstr "格式化為:"
-
-#: live-installer/frontend/partitioning.py:613
-msgid "Mount point:"
-msgstr "掛載點:"
-
-#: live-installer/frontend/partitioning.py:614
-msgid "Cancel"
-msgstr "取消"
-
-#: live-installer/frontend/partitioning.py:615
-#: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
-#: live-installer/frontend/dialogs.py:54
-msgid "OK"
-msgstr "確定"
-
-#: live-installer/frontend/dialogs.py:41
-msgid "No"
-msgstr "否"
-
-#: live-installer/frontend/dialogs.py:42
-msgid "Yes"
-msgstr "是"
 
 #~ msgid "Quit"
 #~ msgstr "退出"

--- a/po/live-installer-zh_TW.po
+++ b/po/live-installer-zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: linuxmint\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-28 17:00+0300\n"
+"POT-Creation-Date: 2024-05-06 19:10+0300\n"
 "PO-Revision-Date: 2019-07-15 01:03+0000\n"
 "Last-Translator: Li,ChengYang <Unknown>\n"
 "Language-Team: Chinese (Traditional) <zh_TW@li.org>\n"
@@ -89,7 +89,7 @@ msgstr ""
 
 #: live-installer/resources/interface.ui:613
 #: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:592
+#: live-installer/frontend/partitioning.py:604
 msgid "GB"
 msgstr "GB"
 
@@ -189,9 +189,9 @@ msgid "Format"
 msgstr "格式化為"
 
 #: live-installer/resources/interface.ui:1419
+#: live-installer/frontend/partitioning.py:282
 #: live-installer/frontend/gtk_interface.py:582
 #: live-installer/frontend/gtk_interface.py:966
-#: live-installer/frontend/partitioning.py:272
 msgid "Create"
 msgstr ""
 
@@ -295,6 +295,12 @@ msgstr ""
 msgid "Use default Btrfs subvolumes"
 msgstr ""
 
+#: live-installer/resources/interface.ui:2678
+#: live-installer/frontend/partitioning.py:888
+#, fuzzy
+msgid "Format subvolume"
+msgstr "格式化為"
+
 #: live-installer/resources/welcome.ui:61
 msgid "Try 17g"
 msgstr ""
@@ -325,8 +331,8 @@ msgstr ""
 
 #: live-installer/frontend/dialogs.py:35 live-installer/frontend/dialogs.py:48
 #: live-installer/frontend/dialogs.py:54
-#: live-installer/frontend/partitioning.py:785
-#: live-installer/frontend/partitioning.py:872
+#: live-installer/frontend/partitioning.py:798
+#: live-installer/frontend/partitioning.py:893
 msgid "OK"
 msgstr "確定"
 
@@ -415,23 +421,94 @@ msgstr ""
 msgid "Welcome to %s"
 msgstr ""
 
-#: live-installer/frontend/gtk_interface.py:109
-#: live-installer/frontend/gtk_interface.py:514
-msgid "Country"
-msgstr "國家"
+#: live-installer/frontend/partitioning.py:72
+msgid "B"
+msgstr "B"
 
-#: live-installer/frontend/gtk_interface.py:290
-msgid "Layout"
-msgstr "配置"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "kB"
+msgstr "KB"
 
-#: live-installer/frontend/gtk_interface.py:298
-msgid "Variant"
-msgstr "變體"
+#: live-installer/frontend/partitioning.py:72
+#: live-installer/frontend/partitioning.py:603
+msgid "MB"
+msgstr "MB"
 
-#: live-installer/frontend/gtk_interface.py:316
-msgid "Calculating file indexes ..."
-msgstr "計算檔案索引中..."
+#: live-installer/frontend/partitioning.py:73
+#: live-installer/frontend/partitioning.py:604
+msgid "TB"
+msgstr "TB"
 
+#: live-installer/frontend/partitioning.py:80
+msgid "Removable:"
+msgstr "可移除:"
+
+#: live-installer/frontend/partitioning.py:190
+#: live-installer/frontend/partitioning.py:199
+#: live-installer/frontend/partitioning.py:201
+#: live-installer/frontend/partitioning.py:236
+#: live-installer/frontend/partitioning.py:278
+#: live-installer/frontend/partitioning.py:340
+#: live-installer/frontend/partitioning.py:352
+#: live-installer/frontend/partitioning.py:356
+#: live-installer/frontend/partitioning.py:776
+#: live-installer/frontend/gtk_interface.py:977
+#: live-installer/frontend/gtk_interface.py:1006
+msgid "btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:195
+msgid "Edit Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:213
+#: live-installer/frontend/gtk_interface.py:598
+msgid "Read only"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:241
+msgid "The name of a subvolume must not start or end with a forward slash"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:245
+msgid "The name of a subvolume must not be blank or contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:249
+msgid "The mount point of a subvolume must not contain a space"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:256
+#, python-format
+msgid "Subvolume with name '%s' already exists"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:291
+#: live-installer/frontend/gtk_interface.py:984
+#: live-installer/frontend/gtk_interface.py:992
+msgid "Create a subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:345
+msgid "Edit"
+msgstr "編輯"
+
+#: live-installer/frontend/partitioning.py:357
+#: live-installer/frontend/partitioning.py:364
+#: live-installer/frontend/partitioning.py:368
+#: live-installer/frontend/partitioning.py:375
+#: live-installer/frontend/partitioning.py:384
+#, fuzzy, python-format
+msgid "Assign to %s"
+msgstr "指定至 /"
+
+#: live-installer/frontend/partitioning.py:391
+msgid "Create btrfs subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:446
+#: live-installer/frontend/partitioning.py:529
 #: live-installer/frontend/gtk_interface.py:467
 #: live-installer/frontend/gtk_interface.py:470
 #: live-installer/frontend/gtk_interface.py:1173
@@ -449,10 +526,104 @@ msgstr "計算檔案索引中..."
 #: live-installer/frontend/gtk_interface.py:1300
 #: live-installer/frontend/gtk_interface.py:1365
 #: live-installer/frontend/gtk_interface.py:1444
-#: live-installer/frontend/partitioning.py:434
-#: live-installer/frontend/partitioning.py:517
 msgid "Installer"
 msgstr ""
+
+#: live-installer/frontend/partitioning.py:447
+msgid ""
+"Disk: {} partition table broken or not exists. Do you want to create new "
+"partition table?"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:469
+#: live-installer/frontend/partitioning.py:687
+#: live-installer/frontend/gtk_interface.py:590
+#: live-installer/frontend/gtk_interface.py:975
+msgid "Free space"
+msgstr "可用空間"
+
+#: live-installer/frontend/partitioning.py:545
+#, python-format
+msgid ""
+"The partition table couldn't be written for %s. Restart the computer and try "
+"again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:590
+#, python-format
+msgid ""
+"The partition %s could not be created. The installation will stop. Restart "
+"the computer and try again."
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:685
+msgid "Logical partition"
+msgstr "邏輯磁碟分割"
+
+#: live-installer/frontend/partitioning.py:686
+msgid "Extended partition"
+msgstr "延伸磁碟分割"
+
+#: live-installer/frontend/partitioning.py:690
+#: live-installer/frontend/partitioning.py:824
+msgid "Unknown"
+msgstr "未知"
+
+#: live-installer/frontend/partitioning.py:741
+msgid "bootloader/recovery"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:754
+#, fuzzy
+msgid "EFI System Partition"
+msgstr "編輯磁碟分割"
+
+#: live-installer/frontend/partitioning.py:790
+msgid "Edit partition"
+msgstr "編輯磁碟分割"
+
+#: live-installer/frontend/partitioning.py:792
+msgid "Device:"
+msgstr "裝置:"
+
+#: live-installer/frontend/partitioning.py:794
+msgid "Format as:"
+msgstr "格式化為:"
+
+#: live-installer/frontend/partitioning.py:796
+#: live-installer/frontend/partitioning.py:883
+msgid "Mount point:"
+msgstr "掛載點:"
+
+#: live-installer/frontend/partitioning.py:797
+#: live-installer/frontend/partitioning.py:892
+msgid "Cancel"
+msgstr "取消"
+
+#: live-installer/frontend/partitioning.py:874
+msgid "Create Subvolume"
+msgstr ""
+
+#: live-installer/frontend/partitioning.py:881
+msgid "Name:"
+msgstr ""
+
+#: live-installer/frontend/gtk_interface.py:109
+#: live-installer/frontend/gtk_interface.py:514
+msgid "Country"
+msgstr "國家"
+
+#: live-installer/frontend/gtk_interface.py:290
+msgid "Layout"
+msgstr "配置"
+
+#: live-installer/frontend/gtk_interface.py:298
+msgid "Variant"
+msgstr "變體"
+
+#: live-installer/frontend/gtk_interface.py:316
+msgid "Calculating file indexes ..."
+msgstr "計算檔案索引中..."
 
 #: live-installer/frontend/gtk_interface.py:480
 msgid "License Agreement"
@@ -567,18 +738,6 @@ msgstr "格式化為"
 msgid "Size"
 msgstr "尺寸"
 
-#: live-installer/frontend/gtk_interface.py:590
-#: live-installer/frontend/gtk_interface.py:975
-#: live-installer/frontend/partitioning.py:457
-#: live-installer/frontend/partitioning.py:675
-msgid "Free space"
-msgstr "可用空間"
-
-#: live-installer/frontend/gtk_interface.py:598
-#: live-installer/frontend/partitioning.py:209
-msgid "Read only"
-msgstr ""
-
 #: live-installer/frontend/gtk_interface.py:626
 #: live-installer/frontend/gtk_interface.py:1367
 msgid "Warning"
@@ -611,25 +770,6 @@ msgstr "退出?"
 #: live-installer/frontend/gtk_interface.py:793
 msgid "Are you sure you want to quit the installer?"
 msgstr "您是否確定要退出安裝程式?"
-
-#: live-installer/frontend/gtk_interface.py:977
-#: live-installer/frontend/gtk_interface.py:1006
-#: live-installer/frontend/partitioning.py:190
-#: live-installer/frontend/partitioning.py:197
-#: live-installer/frontend/partitioning.py:248
-#: live-installer/frontend/partitioning.py:268
-#: live-installer/frontend/partitioning.py:328
-#: live-installer/frontend/partitioning.py:340
-#: live-installer/frontend/partitioning.py:344
-#: live-installer/frontend/partitioning.py:764
-msgid "btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/gtk_interface.py:984
-#: live-installer/frontend/gtk_interface.py:992
-#: live-installer/frontend/partitioning.py:281
-msgid "Create a subvolume"
-msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:994
 #: live-installer/frontend/gtk_interface.py:1008
@@ -869,7 +1009,7 @@ msgid "Disk Encryption: "
 msgstr ""
 
 #: live-installer/frontend/gtk_interface.py:1578
-#: live-installer/installer.py:878
+#: live-installer/installer.py:881
 msgid "Installation finished"
 msgstr "完成安裝"
 
@@ -888,139 +1028,6 @@ msgstr "安裝發生錯誤"
 
 #: live-installer/frontend/gtk_interface.py:1647
 msgid "Error"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:72
-msgid "B"
-msgstr "B"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "kB"
-msgstr "KB"
-
-#: live-installer/frontend/partitioning.py:72
-#: live-installer/frontend/partitioning.py:591
-msgid "MB"
-msgstr "MB"
-
-#: live-installer/frontend/partitioning.py:73
-#: live-installer/frontend/partitioning.py:592
-msgid "TB"
-msgstr "TB"
-
-#: live-installer/frontend/partitioning.py:80
-msgid "Removable:"
-msgstr "可移除:"
-
-#: live-installer/frontend/partitioning.py:194
-msgid "Edit Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:226
-msgid "The name of a subvolume must not start or end with a forward slash"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:230
-msgid "The name of a subvolume must not be blank or contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:234
-msgid "The mount point of a subvolume must not contain a space"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:239
-#, python-format
-msgid "Subvolume with name '%s' already exists"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:333
-msgid "Edit"
-msgstr "編輯"
-
-#: live-installer/frontend/partitioning.py:345
-#: live-installer/frontend/partitioning.py:352
-#: live-installer/frontend/partitioning.py:356
-#: live-installer/frontend/partitioning.py:363
-#: live-installer/frontend/partitioning.py:372
-#, fuzzy, python-format
-msgid "Assign to %s"
-msgstr "指定至 /"
-
-#: live-installer/frontend/partitioning.py:379
-msgid "Create btrfs subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:435
-msgid ""
-"Disk: {} partition table broken or not exists. Do you want to create new "
-"partition table?"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:533
-#, python-format
-msgid ""
-"The partition table couldn't be written for %s. Restart the computer and try "
-"again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:578
-#, python-format
-msgid ""
-"The partition %s could not be created. The installation will stop. Restart "
-"the computer and try again."
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:673
-msgid "Logical partition"
-msgstr "邏輯磁碟分割"
-
-#: live-installer/frontend/partitioning.py:674
-msgid "Extended partition"
-msgstr "延伸磁碟分割"
-
-#: live-installer/frontend/partitioning.py:678
-#: live-installer/frontend/partitioning.py:811
-msgid "Unknown"
-msgstr "未知"
-
-#: live-installer/frontend/partitioning.py:729
-msgid "bootloader/recovery"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:742
-#, fuzzy
-msgid "EFI System Partition"
-msgstr "編輯磁碟分割"
-
-#: live-installer/frontend/partitioning.py:777
-msgid "Edit partition"
-msgstr "編輯磁碟分割"
-
-#: live-installer/frontend/partitioning.py:779
-msgid "Device:"
-msgstr "裝置:"
-
-#: live-installer/frontend/partitioning.py:781
-msgid "Format as:"
-msgstr "格式化為:"
-
-#: live-installer/frontend/partitioning.py:783
-#: live-installer/frontend/partitioning.py:870
-msgid "Mount point:"
-msgstr "掛載點:"
-
-#: live-installer/frontend/partitioning.py:784
-#: live-installer/frontend/partitioning.py:871
-msgid "Cancel"
-msgstr "取消"
-
-#: live-installer/frontend/partitioning.py:861
-msgid "Create Subvolume"
-msgstr ""
-
-#: live-installer/frontend/partitioning.py:868
-msgid "Name:"
 msgstr ""
 
 #: live-installer/main.py:38
@@ -1179,63 +1186,63 @@ msgstr ""
 msgid "Formatting %(partition)s as %(format)s ..."
 msgstr "以 %(format)s 格式化 %(partition)s 中..."
 
-#: live-installer/installer.py:591
+#: live-installer/installer.py:594
 msgid "Setting hostname"
 msgstr "設定主機名稱中"
 
-#: live-installer/installer.py:616
+#: live-installer/installer.py:619
 msgid "Setting locale"
 msgstr "設定語系中"
 
-#: live-installer/installer.py:656
+#: live-installer/installer.py:659
 #, fuzzy
 msgid "Setting timezone"
 msgstr "設定主機名稱中"
 
-#: live-installer/installer.py:691
+#: live-installer/installer.py:694
 msgid "Setting keyboard options"
 msgstr "設定鍵盤選項中"
 
-#: live-installer/installer.py:768
+#: live-installer/installer.py:771
 #, fuzzy
 msgid "Removing extra packages"
 msgstr "移除 live 組態中（軟體包）"
 
-#: live-installer/installer.py:774
+#: live-installer/installer.py:777
 msgid "Clearing package manager"
 msgstr ""
 
-#: live-installer/installer.py:793
+#: live-installer/installer.py:796
 msgid "Generating initramfs"
 msgstr ""
 
-#: live-installer/installer.py:798
+#: live-installer/installer.py:801
 msgid "Preparing bootloader installation"
 msgstr ""
 
-#: live-installer/installer.py:818
+#: live-installer/installer.py:821
 msgid "Installing bootloader"
 msgstr "安裝開機載入器中"
 
-#: live-installer/installer.py:830
+#: live-installer/installer.py:833
 msgid "Configuring bootloader"
 msgstr "設定開機載入器組態中"
 
-#: live-installer/installer.py:838
+#: live-installer/installer.py:841
 msgid ""
 "WARNING: The grub bootloader was not configured properly! You need to "
 "configure it manually."
 msgstr "警示: grub 開機載入器組態未正常設定! 您需要為其手動設定組態。"
 
-#: live-installer/installer.py:851
+#: live-installer/installer.py:854
 msgid "Trying to install updates"
 msgstr ""
 
-#: live-installer/installer.py:904
+#: live-installer/installer.py:907
 msgid "Checking bootloader"
 msgstr "檢查開機載入器中"
 
-#: live-installer/installer.py:941
+#: live-installer/installer.py:944
 msgid "Failed to run command (Exited with {}):"
 msgstr ""
 


### PR DESCRIPTION
implement the ability to add, remove, and modify btrfs subvolumes directly from the installer's manual partitioning tab. This feature provides users with more granular control over their btrfs filesystem during installation.

**Description:**
- Users can specify custom mount points and names for the subvolumes (changing name of the subvolumes that already exists isnt allowed) or remove the subvolumes

**Additional Information:**
I tested the installer with this feature in a few scenarios:
(note: I always mount @ to /, @/usr/local to /usr/local, @home to /home)
- vfat as /boot partition and btrfs partition with @ and @home subvolumes ([video](https://drive.google.com/file/d/1pbHQbfAVn7muVmCRilpqLkIsh9xJJ_rj/view?usp=sharing))
- vfat as /boot partition, btrfs partition with @ and @/usr/local subvolumes, another btrfs partition with @home subvolume
- btrfs partition with @ and @home subvolumes
- 1 btrfs partition with @ and @/usr/local subvolumes, another one with @home subvolume ([video](https://drive.google.com/file/d/1-QqyErdgCW9smFyIv74EkWH6iFA5k76J/view?usp=sharing))

This pull request also addresses four unrelated bugs identified within the installer codebase. Some of these fixes were necessary for the proper functioning of the custom subvolume feature.

Fixed Bugs:

- 837bf41e893f36e17b701ef8491bb2d45f3a97d0: fixed a bug in manual partitioning that didnt allow to more than 1 partition to be formatted if the partition's mount point is empty
- 034b87bee179ee8920287ada5aeeb45b1e2372ab: parted doesnt wipe file system's signature when removing a partition, so deleting and recreating a partition from ui will cause the same partition to be restored
- ee52af03875149845f0b67e763145237e5acb7de: the installer was allowing assign mount point if the file system is Unknown, assigning mount point to unknown partition will make the installation failed
-  9fd778b2e1d33b6a7e24ac1f9c7790039b5df5f6: use .sort() method instead of manual sorting, the problem with the manual sorting was it appends devices multiple times if the partitions have empty mount point 
