### PR TITLE
Visualize the partitions on a drawing area

### DIFF
--- a/live-installer/frontend/partitioning.py
+++ b/live-installer/frontend/partitioning.py
@@ -485,6 +485,7 @@ class PartitionSetup(Gtk.TreeStore):
                 part.raw_size = part.partition.geometry.end - part.partition.geometry.start
                 part.raw_size *= part.partition.geometry.device.sectorSize
                 part.size = to_human_readable(part.raw_size)
+                part.raw_free_space = part.raw_size
                 part.free_space = part.size
             log("{} {}".format(partition.path.replace("-", ""), part.size))
             # skip ranges <5MB
@@ -724,9 +725,11 @@ class Partition(PartitionBase):
 
             self.size = to_human_readable(int(size) * 1024)
             # df returns values in 1024B-blocks by default
-            self.free_space = to_human_readable(int(free) * 1024)
+            self.raw_free_space = int(free) * 1024
+            self.free_space = to_human_readable(self.raw_free_space)
             self.used_percent = self.used_percent.replace("%", "") or 0
         except:
+            self.raw_free_space = 0
             self.free_space = "0"
             self.used_percent = "100"
             self.description = ""

--- a/live-installer/resources/interface.ui
+++ b/live-installer/resources/interface.ui
@@ -1237,7 +1237,18 @@
                   </packing>
                 </child>
                 <child>
-                  <placeholder/>
+                  <object class="GtkDrawingArea" id="drawing_area_partitions">
+                    <property name="height-request">50</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-start">5</property>
+                    <property name="margin-end">5</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
                 <child>
                   <object class="GtkScrolledWindow">
@@ -1264,7 +1275,7 @@
                   <packing>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
-                    <property name="position">0</property>
+                    <property name="position">2</property>
                   </packing>
                 </child>
                 <child>
@@ -1607,7 +1618,7 @@
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">1</property>
+                    <property name="position">3</property>
                   </packing>
                 </child>
               </object>

--- a/live-installer/resources/interface.ui
+++ b/live-installer/resources/interface.ui
@@ -1226,6 +1226,20 @@
                 <property name="can-focus">False</property>
                 <property name="orientation">vertical</property>
                 <child>
+                  <object class="GtkComboBox" id="combobox_disk_selection">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
                   <object class="GtkScrolledWindow">
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>


### PR DESCRIPTION
**52be5738ae3f:**
I changed the treeview to only list partitions (and subvolumes) instead of all the disks. Listing all of the disks on one page could make the treeview way too long (ofc depending on the number of partitions/disks). Also, since I wanted to visualize the partitions in a drawing area, it wouldn't make sense to draw all the partitions/disks in a single area.

**e1f123da924b:**
Added a gparted-like drawing area to visualize the partitions.
(It emits signals for the clicked partition and sends them to the corresponding treeview node)

* Clicking a partition in the drawing area selects it in the treeview.
* Double-clicking opens the dialog.
* Right-clicking opens the menu.  

see screenshots below:

![image](https://github.com/user-attachments/assets/9692f454-0f45-4b17-b6bb-81f2e457857d)
![image](https://github.com/user-attachments/assets/52a57403-14f2-447e-9cf7-f09312dfb533)
![Screenshot_20250702_141441](https://github.com/user-attachments/assets/61a93b5a-8e91-40fb-8790-a3e861e63b8e)
