### PR TITLE
Fix test mode permission error

### DIFF
--- a/live-installer/main.py
+++ b/live-installer/main.py
@@ -5,9 +5,6 @@ from utils import *
 from frontend import *
 from frontend.dialogs import ErrorDialog
 
-single_instance()
-
-
 gettext.install("live-installer", "/usr/share/locale")
 sys.path.insert(1, '/lib/live-installer')
 if (os.path.isdir("/lib/live-installer")):
@@ -37,6 +34,9 @@ if __name__ == "__main__":
         os.environ["TEST"]="1"
     if "--expert" in sys.argv:
         os.environ["EXPERT_MODE"]="1"
+    
+    # Check for single instance (after test mode is set)
+    single_instance()
     if not is_root() and "--test" not in sys.argv:
         ErrorDialog(config.get("distro_title", "17g"), _("You must be root!"))
         exit(1)

--- a/live-installer/utils.py
+++ b/live-installer/utils.py
@@ -135,7 +135,11 @@ def set_governor(governor):
         i += 1
 
 def single_instance():
-    pidfile = "/run/live-installer.pid"
+    # Use temp directory for PID file in test mode
+    if "TEST" in os.environ:
+        pidfile = "/tmp/live-installer.pid"
+    else:
+        pidfile = "/run/live-installer.pid"
     def writepid():
         with open(pidfile, "w") as f:
             f.write(str(os.getpid()))


### PR DESCRIPTION
## Summary
- Fix permission denied error when running installer with `--test` flag
- Move single_instance() call after test mode detection  
- Use /tmp for PID file location in test mode instead of /run

## Problem
The `--test` option was failing with permission denied error because `single_instance()` was trying to create a PID file at `/run/live-installer.pid` which requires root permissions, even in test mode.

## Solution
1. Move the `single_instance()` call from early in the script to after the `--test` argument processing
2. Update the PID file location to use `/tmp/live-installer.pid` when `TEST` environment variable is set

## Test plan
- [x] Run `python3 main.py --test` without root privileges
- [x] Verify installer launches without permission errors
- [x] Confirm PID file is created in /tmp during test mode
- [x] Verify normal operation still works with root privileges

This change allows developers to test the installer UI without requiring root access.