### PR TITLE
Faster installation

### DIFF
--- a/custom/configs/config.yaml
+++ b/custom/configs/config.yaml
@@ -26,8 +26,11 @@ welcome_screen: false
 remove_packages:
   - live-config-*
   - live-boot-*
-  - live-tools
   - pardus-installer
+
+# This should stay here to prevent generating initramfs multiple times (which will take extra unnecessary time)
+remove_packages_finally:
+  - live-tools
 
 ## User section
 autologin_enabled: false

--- a/live-installer/configs/package_managers/apt.yaml
+++ b/live-installer/configs/package_managers/apt.yaml
@@ -3,6 +3,6 @@ check_this_dir: /var/lib/dpkg
 create_rootfs: debootstrap --no-merged-usr stable /target
 install_package: apt install {packages} --yes
 remove_package: apt remove {packages} --yes
-remove_package_with_unusing_deps: apt purge {packages} --yes && apt autoremove --yes
+remove_package_with_unusing_deps: apt autoremove --purge {packages} --yes
 remove_package_with_needed_packages: apt purge {packages} --yes
 full_system_update: chroot /target apt update -yq && chroot /target apt -yq -o Dpkg::Options::="--force-confnew" full-upgrade

--- a/live-installer/installer.py
+++ b/live-installer/installer.py
@@ -779,6 +779,11 @@ class InstallerEngine:
         log(config.get("remove_packages", ["17g-installer"]))
         self.run("chroot||yes | {}".format(config.package_manager(
             "remove_package_with_unusing_deps", config.get("remove_packages", ["17g-installer"]))))
+
+        log(config.get("remove_packages_finally", []))
+        self.run("chroot||yes | {}".format(config.package_manager(
+            "remove_package_with_unusing_deps", config.get("remove_packages_finally", []))))
+
         self.run("chroot|| rm -rf /lib/live-installer",vital=False)
 
 


### PR DESCRIPTION
with this pr the installer speeds up the installation process by preventing initramfs from being generated many times.

before:
![image](https://github.com/pardus/pardus-installer/assets/75365757/7754dedb-fe55-4c93-9170-0e14e0b1cb6c)
after: 
![image](https://github.com/pardus/pardus-installer/assets/75365757/9b2853cd-f779-4065-8966-d28aff282e60)
